### PR TITLE
pkg/cli/admin/release: support extracting baremetal installer

### DIFF
--- a/pkg/cli/admin/release/extract_tools.go
+++ b/pkg/cli/admin/release/extract_tools.go
@@ -305,7 +305,7 @@ func (o *ExtractOptions) extractCommand(command string) error {
 			target.Mapping.Name = fmt.Sprintf(target.ArchiveFormat, releaseName)
 			target.Mapping.To = filepath.Join(dir, target.Mapping.Name)
 		} else {
-			target.Mapping.To = filepath.Join(dir, filepath.Base(target.Mapping.From))
+			target.Mapping.To = filepath.Join(dir, target.Command)
 			target.Mapping.Name = fmt.Sprintf("%s-%s", target.OS, target.Command)
 		}
 		validTargets = append(validTargets, target)
@@ -398,7 +398,7 @@ func (o *ExtractOptions) extractCommand(command string) error {
 
 				zh := &zip.FileHeader{
 					Method:             zip.Deflate,
-					Name:               hdr.Name,
+					Name:               target.Command + ".exe",
 					UncompressedSize64: uint64(hdr.Size),
 					Modified:           hdr.ModTime,
 				}
@@ -436,7 +436,7 @@ func (o *ExtractOptions) extractCommand(command string) error {
 				}
 
 				if err := tw.WriteHeader(&tar.Header{
-					Name:     hdr.Name,
+					Name:     target.Command,
 					Mode:     int64(os.FileMode(0755).Perm()),
 					Size:     hdr.Size,
 					Typeflag: tar.TypeReg,
@@ -454,7 +454,7 @@ func (o *ExtractOptions) extractCommand(command string) error {
 							Size:     0,
 							Typeflag: tar.TypeLink,
 							ModTime:  hdr.ModTime,
-							Linkname: hdr.Name,
+							Linkname: target.Command,
 						}); err != nil {
 							return err
 						}

--- a/pkg/cli/admin/release/extract_tools.go
+++ b/pkg/cli/admin/release/extract_tools.go
@@ -36,8 +36,9 @@ import (
 
 // extractTarget describes how a file in the release image can be extracted to disk.
 type extractTarget struct {
-	OS      string
-	Command string
+	OS       string
+	Command  string
+	Optional bool
 
 	TargetName string
 
@@ -189,6 +190,16 @@ func (o *ExtractOptions) extractCommand(command string) error {
 			InjectReleaseImage: true,
 			ArchiveFormat:      "openshift-install-linux-%s.tar.gz",
 		},
+		{
+			OS:       "linux",
+			Command:  "openshift-baremetal-install",
+			Optional: true,
+			Mapping:  extract.Mapping{Image: "baremetal-installer", From: "usr/bin/openshift-install"},
+
+			Readme:             readmeInstallUnix,
+			InjectReleaseImage: true,
+			ArchiveFormat:      "openshift-baremetal-install-linux-%s.tar.gz",
+		},
 	}
 
 	currentOS := runtime.GOOS
@@ -212,7 +223,9 @@ func (o *ExtractOptions) extractCommand(command string) error {
 		}
 	} else {
 		for _, target := range availableTargets {
-			targets = availableTargets
+			if !target.Optional {
+				targets = append(targets, target)
+			}
 		}
 	}
 


### PR DESCRIPTION
The installer for baremetal is in a separate image as part of the
release, we need to provide awareness to the `oc` command so we can
actually extract the installer and replace the release image location.

A user would extract the baremetal installer like this:

```
oc adm release extract --registry-config <pull secret> --command=openshift-baremetal-install --to /tmp
```
