### PR TITLE
release: Add a better error message when base tag missing

### DIFF
--- a/pkg/cli/admin/release/new.go
+++ b/pkg/cli/admin/release/new.go
@@ -1179,7 +1179,7 @@ func (o *NewOptions) write(r io.Reader, is *imageapi.ImageStream, now time.Time)
 				}
 			}
 			if len(toImageBase) == 0 {
-				return fmt.Errorf("--to-image-base-tag did not point to a tag in the input")
+				return fmt.Errorf("the base image tag %q could not be found in the input, cannot build a release image", o.ToImageBaseTag)
 			}
 		}
 


### PR DESCRIPTION
The current error is confusing for the default value (which is
cluster-version-operator) when the user screws up and doesn't specify
a release image input. Make it clear which tag we couldn't find.