### PR TITLE
Bug 1756107: Make container endpoint collection errors non-fatal

### DIFF
--- a/pkg/cli/admin/inspect/pod.go
+++ b/pkg/cli/admin/inspect/pod.go
@@ -75,7 +75,7 @@ func (o *InspectOptions) gatherContainerInfo(destDir string, pod *corev1.Pod, co
 	}
 
 	if err := o.gatherContainerEndpoints(path.Join(destDir, "/"+container.Name), pod, &container, port); err != nil {
-		return err
+		log.Printf("        Skipping one or more container endpoint collection for pod %q container %q: %v\n", pod.Name, container.Name, err)
 	}
 
 	return nil


### PR DESCRIPTION
Makes the endpoint collection non-fatal.
