### PR TITLE
release: Strip leading bracket indicators from changelogs

### DIFF
--- a/pkg/cli/admin/release/git_test.go
+++ b/pkg/cli/admin/release/git_test.go
@@ -1,0 +1,135 @@
+package release
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/diff"
+)
+
+type fakeGit struct {
+	input string
+}
+
+func (g fakeGit) exec(commands ...string) (string, error) {
+	return g.input, nil
+}
+
+func Test_mergeLogForRepo(t *testing.T) {
+	type args struct {
+	}
+	tests := []struct {
+		name    string
+		input   string
+		repo    string
+		from    string
+		to      string
+		want    []MergeCommit
+		wantErr bool
+	}{
+		{
+			input: "abc\x1e1\x1eMerge pull request #145 from\x1eBug 1743564: test",
+			want: []MergeCommit{
+				{
+					ParentCommits: []string{}, Commit: "abc", PullRequest: 145, CommitDate: time.Unix(1, 0).UTC(),
+					Bugs: []int{1743564}, Subject: "test",
+				},
+			},
+		},
+		{
+			input: "abc\x1e1\x1eMerge pull request #145 from\x1eBug 1743564: test [trailing]",
+			want: []MergeCommit{
+				{
+					ParentCommits: []string{}, Commit: "abc", PullRequest: 145, CommitDate: time.Unix(1, 0).UTC(),
+					Bugs: []int{1743564}, Subject: "test [trailing]",
+				},
+			},
+		},
+		{
+			input: "abc\x1e1\x1eMerge pull request #145 from\x1e[release-4.1] Bug 1743564: test",
+			want: []MergeCommit{
+				{
+					ParentCommits: []string{}, Commit: "abc", PullRequest: 145, CommitDate: time.Unix(1, 0).UTC(),
+					Bugs: []int{1743564}, Subject: "test",
+				},
+			},
+		},
+		{
+			input: "abc\x1e1\x1eMerge pull request #145 from\x1e [release-4.1] Bug 1743564: test",
+			want: []MergeCommit{
+				{
+					ParentCommits: []string{}, Commit: "abc", PullRequest: 145, CommitDate: time.Unix(1, 0).UTC(),
+					Bugs: []int{1743564}, Subject: "test",
+				},
+			},
+		},
+		{
+			input: "abc\x1e1\x1eMerge pull request #145 from\x1e [release-4.1] Bug 1743564 : test",
+			want: []MergeCommit{
+				{
+					ParentCommits: []string{}, Commit: "abc", PullRequest: 145, CommitDate: time.Unix(1, 0).UTC(),
+					Bugs: []int{1743564}, Subject: "test",
+				},
+			},
+		},
+		{
+			input: "abc\x1e1\x1eMerge pull request #145 from\x1e [release-4.1] Bugs 1743564 : test",
+			want: []MergeCommit{
+				{
+					ParentCommits: []string{}, Commit: "abc", PullRequest: 145, CommitDate: time.Unix(1, 0).UTC(),
+					Bugs: []int{1743564}, Subject: "test",
+				},
+			},
+		},
+		{
+			input: "abc\x1e1\x1eMerge pull request #145 from\x1e [release-4.1] Bugs 1743564,: test",
+			want: []MergeCommit{
+				{
+					ParentCommits: []string{}, Commit: "abc", PullRequest: 145, CommitDate: time.Unix(1, 0).UTC(),
+					Bugs: []int{1743564}, Subject: "test",
+				},
+			},
+		},
+		{
+			input: "abc\x1e1\x1eMerge pull request #145 from\x1e [release-4.1] Bugs , 17 43,564,: test",
+			want: []MergeCommit{
+				{
+					ParentCommits: []string{}, Commit: "abc", PullRequest: 145, CommitDate: time.Unix(1, 0).UTC(),
+					Bugs: []int{17, 43, 564}, Subject: "test",
+				},
+			},
+		},
+		{
+			input: "abc\x1e1\x1eMerge pull request #145 from\x1e [release-4.1] bugs , 17 43,564,: test",
+			want: []MergeCommit{
+				{
+					ParentCommits: []string{}, Commit: "abc", PullRequest: 145, CommitDate: time.Unix(1, 0).UTC(),
+					Bugs: []int{17, 43, 564}, Subject: "test",
+				},
+			},
+		},
+		{
+			input: "abc\x1e1\x1eMerge pull request #145 from\x1e [release 4.1] bugs , 17 43,564,: test",
+			want: []MergeCommit{
+				{
+					ParentCommits: []string{}, Commit: "abc", PullRequest: 145, CommitDate: time.Unix(1, 0).UTC(),
+					Bugs: nil, Subject: "[release 4.1] bugs , 17 43,564,: test",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := fakeGit{input: tt.input}
+			got, err := mergeLogForRepo(g, tt.repo, "a", "b")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("mergeLogForRepo() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("mergeLogForRepo(): %s", diff.ObjectReflectDiff(tt.want, got))
+			}
+		})
+	}
+}

--- a/pkg/cli/admin/release/info.go
+++ b/pkg/cli/admin/release/info.go
@@ -1249,14 +1249,19 @@ func describeChangelog(out, errOut io.Writer, diff *ReleaseDiff, dir string) err
 					suffix = commit.Commit[:8]
 				}
 				switch {
-				case commit.Bug > 0:
-					fmt.Fprintf(out,
-						"* [Bug %d](%s): %s %s\n",
-						commit.Bug,
-						fmt.Sprintf("https://bugzilla.redhat.com/show_bug.cgi?id=%d", commit.Bug),
-						commit.Subject,
-						suffix,
-					)
+				case len(commit.Bugs) > 0:
+					for i, bug := range commit.Bugs {
+						if i == 0 {
+							fmt.Fprintf(out, "* [Bug %d](%s)", bug, fmt.Sprintf("https://bugzilla.redhat.com/show_bug.cgi?id=%d", bug))
+						} else {
+							fmt.Fprintf(out, ", [%d](%s)", bug, fmt.Sprintf("https://bugzilla.redhat.com/show_bug.cgi?id=%d", bug))
+						}
+						fmt.Fprintf(out,
+							": %s %s\n",
+							commit.Subject,
+							suffix,
+						)
+					}
 				default:
 					fmt.Fprintf(out,
 						"* %s %s\n",
@@ -1296,10 +1301,10 @@ func describeBugs(out, errOut io.Writer, diff *ReleaseDiff, dir string, format s
 			continue
 		}
 		for _, commit := range commits {
-			if commit.Bug == 0 {
+			if len(commit.Bugs) == 0 {
 				continue
 			}
-			bugIDs.Insert(commit.Bug)
+			bugIDs.Insert(commit.Bugs...)
 		}
 	}
 


### PR DESCRIPTION
Prefixes like `[release-4.3]`, `[4.2]`, `[blocker]` are typically
informational only - to allow a little more flexibility from
contributors in PR titles strip those prefixes. Also support lists
of bugs and mixed case for `Bug` or the use of `Bugs`.

/assign @eparis
/cherrypick release-4.2
/cherrypick release-4.1