### PR TITLE
Bug 1767163: fix app.kubernetes.io/name to use just IS name

### DIFF
--- a/pkg/cli/newapp/newapp.go
+++ b/pkg/cli/newapp/newapp.go
@@ -375,8 +375,8 @@ func (o *AppOptions) RunNewApp() error {
 			"app.kubernetes.io/component": result.Name,
 		}
 
-		for _, name := range o.Config.ImageStreams {
-			if name != "" {
+		for _, is := range o.Config.ImageStreams {
+			if name, _, _ := imageutil.SplitImageStreamTag(is); len(name) > 0 {
 				appLabel["app.kubernetes.io/name"] = name
 			}
 		}


### PR DESCRIPTION
Fixing problem introduced in https://github.com/openshift/oc/pull/101

/assign @adambkaplan @DhritiShikhar