### PR TITLE
Fix `oc version` value replacement during build

### DIFF
--- a/images/cli/Dockerfile.rhel
+++ b/images/cli/Dockerfile.rhel
@@ -2,7 +2,7 @@ FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/oc
 RUN yum install -y gpgme-devel libassuan-devel
 COPY . .
-RUN make build --warn-undefined-variables
+RUN GOPATH=$(echo $GOPATH | cut -d':' -f1) make build --warn-undefined-variables
 
 FROM registry.svc.ci.openshift.org/ocp/4.2:base
 COPY --from=builder /go/src/github.com/openshift/oc/oc /usr/bin/


### PR DESCRIPTION
### TLDR

```patch
- go build -ldflags "-s -w -X /go/src/github.com/openshift/oc/pkg/version.versionFromGit="v4.2.0-201907181819-0-g830fb95" -X /go/src/github.com/openshift/oc/pkg/version.commitFromGit="830fb95" -X /go/src/github.com/openshift/oc/pkg/version.gitTreeState="clean" -X /go/src/github.com/openshift/oc/pkg/version.buildDate="2019-07-19T09:29:57Z" " github.com/openshift/oc/cmd/oc
+ go build -ldflags "-s -w -X github.com/openshift/oc/pkg/version.versionFromGit="v4.2.0-201907181819-0-g830fb95" -X github.com/openshift/oc/pkg/version.commitFromGit="830fb95" -X github.com/openshift/oc/pkg/version.gitTreeState="clean" -X github.com/openshift/oc/pkg/version.buildDate="2019-07-19T09:29:57Z" " github.com/openshift/oc/cmd/oc
```

---

There is a wrong substitution happening here:
https://github.com/openshift/oc/blob/master/vendor/github.com/openshift/library-go/alpha-build-machinery/make/lib/golang.mk#L3

When building with a `GOPATH` that contains multiple paths, for example `GOPATH=/go:/opt/rh/go-toolset-1.11/root/usr/share/gocode` it will generate wrong variable path on `-ldflags -X`.