### PR TITLE
Bug 1759920: Fixed Dockerfile FROM statement parser.

### DIFF
--- a/pkg/helpers/newapp/docker/dockerfile/dockerfile.go
+++ b/pkg/helpers/newapp/docker/dockerfile/dockerfile.go
@@ -69,7 +69,10 @@ func LastBaseImage(node *parser.Node) string {
 func baseImages(node *parser.Node) []string {
 	var images []string
 	for _, pos := range FindAll(node, command.From) {
-		images = append(images, nextValues(node.Children[pos])...)
+		if node.Children[pos].Next == nil {
+			continue
+		}
+		images = append(images, node.Children[pos].Next.Value)
 	}
 	return images
 }

--- a/pkg/helpers/newapp/docker/dockerfile/dockerfile_test.go
+++ b/pkg/helpers/newapp/docker/dockerfile/dockerfile_test.go
@@ -245,6 +245,16 @@ COPY . /boot
 FROM centos:7`,
 			want: []string{"scratch", "centos:7"},
 		},
+		"single FROM with alias": {
+			in:   `FROM golang AS builder`,
+			want: []string{"golang"},
+		},
+		"multiple FROM with aliases": {
+			in: `FROM scratch AS builder
+COPY . /boot
+FROM centos:7 as runner`,
+			want: []string{"scratch", "centos:7"},
+		},
 	}
 	for name, tc := range testCases {
 		node, err := parser.Parse(strings.NewReader(tc.in))


### PR DESCRIPTION
In some cases the FROM statement on a Dockerfile may contain an extra
alias, e.g.:

FROM fedora:latest AS builder

This commit fixes the parser to use only the second parsed node on the
FROM statement(on this case "fedora:latest") instead of returning the
last one(on this case "builder").