### PR TITLE
admin/release/new: always consider all mappings

### DIFF
--- a/pkg/cli/admin/release/new.go
+++ b/pkg/cli/admin/release/new.go
@@ -586,15 +586,6 @@ func (o *NewOptions) Run() error {
 			}
 		}
 		fmt.Fprintf(o.ErrOut, "info: Found %d operator manifest directories on disk\n", len(ordered))
-
-	default:
-		for _, m := range o.Mappings {
-			if exclude.Has(m.Source) {
-				klog.V(2).Infof("Excluded mapping %s", m.Source)
-				continue
-			}
-			ordered = append(ordered, m.Source)
-		}
 	}
 
 	name := o.Name
@@ -648,6 +639,7 @@ func (o *NewOptions) Run() error {
 			klog.V(2).Infof("Excluded mapping %s", m.Source)
 			continue
 		}
+		ordered = append(ordered, m.Source)
 		tag := hasTag(is.Spec.Tags, m.Source)
 		if tag == nil {
 			is.Spec.Tags = append(is.Spec.Tags, imageapi.TagReference{


### PR DESCRIPTION
Previously, additional mappings provided as args weren't considered when
creating a new release image from an ImageStream, an exsting release
image, or a directory. The was particularly problematic when attempting
to add new images:

    oc adm release new \
      --from-release quay.io/openshift-release-dev/ocp-release:4.2 \
      --to-image quay.io/crawford/openshift-release \
      cluster-etcd-operator=quay.io/hexfusion/cluster-etcd-operator

Without this patch, the previous command would create a release image
but it wouldn't the cluster-etcd-operator manifests.

Instead of adding new mappings in the default case (when not using an
existing ImageStream, release image, or directory), add them
unconditionally. Clayton thinks that this defect may have been
introduced when the validation code was being reworked.