### PR TITLE
Bug 1704827: Improve error msg when console URL passed to login via CLI

### DIFF
--- a/pkg/cli/login/error_translation.go
+++ b/pkg/cli/login/error_translation.go
@@ -22,7 +22,15 @@ You can also run this command again providing the path to a config file directly
 `
 	tlsOversizedRecordMsg = `Unable to connect to %[2]s using TLS: %[1]s.
 Ensure the specified server supports HTTPS.`
+	invalidServerURLMsg = `Seems you passed an HTML page (console?) instead of server URL.
+Verify provided address and try again.`
 )
+
+type errInvalidServerURL struct{}
+
+func (e *errInvalidServerURL) Error() string {
+	return invalidServerURLMsg
+}
 
 // GetPrettyMessageForServer prettifys the message of the provided error
 func getPrettyMessageForServer(err error, serverName string) string {
@@ -50,6 +58,7 @@ func getPrettyMessageForServer(err error, serverName string) string {
 
 	case certificateInvalidReason:
 		return fmt.Sprintf("The server is using an invalid certificate: %s", err)
+
 	}
 
 	return err.Error()

--- a/pkg/cli/login/helpers.go
+++ b/pkg/cli/login/helpers.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	restclient "k8s.io/client-go/rest"
@@ -72,6 +73,13 @@ func dialToServer(clientConfig restclient.Config) error {
 	res, err := rt.RoundTrip(req)
 	if err != nil {
 		return err
+	}
+
+	// This is to guide a user who passes the console URL instead of server URL
+	// See https://bugzilla.redhat.com/show_bug.cgi?id=1704827
+	contentType := res.Header.Get("Content-Type")
+	if strings.Contains(contentType, "text/html") {
+		return &errInvalidServerURL{}
 	}
 
 	defer res.Body.Close()

--- a/pkg/cli/login/loginoptions.go
+++ b/pkg/cli/login/loginoptions.go
@@ -142,6 +142,11 @@ func (o *LoginOptions) getClientConfig() (*restclient.Config, error) {
 				clientConfig.Insecure = true
 				clientConfig.CAFile = ""
 				clientConfig.CAData = nil
+				// dialToServer was called above but in case of user choosing insecure,
+				// need to call again for invalidServerURL check
+				if err := dialToServer(*clientConfig); err != nil {
+					return nil, err
+				}
 			} else {
 				return nil, getPrettyErrorForServer(err, o.Server)
 			}
@@ -155,6 +160,7 @@ func (o *LoginOptions) getClientConfig() (*restclient.Config, error) {
 			}
 			return nil, err
 		}
+
 	}
 
 	o.Config = clientConfig
@@ -229,6 +235,7 @@ func (o *LoginOptions) gatherAuthInfo() error {
 	clientConfig.KeyData = []byte{}
 	clientConfig.CertFile = o.CertFile
 	clientConfig.KeyFile = o.KeyFile
+
 	token, err := tokencmd.RequestToken(o.Config, o.In, o.Username, o.Password)
 	if err != nil {
 		return err


### PR DESCRIPTION
This adds a very specific error message for users who pass the console URL instead of API URL. 

Adds a check for http response with Content-Type "html/text"  (console url) instead of "application/json" (server URL) 

(see output below)
_btw: kubeadmin is not meant to be used via CLI, only to be used for admin login to console to set up a valid identity provider via console, however, I used kubeadmin in the examples below bc I did not set up any other idp_
