### PR TITLE
Bug 1715001: If extracted from payload, 'oc version' reports payload version

### DIFF
--- a/pkg/cli/admin/release/extract_tools_test.go
+++ b/pkg/cli/admin/release/extract_tools_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func Test_copyAndReplaceReleaseImage(t *testing.T) {
-	baseLen := len(installerReplacement)
+	baseLen := len(binaryReplacement)
 	tests := []struct {
 		name         string
 		r            *bytes.Buffer
@@ -61,7 +61,7 @@ func Test_copyAndReplaceReleaseImage(t *testing.T) {
 			original := make([]byte, len(src))
 			copy(original, src)
 
-			got, err := copyAndReplaceReleaseImage(w, tt.r, tt.buffer, tt.releaseImage)
+			got, err := copyAndReplaceReleaseInfo(w, tt.r, tt.buffer, tt.releaseImage)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("copyAndReplaceReleaseImage() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -89,7 +89,7 @@ func fakeInput(lengths ...int) *bytes.Buffer {
 	buf := &bytes.Buffer{}
 	for _, l := range lengths {
 		if l == 0 {
-			buf.WriteString(installerReplacement)
+			buf.WriteString(binaryReplacement)
 		} else {
 			b := byte(rand.Intn(256))
 			buf.Write(bytes.Repeat([]byte{b}, l))

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -19,6 +19,7 @@ package version
 import (
 	"fmt"
 	"runtime"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/version"
 )
@@ -54,4 +55,48 @@ func Get() version.Info {
 		Compiler:     runtime.Compiler,
 		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 	}
+}
+
+// This file handles correctly identifying the default release version, which is expected to be
+// replaced in the binary post-compile by the release name extracted from a payload. The expected modification is:
+//
+// 1. Extract a release binary that contains a cli image
+// 2. Identify the release name, add a NUL terminator byte (0x00) to the end, calculate length
+// 3. Length must be less than 300 bytes
+// 4. Search through the cli binary looking for `\x00_RELEASE_IMAGE_LOCATION_\x00<PADDING_TO_LENGTH>`
+//    where padding is the ASCII character X and length is the total length of the image
+// 5. Overwrite that chunk of the bytes if found, otherwise return error.
+
+var (
+	// defaultReleaseInfoPadded may be replaced in the binary with a pull spec that overrides defaultReleaseInfo as
+	// a null-terminated string within the allowed character length. This allows a distributor to override the payload
+	// location without having to rebuild the source.
+	defaultReleaseInfoPadded = "\x00_RELEASE_IMAGE_LOCATION_\x00XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\x00"
+	defaultReleaseInfoPrefix = "\x00_RELEASE_IMAGE_LOCATION_\x00"
+	defaultReleaseInfoLength = len(defaultReleaseInfoPadded)
+)
+
+// ExtractVersion() abstracts how the binary loads the default release payload. We want to lock the binary
+// to the pull spec of the payload we test it with, and since a payload contains the cli image we can't
+// know that at build time. Instead, we make it possible to replace the release string after build via a
+// known constant in the binary.  When extracting oc from release image, 'oc version' reports the payload version.
+func ExtractVersion() (version.Info, string, error) {
+	if strings.HasPrefix(defaultReleaseInfoPadded, defaultReleaseInfoPrefix) {
+		return Get(), "", nil
+	}
+	nullTerminator := strings.IndexByte(defaultReleaseInfoPadded, '\x00')
+	if nullTerminator == -1 {
+		// the binary has been altered, but we didn't find a null terminator within the release name constant which is an error
+		return version.Info{}, "", fmt.Errorf("release name location was replaced but without a null terminator before %d bytes", defaultReleaseInfoLength)
+	}
+	if nullTerminator > len(defaultReleaseInfoPadded) {
+		// the binary has been altered, but the null terminator is *longer* than the constant encoded in the binary
+		return version.Info{}, "", fmt.Errorf("release name location contains no null-terminator and constant is corrupted")
+	}
+	releaseName := defaultReleaseInfoPadded[:nullTerminator]
+	if len(releaseName) == 0 {
+		// the binary has been altered, but the replaced release name is empty which is incorrect
+		return version.Info{}, "", fmt.Errorf("release name location is empty, this binary was incorrectly generated")
+	}
+	return Get(), releaseName, nil
 }


### PR DESCRIPTION
This PR refactors `oc adm release extract` to report payload version for `oc version`.
In case of `oc version -o yaml` full output will print the version struct plus a new field `releaseClientVersion: payloadversion` 

See output below. 
`make build` w/ this PR checked out, then
with `oc adm release extract --tools quay.io/sallyom/release:test -v=3` access a test release image that includes:
* registry.svc.ci.openshift.org/ocp/release:4.3.0-0.ci-2019-10-07-053008
* cli image built from this PR 

/assign @soltysh  

cc @wking @tnozicka @smarterclayton