### PR TITLE
Bug 1737127: idle: fix null dereference when pod's controller can't be found

### DIFF
--- a/pkg/cli/idle/idle.go
+++ b/pkg/cli/idle/idle.go
@@ -405,10 +405,10 @@ func findScalableResourcesForEndpoints(endpoints *corev1.Endpoints, getPod func(
 	immediateControllerRefs := make(map[namespacedOwnerReference]struct{})
 	for _, pod := range podRefs {
 		controllerRef := metav1.GetControllerOf(pod)
-		ref := normalizedNSOwnerRef(pod.Namespace, controllerRef)
 		if controllerRef == nil {
 			return nil, fmt.Errorf("unable to find controller for pod %s/%s: no creator reference listed", pod.Namespace, pod.Name)
 		}
+		ref := normalizedNSOwnerRef(pod.Namespace, controllerRef)
 		immediateControllerRefs[ref] = struct{}{}
 	}
 


### PR DESCRIPTION
Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1737127