### PR TITLE
cmd/oc: disable docker's use of pigz earlier

### DIFF
--- a/cmd/oc/oc.go
+++ b/cmd/oc/oc.go
@@ -62,6 +62,10 @@ func main() {
 		runtime.GOMAXPROCS(runtime.NumCPU())
 	}
 
+	// Prevents race condition present in vendored version of Docker.
+	// See: https://github.com/moby/moby/issues/39859
+	os.Setenv("MOBY_DISABLE_PIGZ", "true")
+
 	pflag.CommandLine.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
 	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 	injectLoglevelFlag(pflag.CommandLine)

--- a/pkg/cli/image/extract/extract.go
+++ b/pkg/cli/image/extract/extract.go
@@ -483,10 +483,6 @@ func (o *Options) Run() error {
 }
 
 func layerByEntry(r io.Reader, options *archive.TarOptions, layerInfo LayerInfo, fn TarEntryFunc, allLayers bool, alreadySeen map[string]struct{}) (bool, error) {
-	// Prevents race condition present in vendored version of docker
-	// https://github.com/moby/moby/issues/39859
-	os.Setenv("MOBY_DISABLE_PIGZ", "true")
-
 	rc, err := dockerarchive.DecompressStream(r)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
Due to a race condition in Docker[1], we need to disable extraction
using unpigz. Currently this is done in the image extraction code,
however this code is multi-threaded.  Setenv is not thread safe in C[2],
so even thought it is safe in go[3], there's a small risk if there's
any C threads running.

It's safer to just set this env variable once when `oc` starts, rather
every time the layerByEntry function is called.

[1] https://github.com/moby/moby/issues/39859
[2] https://github.com/rust-lang/rust/pull/24741
[3] https://github.com/golang/go/blob/a38a917aee626a9b9d5ce2b93964f586bf759ea0/src/syscall/env_unix.go#L18