### PR TITLE
quick and dirty way to get a kubectl version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,14 @@
 all: build
 .PHONY: all
 
+GO_LD_EXTRAFLAGS :=-X github.com/openshift/oc/vendor/k8s.io/kubernetes/pkg/version.gitMajor="1" \
+                   -X github.com/openshift/oc/vendor/k8s.io/kubernetes/pkg/version.gitMinor="14" \
+                   -X github.com/openshift/oc/vendor/k8s.io/kubernetes/pkg/version.gitVersion="v1.14.0+724e12f93f" \
+                   -X github.com/openshift/oc/vendor/k8s.io/kubernetes/pkg/version.gitCommit="$(shell git rev-parse --short "HEAD^{commit}" 2>/dev/null)" \
+                   -X github.com/openshift/oc/vendor/k8s.io/kubernetes/pkg/version.buildDate="$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+                   -X github.com/openshift/oc/vendor/k8s.io/kubernetes/pkg/version.gitTreeState="clean"
+
+
 # Include the library makefile
 include $(addprefix ./vendor/github.com/openshift/library-go/alpha-build-machinery/make/, \
 	golang.mk \


### PR DESCRIPTION
Much better option than https://github.com/openshift/origin/pull/23438

It's still not pretty, but it's slightly better.