### PR TITLE
pkg/cli/admin/release: include baremetal-installer in release

### DIFF
--- a/pkg/cli/admin/release/new.go
+++ b/pkg/cli/admin/release/new.go
@@ -50,7 +50,7 @@ func NewNewOptions(streams genericclioptions.IOStreams) *NewOptions {
 		// TODO: only cluster-version-operator and maybe CLI should be in this list,
 		//   the others should always be referenced by the cluster-bootstrap or
 		//   another operator.
-		AlwaysInclude:  []string{"cluster-version-operator", "cli", "installer"},
+		AlwaysInclude:  []string{"baremetal-installer", "cluster-version-operator", "cli", "installer"},
 		ToImageBaseTag: "cluster-version-operator",
 		// We strongly control the set of allowed component versions to prevent confusion
 		// about what component versions may be used for. Changing this list requires


### PR DESCRIPTION
https://github.com/openshift/release/pull/4640 added the baremetal-installer
image.

This adds baremetal-installer to always be included in a release, which
is openshift-installer that includes the baremetal platform.