### PR TITLE
Bug 1763728: fix 'oc adm release extract' version injection

### DIFF
--- a/pkg/cli/admin/release/extract_tools_test.go
+++ b/pkg/cli/admin/release/extract_tools_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func Test_copyAndReplaceReleaseImage(t *testing.T) {
-	baseLen := len(binaryReplacement)
+	baseLen := len(installerReplacement)
 	tests := []struct {
 		name         string
 		r            *bytes.Buffer
@@ -89,7 +89,97 @@ func fakeInput(lengths ...int) *bytes.Buffer {
 	buf := &bytes.Buffer{}
 	for _, l := range lengths {
 		if l == 0 {
-			buf.WriteString(binaryReplacement)
+			buf.WriteString(installerReplacement)
+		} else {
+			b := byte(rand.Intn(256))
+			buf.Write(bytes.Repeat([]byte{b}, l))
+		}
+	}
+	return buf
+}
+
+func Test_copyAndReplaceReleaseVersion(t *testing.T) {
+	baseLen := len(releaseVersionReplacement)
+	tests := []struct {
+		name         string
+		r            *bytes.Buffer
+		buffer       int
+		releaseImage string
+		wantIndex    int
+		wantErr      bool
+	}{
+		{buffer: 10, wantErr: true, wantIndex: -1},
+		{buffer: baseLen, wantErr: false, wantIndex: -1},
+
+		{releaseImage: "test:latest", r: fakeInputVersion(1024, 0), wantIndex: 1024, name: "end of file"},
+		{releaseImage: "test:latest", r: fakeInputVersion(2*1024, 0), wantIndex: 2 * 1024},
+
+		{releaseImage: "test:latest", r: fakeInputVersion(1024-1, 0, 1), wantIndex: 1024 - 1},
+		{releaseImage: "test:latest", r: fakeInputVersion(0, 1), wantIndex: 0},
+
+		{releaseImage: "test:latest", r: fakeInputVersion(baseLen, 0), wantIndex: baseLen},
+		{releaseImage: "test:latest", r: fakeInputVersion(baseLen*2, 0), wantIndex: baseLen * 2},
+		{releaseImage: "test:latest", r: fakeInputVersion(baseLen-1, 0), wantIndex: baseLen - 1},
+		{releaseImage: "test:latest", r: fakeInputVersion(baseLen*2-1, 0), wantIndex: baseLen*2 - 1},
+		{releaseImage: "test:latest", r: fakeInputVersion(baseLen+1, 0), wantIndex: baseLen + 1},
+		{releaseImage: "test:latest", r: fakeInputVersion(baseLen*2+1, 0), wantIndex: baseLen*2 + 1},
+
+		{releaseImage: strings.Repeat("a", baseLen), wantIndex: -1, wantErr: true},
+		{releaseImage: strings.Repeat("a", baseLen+1), wantIndex: -1, wantErr: true},
+
+		{releaseImage: strings.Repeat("a", baseLen-1), r: fakeInputVersion(baseLen, 0), wantIndex: baseLen},
+		{releaseImage: strings.Repeat("a", baseLen-2), r: fakeInputVersion(baseLen, 0), wantIndex: baseLen},
+		{releaseImage: strings.Repeat("a", baseLen-1), r: fakeInputVersion(1, baseLen, 0), wantIndex: 1 + baseLen},
+		{releaseImage: strings.Repeat("a", baseLen-2), r: fakeInputVersion(1, 0, baseLen), wantIndex: 1},
+
+		{releaseImage: strings.Repeat("a", baseLen-1), r: fakeInputVersion(baseLen*2, 0), wantIndex: baseLen * 2},
+		{releaseImage: strings.Repeat("a", baseLen-2), r: fakeInputVersion(baseLen*2, 0), wantIndex: baseLen * 2},
+		{releaseImage: strings.Repeat("a", baseLen-1), r: fakeInputVersion(1, baseLen*2, 0), wantIndex: 1 + baseLen*2},
+		{releaseImage: strings.Repeat("a", baseLen-2), r: fakeInputVersion(1, 0, baseLen*2), wantIndex: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := &bytes.Buffer{}
+			if tt.buffer == 0 {
+				tt.buffer = 1024
+			}
+			if tt.r == nil {
+				tt.r = &bytes.Buffer{}
+			}
+
+			src := tt.r.Bytes()
+			original := make([]byte, len(src))
+			copy(original, src)
+
+			got, err := copyAndReplaceReleaseVersion(w, tt.r, tt.buffer, tt.releaseImage)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("copyAndReplaceReleaseVersion() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != (tt.wantIndex != -1) {
+				t.Fatalf("copyAndReplaceReleaseVersion) = %v, want %v", got, tt.wantIndex != -1)
+			}
+			if got {
+				if len(w.Bytes()) != len(original) {
+					t.Fatalf("mismatched lengths: %d vs %d \n%s\n%s", len(original), w.Len(), hex.Dump(original), hex.Dump(w.Bytes()))
+				}
+				index := bytes.Index(w.Bytes(), []byte(tt.releaseImage+"\x00"))
+				if index != tt.wantIndex {
+					t.Errorf("expected index %d, got index %d\n%s", tt.wantIndex, index, hex.Dump(w.Bytes()))
+				}
+			} else {
+				if !bytes.Equal(w.Bytes(), original) {
+					t.Fatalf("unexpected response body:\n%s\n%s", hex.Dump(original), hex.Dump(w.Bytes()))
+				}
+			}
+		})
+	}
+}
+
+func fakeInputVersion(lengths ...int) *bytes.Buffer {
+	buf := &bytes.Buffer{}
+	for _, l := range lengths {
+		if l == 0 {
+			buf.WriteString(releaseVersionReplacement)
 		} else {
 			b := byte(rand.Intn(256))
 			buf.Write(bytes.Repeat([]byte{b}, l))

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -63,40 +63,41 @@ func Get() version.Info {
 // 1. Extract a release binary that contains a cli image
 // 2. Identify the release name, add a NUL terminator byte (0x00) to the end, calculate length
 // 3. Length must be less than 300 bytes
-// 4. Search through the cli binary looking for `\x00_RELEASE_IMAGE_LOCATION_\x00<PADDING_TO_LENGTH>`
+// 4. Search through the cli binary for `\x00_RELEASE_VERSION_LOCATION_\x00<PADDING_TO_LENGTH>`
 //    where padding is the ASCII character X and length is the total length of the image
 // 5. Overwrite that chunk of the bytes if found, otherwise return error.
 
 var (
-	// defaultReleaseInfoPadded may be replaced in the binary with a pull spec that overrides defaultReleaseInfo as
+	// defaultReleaseInfoPadded may be replaced in the binary with Release Metadata: Version that overrides defaultVersion as
 	// a null-terminated string within the allowed character length. This allows a distributor to override the payload
 	// location without having to rebuild the source.
-	defaultReleaseInfoPadded = "\x00_RELEASE_IMAGE_LOCATION_\x00XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\x00"
-	defaultReleaseInfoPrefix = "\x00_RELEASE_IMAGE_LOCATION_\x00"
-	defaultReleaseInfoLength = len(defaultReleaseInfoPadded)
+	defaultVersionPadded = "\x00_RELEASE_VERSION_LOCATION_\x00XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\x00"
+	defaultVersionPrefix = "\x00_RELEASE_VERSION_LOCATION_\x00"
+	defaultVersionLength = len(defaultVersionPadded)
 )
 
 // ExtractVersion() abstracts how the binary loads the default release payload. We want to lock the binary
-// to the pull spec of the payload we test it with, and since a payload contains the cli image we can't
-// know that at build time. Instead, we make it possible to replace the release string after build via a
+// to version of the payload we test it with, and since a payload contains the cli image we can't
+// know that at build time. Instead, we make it possible to replace the version string after build via a
 // known constant in the binary.  When extracting oc from release image, 'oc version' reports the payload version.
 func ExtractVersion() (version.Info, string, error) {
-	if strings.HasPrefix(defaultReleaseInfoPadded, defaultReleaseInfoPrefix) {
+	if strings.HasPrefix(defaultVersionPadded, defaultVersionPrefix) {
 		return Get(), "", nil
 	}
-	nullTerminator := strings.IndexByte(defaultReleaseInfoPadded, '\x00')
+	nullTerminator := strings.IndexByte(defaultVersionPadded, '\x00')
 	if nullTerminator == -1 {
 		// the binary has been altered, but we didn't find a null terminator within the release name constant which is an error
-		return version.Info{}, "", fmt.Errorf("release name location was replaced but without a null terminator before %d bytes", defaultReleaseInfoLength)
+		return version.Info{}, "", fmt.Errorf("release name location was replaced but without a null terminator before %d bytes", defaultVersionLength)
 	}
-	if nullTerminator > len(defaultReleaseInfoPadded) {
+	if nullTerminator > len(defaultVersionPadded) {
 		// the binary has been altered, but the null terminator is *longer* than the constant encoded in the binary
 		return version.Info{}, "", fmt.Errorf("release name location contains no null-terminator and constant is corrupted")
 	}
-	releaseName := defaultReleaseInfoPadded[:nullTerminator]
+	releaseName := defaultVersionPadded[:nullTerminator]
 	if len(releaseName) == 0 {
 		// the binary has been altered, but the replaced release name is empty which is incorrect
-		return version.Info{}, "", fmt.Errorf("release name location is empty, this binary was incorrectly generated")
+		// the oc binary will not be pinned to Release Metadata:Version
+		return version.Info{}, "", fmt.Errorf("oc version was incorrectly replaced during extract")
 	}
 	return Get(), releaseName, nil
 }


### PR DESCRIPTION
Since[ this](https://github.com/openshift/oc/pull/88) merged, when using an extracted oc to extract openshift-install|oc, command fails, because the shared binary replacement location.  This PR is the fix. 

/cc @soltysh 