### PR TITLE
Set the same tags as origin did

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ include $(addprefix ./vendor/github.com/openshift/library-go/alpha-build-machine
 GO_BUILD_PACKAGES :=$(strip \
 	./cmd/... \
 )
+# These tags make sure we can statically link and avoid shared dependencies
+GO_BUILD_FLAGS :=-tags 'include_gcs include_oss containers_image_openpgp no_openssl gssapi'
 
 # This will call a macro called "build-image" which will generate image specific targets based on the parameters:
 # $0 - macro name


### PR DESCRIPTION
Copy all tags from origin (some might not be needed scoped to this repo) but this is how oc has been compiled. Changes:

```
ldd oc
	linux-vdso.so.1 (0x00007ffc710e0000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007f3f59961000)
	libgpgme.so.11 => /lib64/libgpgme.so.11 (0x00007f3f59914000)
	libassuan.so.0 => /lib64/libassuan.so.0 (0x00007f3f598fe000)
	libgpg-error.so.0 => /lib64/libgpg-error.so.0 (0x00007f3f598db000)
	libc.so.6 => /lib64/libc.so.6 (0x00007f3f59715000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f3f599b1000)
```
into
```
ldd oc
	linux-vdso.so.1 (0x00007ffeccae7000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fc132ddd000)
	libdl.so.2 => /lib64/libdl.so.2 (0x00007fc132dd7000)
	libc.so.6 => /lib64/libc.so.6 (0x00007fc132c11000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fc132e2d000)
```

/cc @deads2k @sttts 