### PR TITLE
Extend version cmd

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -57,6 +57,7 @@ import (
 	"github.com/openshift/oc/pkg/cli/startbuild"
 	"github.com/openshift/oc/pkg/cli/status"
 	"github.com/openshift/oc/pkg/cli/tag"
+	"github.com/openshift/oc/pkg/cli/version"
 	"github.com/openshift/oc/pkg/cli/whoami"
 	cmdutil "github.com/openshift/oc/pkg/helpers/cmd"
 	"github.com/openshift/oc/pkg/helpers/term"
@@ -267,7 +268,7 @@ func NewOcCommand(name, fullName string, in io.Reader, out, errout io.Writer) *c
 	cmds.AddCommand(newExperimentalCommand("ex", name+" ex", f, ioStreams))
 
 	cmds.AddCommand(kubectlwrappers.NewCmdPlugin(fullName, f, ioStreams))
-	cmds.AddCommand(kubectlwrappers.NewCmdVersion(fullName, f, ioStreams))
+	cmds.AddCommand(version.NewCmdVersion(fullName, f, ioStreams))
 	cmds.AddCommand(options.NewCmdOptions(ioStreams))
 
 	if cmds.Flag("namespace") != nil {

--- a/pkg/cli/deployer/deployer.go
+++ b/pkg/cli/deployer/deployer.go
@@ -29,7 +29,6 @@ import (
 	"github.com/openshift/oc/pkg/cli/deployer/strategy"
 	"github.com/openshift/oc/pkg/cli/deployer/strategy/recreate"
 	"github.com/openshift/oc/pkg/cli/deployer/strategy/rolling"
-	cmdversion "github.com/openshift/oc/pkg/cli/version"
 	"github.com/openshift/oc/pkg/version"
 )
 
@@ -86,7 +85,7 @@ func NewCommandDeployer(name string) *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(cmdversion.NewCmdVersion(name, version.Get(), os.Stdout))
+	cmd.AddCommand(NewCmdVersion(name, version.Get(), os.Stdout))
 
 	flag := cmd.Flags()
 	flag.StringVar(&cfg.rcName, "deployment", os.Getenv("OPENSHIFT_DEPLOYMENT_NAME"), "The deployment name to start")

--- a/pkg/cli/deployer/version.go
+++ b/pkg/cli/deployer/version.go
@@ -1,0 +1,25 @@
+package deployer
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"k8s.io/apimachinery/pkg/version"
+)
+
+// NewCmdVersion provides a shim around version for
+// non-client packages that require version information
+func NewCmdVersion(fullName string, versionInfo version.Info, out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Display version",
+		Long:  "Display version",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Fprintf(out, "%s %v\n", fullName, versionInfo)
+		},
+	}
+
+	return cmd
+}

--- a/pkg/cli/kubectlwrappers/wrappers.go
+++ b/pkg/cli/kubectlwrappers/wrappers.go
@@ -39,7 +39,6 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/cmd/run"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/scale"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
-	"k8s.io/kubernetes/pkg/kubectl/cmd/version"
 	kwait "k8s.io/kubernetes/pkg/kubectl/cmd/wait"
 	"k8s.io/kubernetes/pkg/kubectl/util/templates"
 
@@ -474,8 +473,4 @@ func NewCmdApiResources(fullName string, f kcmdutil.Factory, streams genericclio
 
 func NewCmdApiVersions(fullName string, f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
 	return cmdutil.ReplaceCommandName("kubectl", fullName, templates.Normalize(apiresources.NewCmdAPIVersions(f, streams)))
-}
-
-func NewCmdVersion(fullName string, f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
-	return cmdutil.ReplaceCommandName("kubectl", fullName, templates.Normalize(version.NewCmdVersion(f, streams)))
 }

--- a/pkg/cli/shim_kubectl.go
+++ b/pkg/cli/shim_kubectl.go
@@ -5,7 +5,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions/openshiftpatch"
 	kclientcmd "k8s.io/client-go/tools/clientcmd"
 	kcmdset "k8s.io/kubernetes/pkg/kubectl/cmd/set"
-	"k8s.io/kubernetes/pkg/kubectl/cmd/version"
 	describeversioned "k8s.io/kubernetes/pkg/kubectl/describe/versioned"
 	"k8s.io/kubernetes/pkg/kubectl/generate/versioned"
 	"k8s.io/kubernetes/pkg/kubectl/polymorphichelpers"
@@ -13,7 +12,6 @@ import (
 	"github.com/openshift/library-go/pkg/legacyapi/legacygroupification"
 	"github.com/openshift/oc/pkg/helpers/clientcmd"
 	"github.com/openshift/oc/pkg/helpers/originpolymorphichelpers"
-	oversion "github.com/openshift/oc/pkg/version"
 )
 
 func shimKubectlForOc() {
@@ -43,5 +41,4 @@ func shimKubectlForOc() {
 	// update some functions we inject
 	versioned.GeneratorFn = originpolymorphichelpers.NewGeneratorsFn(versioned.GeneratorFn)
 	describeversioned.DescriberFn = originpolymorphichelpers.NewDescriberFn(describeversioned.DescriberFn)
-	version.OverrideGetVersionFn = oversion.Get
 }

--- a/pkg/cli/version/version.go
+++ b/pkg/cli/version/version.go
@@ -1,25 +1,186 @@
 package version
 
 import (
+	"encoding/json"
 	"fmt"
-	"io"
 
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
 
-	"k8s.io/apimachinery/pkg/version"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apimachineryversion "k8s.io/apimachinery/pkg/version"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	kversion "k8s.io/kubernetes/pkg/kubectl/cmd/version"
+	"k8s.io/kubernetes/pkg/kubectl/util/i18n"
+	"k8s.io/kubernetes/pkg/kubectl/util/templates"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	"github.com/openshift/oc/pkg/version"
 )
 
-// NewCmdVersion provides a shim around version for
-// non-client packages that require version information
-func NewCmdVersion(fullName string, versionInfo version.Info, out io.Writer) *cobra.Command {
+type Version struct {
+	kversion.Version
+	OpenShiftVersion string `json:"openshiftVersion,omitempty"`
+}
+
+var (
+	versionLong = templates.LongDesc(`
+        Print the OpenShift client, kube-apiserver, and openshift-apiserver versions for the current context.
+        Pass --client to print only the OpenShift client version.`)
+	versionExample = templates.Examples(`
+        # Print the OpenShift client, kube-apiserver, and openshift-apiserver version information for the current context.
+        %[1]s version
+        # Print the OpenShift client, kube-apiserver, and openshift-apiserver version numbers for the current context.
+        %[1]s version --short
+        # Print the OpenShift client version information for the current context.
+        %[1]s version --client`)
+)
+
+type VersionOptions struct {
+	kversion.VersionOptions
+	oClient         configv1client.ClusterOperatorsGetter
+	discoveryClient discovery.CachedDiscoveryInterface
+
+	genericclioptions.IOStreams
+}
+
+func NewVersionOptions(ioStreams genericclioptions.IOStreams) *VersionOptions {
+	return &VersionOptions{
+		IOStreams: ioStreams,
+	}
+}
+
+// NewCmdVersion is copied from upstream NewCmdVersion with addition of OpenShift Server version info.
+// OpenShift Server version is output only if logged in to a cluster as an admin user.
+func NewCmdVersion(fullName string, f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	o := NewVersionOptions(ioStreams)
 	cmd := &cobra.Command{
-		Use:   "version",
-		Short: "Display version",
-		Long:  "Display version",
+		Use:     "version",
+		Short:   i18n.T("Print the client and server version information"),
+		Long:    "Print the client and server version information for the current context",
+		Example: fmt.Sprintf(versionExample, fullName),
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Fprintf(out, "%s %v\n", fullName, versionInfo)
+			cmdutil.CheckErr(o.Validate())
+			cmdutil.CheckErr(o.Complete(f, cmd))
+			cmdutil.CheckErr(o.Run())
 		},
 	}
-
+	cmd.Flags().BoolVar(&o.ClientOnly, "client", o.ClientOnly, "Client version only (no server required).")
+	cmd.Flags().BoolVar(&o.Short, "short", o.Short, "Print just the version number.")
+	cmd.Flags().StringVarP(&o.Output, "output", "o", o.Output, "One of 'yaml' or 'json'.")
 	return cmd
+}
+
+// Complete is copied from upstream version command with added clusteroperator client
+// to report OpenShift server version
+func (o *VersionOptions) Complete(f cmdutil.Factory, cmd *cobra.Command) error {
+	var err error
+	if o.ClientOnly {
+		return nil
+	}
+	o.discoveryClient, err = f.ToDiscoveryClient()
+	// if we had an empty rest.Config, continue and just print out client information.
+	// if we had an error other than being unable to build a rest.Config, fail.
+	if err != nil && !clientcmd.IsEmptyConfig(err) {
+		return err
+	}
+
+	clientConfig, err := f.ToRESTConfig()
+	if err != nil && !clientcmd.IsEmptyConfig(err) {
+		return err
+	}
+	if clientConfig != nil {
+		o.oClient, err = configv1client.NewForConfig(clientConfig)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Run is copied from upstream version command, with added OpenShift server version logic
+func (o *VersionOptions) Run() error {
+	var versionInfo Version
+	clientVersion := version.Get()
+	versionInfo.ClientVersion = &clientVersion
+
+	var serverErr error
+	var serverVersion *apimachineryversion.Info
+	if !o.ClientOnly {
+		if o.discoveryClient != nil {
+			// Always request fresh data from the server
+			o.discoveryClient.Invalidate()
+			serverVersion, serverErr = o.discoveryClient.ServerVersion()
+			versionInfo.ServerVersion = serverVersion
+		}
+		if o.oClient != nil {
+			var clusterOperator *configv1.ClusterOperator
+			clusterOperator, serverErr = o.oClient.ClusterOperators().Get("openshift-apiserver", metav1.GetOptions{})
+			// error here indicates logged in as non-admin, log and move on
+			if serverErr != nil {
+				switch {
+				case kerrors.IsForbidden(serverErr), kerrors.IsNotFound(serverErr):
+					klog.V(5).Infof("OpenShift Version not found (must be logged in to cluster as admin): %v", serverErr)
+					serverErr = nil
+				}
+			}
+			if clusterOperator != nil {
+				for _, ver := range clusterOperator.Status.Versions {
+					if ver.Name == "operator" {
+						// openshift-apiserver does not report version,
+						// clusteroperator/openshift-apiserver does, and only version number
+						versionInfo.OpenShiftVersion = ver.Version
+					}
+				}
+			}
+		}
+	}
+	switch o.Output {
+	case "":
+		if o.Short {
+			if versionInfo.ClientVersion != nil {
+				fmt.Fprintf(o.Out, "Client Version: %s\n", clientVersion.GitVersion)
+			}
+			if versionInfo.ServerVersion != nil {
+				fmt.Fprintf(o.Out, "Server Version: %s\n", serverVersion.GitVersion)
+			}
+			if len(versionInfo.OpenShiftVersion) != 0 {
+				fmt.Fprintf(o.Out, "OpenShift Version: %s\n", fmt.Sprintf("%s", versionInfo.OpenShiftVersion))
+			}
+		} else {
+			if versionInfo.ClientVersion != nil {
+				fmt.Fprintf(o.Out, "Client Version: %s\n", fmt.Sprintf("%#v", clientVersion))
+			}
+			if versionInfo.ServerVersion != nil {
+				fmt.Fprintf(o.Out, "Server Version: %s\n", fmt.Sprintf("%#v", *serverVersion))
+			}
+			if len(versionInfo.OpenShiftVersion) != 0 {
+				fmt.Fprintf(o.Out, "OpenShift Version: %s\n", fmt.Sprintf("%s", versionInfo.OpenShiftVersion))
+			}
+		}
+	case "yaml":
+		marshalled, err := yaml.Marshal(&versionInfo)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(o.Out, string(marshalled))
+	case "json":
+		marshalled, err := json.MarshalIndent(&versionInfo, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(o.Out, string(marshalled))
+	default:
+		// There is a bug in the program if we hit this case.
+		// However, we follow a policy of never panicking.
+		return fmt.Errorf("VersionOptions were not validated: --output=%q should have been rejected", o.Output)
+	}
+
+	return serverErr
 }


### PR DESCRIPTION
This PR
* adds OpenShift version information (clusteroperator openshift-apiserver version) to `oc version`
* there is no extended information for OpenShift version, only the clusteroperator/openshift-apiserver version number
* new version cmd, same as kubectl version with added OpenShift server version information

(see output below)
**NOTE** 
OpenShift Server Version requires admin user, if not logged in as admin user command or if clusteroperator not found, no info is given for OpenShift Version (no error) below -v 5, see output for -v 5 Info message. 

*Could not figure out git cmds to pull directly from https://github.com/openshift/origin/pull/23309 so did it manually*  