### PR TITLE
Support both kubectl and oc prefixes for binary plugins

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -109,7 +109,9 @@ func NewDefaultOcCommand(name, fullName string, in io.Reader, out, errout io.Wri
 	}
 
 	cmdPathPieces := os.Args[1:]
-	pluginHandler := kubecmd.NewDefaultPluginHandler(plugin.ValidPluginFilenamePrefixes)
+
+	// support both upstream "kubectl" and "oc" as plugin prefixes
+	pluginHandler := kubecmd.NewDefaultPluginHandler(append(plugin.ValidPluginFilenamePrefixes, name))
 
 	// only look for suitable extension executables if
 	// the specified command does not already exist


### PR DESCRIPTION
This allows plugin authors to either prefix with "kubectl-" or "oc-" when designing a cli plugin.

All of the following would work with this:
- kubectl-foo
- kubectl-bar
- kubectl-bar-baz
- oc-foo
- oc-bar
- oc-bar-baz