### PR TITLE
Turn on schema validation

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -307,14 +307,6 @@ func changeSharedFlagDefaults(rootCmd *cobra.Command) {
 			showAllFlag.Changed = false
 			showAllFlag.Usage = "When printing, show all resources (false means hide terminated pods.)"
 		}
-
-		// we want to disable the --validate flag by default when we're running kube commands from oc.  We want to make sure
-		// that we're only getting the upstream --validate flags, so check both the flag and the usage
-		if validateFlag := currCmd.Flags().Lookup("validate"); (validateFlag != nil) && (validateFlag.Usage == "If true, use a schema to validate the input before sending it") {
-			validateFlag.DefValue = "false"
-			validateFlag.Value.Set("false")
-			validateFlag.Changed = false
-		}
 	}
 }
 

--- a/pkg/cli/kubectl_compat_test.go
+++ b/pkg/cli/kubectl_compat_test.go
@@ -63,7 +63,7 @@ kubectlLoop:
 // this only checks one level deep for nested commands, but it does ensure that we've gotten several
 // --validate flags.  Based on that we can reasonably assume we got them in the kube commands since they
 // all share the same registration.
-func TestValidateDisabled(t *testing.T) {
+func TestValidateEnabledByDefaultButUnchanged(t *testing.T) {
 	oc := NewOcCommand("oc", "oc", &bytes.Buffer{}, ioutil.Discard, ioutil.Discard)
 	kubectl := kcmd.NewKubectlCommand(nil, ioutil.Discard, ioutil.Discard)
 
@@ -75,11 +75,13 @@ func TestValidateDisabled(t *testing.T) {
 					continue
 				}
 
-				if ocValidateFlag.Value.String() != "false" {
-					t.Errorf("%s --validate is not defaulting to false", occmd.Name())
+				if ocValidateFlag.Value.String() != "true" {
+					t.Errorf("%s --validate is not defaulting to true", occmd.Name())
+				}
+				if ocValidateFlag.Changed {
+					t.Errorf("%s --validate is not changed, but shouldn't", occmd.Name())
 				}
 			}
 		}
 	}
-
 }

--- a/vendor/k8s.io/kubectl/pkg/cmd/apply/apply.go
+++ b/vendor/k8s.io/kubectl/pkg/cmd/apply/apply.go
@@ -82,6 +82,7 @@ type ApplyOptions struct {
 	PruneWhitelist  []string
 
 	Validator       validation.Schema
+	FatalSchema     bool
 	Builder         *resource.Builder
 	Mapper          meta.RESTMapper
 	DynamicClient   dynamic.Interface
@@ -251,6 +252,7 @@ func (o *ApplyOptions) Complete(f cmdutil.Factory, cmd *cobra.Command) error {
 
 	o.OpenAPISchema, _ = f.OpenAPISchema()
 	o.Validator, err = f.Validator(cmdutil.GetFlagBool(cmd, "validate"))
+	o.FatalSchema = cmdutil.IsSchemaFatal(cmd)
 	o.Builder = f.NewBuilder()
 	o.Mapper, err = f.ToRESTMapper()
 	if err != nil {
@@ -344,7 +346,7 @@ func (o *ApplyOptions) Run() error {
 	// unless explicitly set --include-uninitialized=false
 	r := o.Builder.
 		Unstructured().
-		Schema(o.Validator).
+		Schema(o.Validator, o.FatalSchema).
 		ContinueOnError().
 		NamespaceParam(o.Namespace).DefaultNamespace().
 		FilenameParam(o.EnforceNamespace, &o.DeleteOptions.FilenameOptions).

--- a/vendor/k8s.io/kubectl/pkg/cmd/create/create.go
+++ b/vendor/k8s.io/kubectl/pkg/cmd/create/create.go
@@ -235,7 +235,7 @@ func (o *CreateOptions) RunCreate(f cmdutil.Factory, cmd *cobra.Command) error {
 
 	r := f.NewBuilder().
 		Unstructured().
-		Schema(schema).
+		Schema(schema, cmdutil.IsSchemaFatal(cmd)).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &o.FilenameOptions).

--- a/vendor/k8s.io/kubectl/pkg/cmd/replace/replace.go
+++ b/vendor/k8s.io/kubectl/pkg/cmd/replace/replace.go
@@ -80,6 +80,7 @@ type ReplaceOptions struct {
 	validate         bool
 
 	Schema      validation.Schema
+	FatalSchema bool
 	Builder     func() *resource.Builder
 	BuilderArgs []string
 
@@ -179,6 +180,7 @@ func (o *ReplaceOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []
 	}
 
 	o.Schema = schema
+	o.FatalSchema = cmdutil.IsSchemaFatal(cmd)
 	o.Builder = f.NewBuilder
 	o.BuilderArgs = args
 
@@ -241,7 +243,7 @@ func (o *ReplaceOptions) Run(f cmdutil.Factory) error {
 
 	r := o.Builder().
 		Unstructured().
-		Schema(o.Schema).
+		Schema(o.Schema, o.FatalSchema).
 		ContinueOnError().
 		NamespaceParam(o.Namespace).DefaultNamespace().
 		FilenameParam(o.EnforceNamespace, &o.DeleteOptions.FilenameOptions).
@@ -330,7 +332,7 @@ func (o *ReplaceOptions) forceReplace() error {
 
 	r = o.Builder().
 		Unstructured().
-		Schema(o.Schema).
+		Schema(o.Schema, o.FatalSchema).
 		ContinueOnError().
 		NamespaceParam(o.Namespace).DefaultNamespace().
 		FilenameParam(o.EnforceNamespace, &o.DeleteOptions.FilenameOptions).

--- a/vendor/k8s.io/kubectl/pkg/cmd/rollingupdate/rollingupdate.go
+++ b/vendor/k8s.io/kubectl/pkg/cmd/rollingupdate/rollingupdate.go
@@ -100,6 +100,7 @@ type RollingUpdateOptions struct {
 	Builder     *resource.Builder
 
 	ShouldValidate bool
+	FatalSchema    bool
 	Validator      func(bool) (validation.Schema, error)
 
 	FindNewName func(*corev1.ReplicationController) string
@@ -199,6 +200,7 @@ func (o *RollingUpdateOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, a
 	o.OutputFormat = cmdutil.GetFlagString(cmd, "output")
 	o.KeepOldName = len(args) == 1
 	o.ShouldValidate = cmdutil.GetFlagBool(cmd, "validate")
+	o.FatalSchema = cmdutil.IsSchemaFatal(cmd)
 
 	o.Validator = f.Validator
 	o.FindNewName = func(obj *corev1.ReplicationController) string {
@@ -271,7 +273,7 @@ func (o *RollingUpdateOptions) Run() error {
 
 		request := o.Builder.
 			Unstructured().
-			Schema(schema).
+			Schema(schema, o.FatalSchema).
 			NamespaceParam(o.Namespace).DefaultNamespace().
 			FilenameParam(o.EnforceNamespace, &resource.FilenameOptions{Recursive: false, Filenames: []string{filename}}).
 			Flatten().

--- a/vendor/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/vendor/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -332,6 +332,20 @@ func GetFlagBool(cmd *cobra.Command, flag string) bool {
 	return b
 }
 
+func IsInteractive(cmd *cobra.Command) bool {
+	out := cmd.OutOrStdout()
+	if out != os.Stdout {
+		return false
+	}
+	outStat, _ := os.Stdout.Stat()
+	ret := (outStat.Mode() & os.ModeCharDevice) != 0
+	return ret
+}
+
+func IsSchemaFatal(cmd *cobra.Command) bool {
+	return cmd.Flag("validate").Changed || IsInteractive(cmd)
+}
+
 // Assumes the flag has a default value.
 func GetFlagInt(cmd *cobra.Command, flag string) int {
 	i, err := cmd.Flags().GetInt(flag)
@@ -376,11 +390,11 @@ func GetPodRunningTimeoutFlag(cmd *cobra.Command) (time.Duration, error) {
 }
 
 func AddValidateFlags(cmd *cobra.Command) {
-	cmd.Flags().Bool("validate", true, "If true, use a schema to validate the input before sending it")
+	cmd.Flags().Bool("validate", true, "If true, use a schema to validate the input before sending it. On a terminal and when explicitly given as flag errors are fatal, otherwise only warnings.")
 }
 
 func AddValidateOptionFlags(cmd *cobra.Command, options *ValidateOptions) {
-	cmd.Flags().BoolVar(&options.EnableValidation, "validate", options.EnableValidation, "If true, use a schema to validate the input before sending it")
+	cmd.Flags().BoolVar(&options.EnableValidation, "validate", options.EnableValidation, "If true, use a schema to validate the input before sending it. On a terminal and when explicitly given as flag errors are fatal, otherwise only warnings.")
 }
 
 func AddFilenameOptionFlags(cmd *cobra.Command, options *resource.FilenameOptions, usage string) {

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/convert/convert.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/convert/convert.go
@@ -71,6 +71,7 @@ type ConvertOptions struct {
 	builder   func() *resource.Builder
 	local     bool
 	validator func() (validation.Schema, error)
+	fatalSchema bool
 
 	resource.FilenameOptions
 	genericclioptions.IOStreams
@@ -126,6 +127,7 @@ func (o *ConvertOptions) Complete(f cmdutil.Factory, cmd *cobra.Command) (err er
 	o.validator = func() (validation.Schema, error) {
 		return f.Validator(cmdutil.GetFlagBool(cmd, "validate"))
 	}
+	o.fatalSchema = cmdutil.IsSchemaFatal(cmd)
 
 	// build the printer
 	o.Printer, err = o.PrintFlags.ToPrinter()
@@ -153,7 +155,7 @@ func (o *ConvertOptions) RunConvert() error {
 		if err != nil {
 			return err
 		}
-		b.Schema(schema)
+		b.Schema(schema, o.fatalSchema)
 	}
 
 	r := b.NamespaceParam(o.Namespace).


### PR DESCRIPTION
Fatal when interactive or explicitly passed via `--validate`, warning if not.