### PR TITLE
inspect: capture events for each namespace

### DIFF
--- a/pkg/cli/admin/inspect/events.go
+++ b/pkg/cli/admin/inspect/events.go
@@ -1,0 +1,28 @@
+package inspect
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// gatherNamespaceEvents will gather all events for given namespace
+func (o *InspectOptions) gatherNamespaceEvents(targetFileName, namespace string) error {
+	events, err := o.kubeClient.CoreV1().Events(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	var formattedEvents []string
+	sortedEvents := events.Items
+	// sort by LastTimestamp
+	sort.Slice(sortedEvents, func(i, j int) bool {
+		return sortedEvents[i].LastTimestamp.Time.Before(sortedEvents[j].LastTimestamp.Time)
+	})
+	// use simplified format for events to save space and make events more readable
+	for _, event := range sortedEvents {
+		formattedEvents = append(formattedEvents, fmt.Sprintf("%s [%s] %s", event.LastTimestamp, event.Type[0:1], event.Message))
+	}
+	return o.fileWriter.WriteFromSource(targetFileName, &TextWriterSource{Text: strings.Join(formattedEvents, "\n")})
+}

--- a/pkg/cli/admin/inspect/namespace.go
+++ b/pkg/cli/admin/inspect/namespace.go
@@ -65,6 +65,12 @@ func (o *InspectOptions) gatherNamespaceData(baseDir, namespace string) error {
 		resourcesToStore[gvr] = list
 	}
 
+	// collect all events reported for this namespace
+	log.Printf("    Collecting events for namespace %q...\n", namespace)
+	if err := o.gatherNamespaceEvents(path.Join(destDir, "/events"), namespace); err != nil {
+		return err
+	}
+
 	log.Printf("    Gathering pod data for namespace %q...\n", namespace)
 	// gather specific pod data
 	for _, pod := range resourcesToStore[corev1.SchemeGroupVersion.WithResource("pods")].(*unstructured.UnstructuredList).Items {


### PR DESCRIPTION
This enhance the `oc adm inspect` by adding events collection per namespace. The events are sorted by timestamp and formatted as one-line log and stored in `./events` file next to the namespace YAML file.

/cc @deads2k 