### PR TITLE
pkg/cli/image/extract: disable pigz to prevent race condition

### DIFF
--- a/pkg/cli/image/extract/extract.go
+++ b/pkg/cli/image/extract/extract.go
@@ -483,6 +483,10 @@ func (o *Options) Run() error {
 }
 
 func layerByEntry(r io.Reader, options *archive.TarOptions, layerInfo LayerInfo, fn TarEntryFunc, allLayers bool, alreadySeen map[string]struct{}) (bool, error) {
+	// Prevents race condition present in vendored version of docker
+	// https://github.com/moby/moby/issues/39859
+	os.Setenv("MOBY_DISABLE_PIGZ", "true")
+
 	rc, err := dockerarchive.DecompressStream(r)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
There is a race condition in the vendored version of docker code that
can cause image extraction to panic.  When the `pigz` package is
installed, docker's DecompressStream code prefers to use it, however,
that code can return the io buffer to the pool while the command is
still writing to it. If the buffer is reused while that's happening,
`oc` will panic.  There are many reports of this happening.

As the vendored docker comes from kubectl, and the version there (even
for k8s 1.16) is quite old, this disables using pigz at all by setting
MOBY_DISABLE_PIGZ environment variable. 

fixes #58