### PR TITLE
describe: print empty image config fields if the docker config is nil

### DIFF
--- a/pkg/helpers/describe/describer.go
+++ b/pkg/helpers/describe/describer.go
@@ -718,11 +718,15 @@ func DescribeImage(image *imagev1.Image, imageName string) (string, error) {
 		formatString(out, "Author", dockerImage.Author)
 		formatString(out, "Arch", dockerImage.Architecture)
 
-		if dockerImage.Config != nil {
-			// Config is the configuration of the container received from the client.
-			// In most cases this field is always set for images.
-			describeDockerImage(out, dockerImage.Config)
+		dockerImageConfig := dockerImage.Config
+		// This field should always be populated, if it is not we should print empty fields.
+		if dockerImageConfig == nil {
+			dockerImageConfig = &dockerv10.DockerConfig{}
 		}
+
+		// Config is the configuration of the container received from the client.
+		// In most cases this field is always set for images.
+		describeDockerImage(out, dockerImageConfig)
 		return nil
 	})
 }


### PR DESCRIPTION
The scenario when the docker image config field is not set (nil) is an error and instead of hiding it, we should print the empty fields.

Follow up for https://github.com/openshift/origin/pull/23318

/cc @smarterclayton 
/cc @tnozicka 