### PR TITLE
Bug 1748372: oc adm must-gather must prefix lines from stdout and stderr

### DIFF
--- a/pkg/cli/admin/mustgather/mustgather_test.go
+++ b/pkg/cli/admin/mustgather/mustgather_test.go
@@ -72,6 +72,7 @@ func TestImagesAndImageStreams(t *testing.T) {
 				ImageClient:  imageclient.NewSimpleClientset(tc.objects...).ImageV1(),
 				Images:       tc.images,
 				ImageStreams: tc.imageStreams,
+				LogOut:       genericclioptions.NewTestIOStreamsDiscard().Out,
 			}
 			err := options.completeImages()
 			if err != nil {


### PR DESCRIPTION
Prepend log output with some hint as to where it is coming from.
Example:
```
[must-gather      ] OUT Using must-gather plugin-in image: registry.svc.ci.openshift.org/ocp/4.2-2019-09-03-102629@sha256:99353133df86a6baacaeaeab602f0fc9638c8abc79ae768e4d516bb2fe4a0a3a, registry.svc.ci.openshift.org/ocp/4.2-2019-09-03-102629@sha256:99353133df86a6baacaeaeab602f0fc9638c8abc79ae768e4d516bb2fe4a0a3a
[must-gather      ] OUT namespace/openshift-must-gather-wtds4 created
[must-gather      ] OUT clusterrolebinding.rbac.authorization.k8s.io/must-gather-9pbwm created
[must-gather      ] OUT [must-gather-f8xr4] pod for plug-in image registry.svc.ci.openshift.org/ocp/4.2-2019-09-03-102629@sha256:99353133df86a6baacaeaeab602f0fc9638c8abc79ae768e4d516bb2fe4a0a3a created
[must-gather      ] OUT [must-gather-bhzm2] pod for plug-in image registry.svc.ci.openshift.org/ocp/4.2-2019-09-03-102629@sha256:99353133df86a6baacaeaeab602f0fc9638c8abc79ae768e4d516bb2fe4a0a3a created
[must-gather-bhzm2] POD 2019/09/03 18:56:02 Gathering data for ns/openshift-config...
[must-gather-bhzm2] POD 2019/09/03 18:56:02     Collecting resources for namespace "openshift-config"...
[must-gather-bhzm2] POD 2019/09/03 18:56:02     Gathering pod data for namespace "openshift-config"...
[must-gather-f8xr4] POD 2019/09/03 18:56:02 Gathering data for ns/openshift-config...
[must-gather-f8xr4] POD 2019/09/03 18:56:02     Collecting resources for namespace "openshift-config"...
[must-gather-f8xr4] POD 2019/09/03 18:56:02     Gathering pod data for namespace "openshift-config"...
[must-gather-bhzm2] POD 2019/09/03 18:56:02 Finished successfully with no errors.
```