### PR TITLE
fix(inspect): changes --base-dir flag to --dest-dir

### DIFF
--- a/pkg/cli/admin/inspect/inspect.go
+++ b/pkg/cli/admin/inspect/inspect.go
@@ -163,7 +163,7 @@ func (o *InspectOptions) Complete(cmd *cobra.Command, args []string) error {
 
 func (o *InspectOptions) Validate() error {
 	if len(o.destDir) == 0 {
-		return fmt.Errorf("--base-dir must not be empty")
+		return fmt.Errorf("--dest-dir must not be empty")
 	}
 	return nil
 }


### PR DESCRIPTION
This commit fix wrong error flag shown during oc adm inspect command.

Signed-off-by: Ashish Ranjan <aranjan@redhat.com>