### PR TITLE
Fixup the following crash

### DIFF
--- a/pkg/cli/secrets/sshauth.go
+++ b/pkg/cli/secrets/sshauth.go
@@ -146,6 +146,9 @@ func (o *CreateSSHAuthSecretOptions) NewSSHAuthSecret() (*corev1.Secret, error) 
 // Complete fills CreateSSHAuthSecretOptions fields with data and checks whether necessary
 // arguments were provided.
 func (o *CreateSSHAuthSecretOptions) Complete(f kcmdutil.Factory, args []string) error {
+	if len(args) != 1 {
+		return errors.New("must have exactly one argument: secret name")
+	}
 	o.SecretName = args[0]
 
 	clientConfig, err := f.ToRESTConfig()


### PR DESCRIPTION
$ oc secret new-sshauth
Command "new-sshauth" is deprecated, use oc create secret
panic: runtime error: index out of range

goroutine 1 [running]:
github.com/openshift/origin/pkg/oc/cli/secrets.(*CreateSSHAuthSecretOptions).Complete(0xc420e5caa0, 0x3caf1a0, 0xc420f177d0, 0x5303668, 0x0, 0x0, 0x23, 0x23)
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/pkg/oc/cli/secrets/sshauth.go:149 +0x2ae
github.com/openshift/origin/pkg/oc/cli/secrets.NewCmdCreateSSHAuthSecret.func1(0xc4213ab900, 0x5303668, 0x0, 0x0)
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/pkg/oc/cli/secrets/sshauth.go:80 +0x7a
github.com/openshift/origin/vendor/github.com/spf13/cobra.(*Command).execute(0xc4213ab900, 0x5303668, 0x0, 0x0, 0xc4213ab900, 0x5303668)
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/spf13/cobra/command.go:760 +0x2c1
github.com/openshift/origin/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc421490780, 0xc42000c010, 0xc42000c020, 0xc421490780)
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/spf13/cobra/command.go:846 +0x30a
github.com/openshift/origin/vendor/github.com/spf13/cobra.(*Command).Execute(0xc421490780, 0x2, 0xc421490780)
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/spf13/cobra/command.go:794 +0x2b
main.main()
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/cmd/oc/oc.go:70 +0x583

Signed-off-by: Zhou Peng <p@ctriple.cn>