### PR TITLE
Bug 1709239: Remove Git Repo option from 'oc set volumes' cmd

### DIFF
--- a/pkg/cli/set/env.go
+++ b/pkg/cli/set/env.go
@@ -49,8 +49,8 @@ var (
 		syntax.`)
 
 	envExample = templates.Examples(`
-		# Update deployment 'registry' with a new environment variable
-	  %[1]s env dc/registry STORAGE_DIR=/local
+	  # Update deployment config 'myapp' with a new environment variable
+	  %[1]s env dc/myapp STORAGE_DIR=/local
 
 	  # List the environment variables defined on a build config 'sample-build'
 	  %[1]s env bc/sample-build --list
@@ -78,7 +78,7 @@ var (
 	  %[1]s env -f dc.json ENV-
 
 	  # Set some of the local shell environment into a deployment config on the server
-	  env | grep RAILS_ | %[1]s env -e - dc/registry`)
+	  env | grep RAILS_ | %[1]s env -e - dc/myapp`)
 )
 
 type EnvOptions struct {

--- a/pkg/cli/set/probe.go
+++ b/pkg/cli/set/probe.go
@@ -50,11 +50,11 @@ var (
 		to fail.`)
 
 	probeExample = templates.Examples(`
-		# Clear both readiness and liveness probes off all containers
-	  %[1]s probe dc/registry --remove --readiness --liveness
+	  # Clear both readiness and liveness probes off all containers
+	  %[1]s probe dc/myapp --remove --readiness --liveness
 
 	  # Set an exec action as a liveness probe to run 'echo ok'
-	  %[1]s probe dc/registry --liveness -- echo ok
+	  %[1]s probe dc/myapp --liveness -- echo ok
 
 	  # Set a readiness probe to try to open a TCP socket on 3306
 	  %[1]s probe rc/mysql --readiness --open-tcp=3306

--- a/pkg/cli/set/triggers.go
+++ b/pkg/cli/set/triggers.go
@@ -60,14 +60,14 @@ var (
 		trigger for a build config will only trigger the first build.`)
 
 	triggersExample = templates.Examples(`
-		# Print the triggers on the registry
-	  %[1]s triggers dc/registry
+	  # Print the triggers on the deployment config 'myapp'
+	  %[1]s triggers dc/myapp
 
 	  # Set all triggers to manual
-	  %[1]s triggers dc/registry --manual
+	  %[1]s triggers dc/myapp --manual
 
 	  # Enable all automatic triggers
-	  %[1]s triggers dc/registry --auto
+	  %[1]s triggers dc/myapp --auto
 
 	  # Reset the GitHub webhook on a build to a new, generated secret
 	  %[1]s triggers bc/webapp --from-github
@@ -77,7 +77,7 @@ var (
 	  %[1]s triggers bc/webapp --remove-all
 
 	  # Stop triggering on config change
-	  %[1]s triggers dc/registry --from-config --remove
+	  %[1]s triggers dc/myapp --from-config --remove
 
 	  # Add an image trigger to a build config
 	  %[1]s triggers bc/webapp --from-image=namespace1/image:latest


### PR DESCRIPTION
This PR:
1) Removes Git Repo examples from `oc set volume` help menu, since git volume source is no longer supported.
2) updates examples in oc `dc/registry` to `dc/myapp`  
    (3.x dc/registry vs 4.x deployment/image-registry), might cause confusion if left as/is.  