### PR TITLE
Improve release to work better for disconnected

### DIFF
--- a/pkg/cli/admin/release/extract.go
+++ b/pkg/cli/admin/release/extract.go
@@ -55,6 +55,10 @@ func NewExtract(f kcmdutil.Factory, parentName string, streams genericclioptions
 			any destructive actions on your behalf except for executing a 'git checkout' which
 			may change the current branch. Requires 'git' to be on your path.
 		`),
+		Example: templates.Examples(`
+			# Use git to check out the source code for the current cluster release to DIR
+			%[1]s --git=DIR
+			`),
 		Run: func(cmd *cobra.Command, args []string) {
 			kcmdutil.CheckErr(o.Complete(f, cmd, args))
 			kcmdutil.CheckErr(o.Run())

--- a/pkg/cli/admin/release/info.go
+++ b/pkg/cli/admin/release/info.go
@@ -91,6 +91,20 @@ func NewInfo(f kcmdutil.Factory, parentName string, streams genericclioptions.IO
 			the code changes that occurred between the two release arguments. This operation is slow
 			and requires sufficient disk space on the selected drive to clone all repositories.
 		`),
+		Example: templates.Examples(`
+			# Show information about the cluster's current release
+			%[1]s
+
+			# Show the source code that comprises a release
+			%[1]s 4.2.2 --commit-urls
+
+			# Show the source code difference between two releases
+			%[1]s 4.2.0 4.2.2 --commits
+
+			# Show where the images referenced by the release are located
+			%[1]s quay.io/openshift-release-dev/ocp-release:4.2.2 --pullspecs
+
+			`),
 		Run: func(cmd *cobra.Command, args []string) {
 			kcmdutil.CheckErr(o.Complete(f, cmd, args))
 			kcmdutil.CheckErr(o.Validate())

--- a/pkg/cli/admin/release/info.go
+++ b/pkg/cli/admin/release/info.go
@@ -24,6 +24,8 @@ import (
 	units "github.com/docker/go-units"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/spf13/cobra"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/transport"
 	"k8s.io/klog"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -34,6 +36,7 @@ import (
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/templates"
 
+	configv1 "github.com/openshift/api/config/v1"
 	imageapi "github.com/openshift/api/image/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/library-go/pkg/image/dockerv1client"
@@ -66,14 +69,17 @@ func NewInfo(f kcmdutil.Factory, parentName string, streams genericclioptions.IO
 			validate that updates have not been tampered with.
 
 			If no arguments are specified the release of the currently connected cluster is displayed.
-			Specify one or more images via pull spec to see details of each release image. The --commits
-			flag will display the Git commit IDs and repository URLs for the source of each component
-			image. The --pullspecs flag will display the full component image pull spec. --size will show
-			a breakdown of each image, their layers, and the total size of the payload. --contents shows
-			the configuration that will be applied to the cluster when the update is run. If you have
-			specified two images the difference between the first and second image will be shown. You
-			may use -o name, -o digest, or -o pullspec to output the tag name, digest for image, or
-			pullspec of the images referenced in the release image.
+			Specify one or more images via pull spec to see details of each release image. You may also
+			pass a semantic version (4.2.2) as an argument, and if cluster version object has seen such a
+			version in the upgrades channel it will find the release info for that version.
+
+			The --commits flag will display the Git commit IDs and repository URLs for the source of each
+			component image. The --pullspecs flag will display the full component image pull spec. --size
+			will show a breakdown of each image, their layers, and the total size of the payload.
+			--contents shows the configuration that will be applied to the cluster when the update is run.
+			If you have specified two images the difference between the first and second image will be
+			shown. You may use -o name, -o digest, or -o pullspec to output the tag name, digest for
+			image, or pullspec of the images referenced in the release image.
 
 			The --verify flag will display one summary line per input release image and verify the
 			integrity of each. The command will return an error if the release has been tampered with.
@@ -137,31 +143,199 @@ type InfoOptions struct {
 	SecurityOptions imagemanifest.SecurityOptions
 }
 
-func (o *InfoOptions) Complete(f kcmdutil.Factory, cmd *cobra.Command, args []string) error {
-	if len(args) == 0 {
-		cfg, err := f.ToRESTConfig()
+func findSemanticVersionArgs(args []string) map[string]semver.Version {
+	semvers := make(map[string]semver.Version)
+	for _, arg := range args {
+		v, err := semver.Parse(arg)
 		if err != nil {
-			return fmt.Errorf("info expects one argument, or a connection to an OpenShift 4.x server: %v", err)
+			continue
 		}
-		client, err := configv1client.NewForConfig(cfg)
-		if err != nil {
-			return fmt.Errorf("info expects one argument, or a connection to an OpenShift 4.x server: %v", err)
+		semvers[arg] = v
+	}
+	return semvers
+}
+
+func findImageInClusterVersion(cv *configv1.ClusterVersion, arg string) (string, bool) {
+	if cv.Status.Desired.Version == arg && len(cv.Status.Desired.Image) > 0 {
+		return cv.Status.Desired.Image, true
+	}
+	for _, available := range cv.Status.AvailableUpdates {
+		if available.Version == arg && len(available.Image) > 0 {
+			return available.Image, true
 		}
-		cv, err := client.ConfigV1().ClusterVersions().Get("version", metav1.GetOptions{})
-		if err != nil {
-			if errors.IsNotFound(err) {
-				return fmt.Errorf("you must be connected to an OpenShift 4.x server to fetch the current version")
+	}
+	for _, history := range cv.Status.History {
+		if history.Version == arg && len(history.Image) > 0 {
+			return history.Image, true
+		}
+	}
+	return "", false
+}
+
+type versionNode struct {
+	Version string `json:"version"`
+	Payload string `json:"payload"`
+}
+
+type versionGraph struct {
+	Nodes []versionNode `json:"nodes"`
+}
+
+const defaultGraphURL = "https://api.openshift.com/api/upgrades_info/v1/graph"
+
+// replaceStableSemanticArgs attempts to look up known major versions in existing public stable
+// channels.
+// TODO: perfom graph lookups from the cluster's graph endpoint and channel in preference
+func replaceStableSemanticArgs(args []string, semanticArgs map[string]semver.Version, graphURL string) error {
+	if len(graphURL) == 0 {
+		graphURL = defaultGraphURL
+	}
+	u, err := url.Parse(graphURL)
+	if err != nil {
+		return err
+	}
+
+	transport, err := transport.HTTPWrappersForConfig(
+		&transport.Config{
+			UserAgent: rest.DefaultKubernetesUserAgent() + "(release-info)",
+		},
+		http.DefaultTransport,
+	)
+	if err != nil {
+		return err
+	}
+	client := &http.Client{Transport: transport}
+
+	for i, arg := range args {
+		v, ok := semanticArgs[arg]
+		if !ok {
+			continue
+		}
+		if v.Major != 4 {
+			continue
+		}
+
+		var found bool
+		for _, stream := range []string{"fast", "stable", "candidate"} {
+			u.RawQuery = url.Values{"channel": []string{fmt.Sprintf("%s-%d.%d", stream, v.Major, v.Minor)}}.Encode()
+			if err := func() error {
+				req, err := http.NewRequest("GET", u.String(), nil)
+				if err != nil {
+					return err
+				}
+				req.Header.Set("Accept", "application/json")
+				resp, err := client.Do(req)
+				if err != nil {
+					return err
+				}
+				defer resp.Body.Close()
+				switch resp.StatusCode {
+				case http.StatusOK:
+				default:
+					io.Copy(ioutil.Discard, resp.Body)
+					return fmt.Errorf("unable to retrieve status for %q: %d", arg, resp.StatusCode)
+				}
+				data, err := ioutil.ReadAll(resp.Body)
+				if err != nil {
+					return err
+				}
+				var versions versionGraph
+				if err := json.Unmarshal(data, &versions); err != nil {
+					return err
+				}
+				for _, version := range versions.Nodes {
+					if version.Version == arg && len(version.Payload) > 0 {
+						delete(semanticArgs, arg)
+						args[i] = version.Payload
+						found = true
+						break
+					}
+				}
+				return nil
+			}(); err != nil {
+				return err
 			}
-			return fmt.Errorf("info expects one argument, or a connection to an OpenShift 4.x server: %v", err)
+			if found {
+				break
+			}
 		}
+	}
+	return nil
+}
+
+func replaceClusterSemanticArgs(f kcmdutil.Factory, args []string, semanticArgs map[string]semver.Version) ([]string, error) {
+	cfg, err := f.ToRESTConfig()
+	if err != nil {
+		return args, fmt.Errorf("info expects one argument, or a connection to an OpenShift 4.x server: %v", err)
+	}
+	client, err := configv1client.NewForConfig(cfg)
+	if err != nil {
+		return args, fmt.Errorf("info expects one argument, or a connection to an OpenShift 4.x server: %v", err)
+	}
+	cv, err := client.ConfigV1().ClusterVersions().Get("version", metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return args, fmt.Errorf("you must be connected to an OpenShift 4.x server to fetch the current version")
+		}
+		return args, fmt.Errorf("info expects one argument, or a connection to an OpenShift 4.x server: %v", err)
+	}
+
+	if len(args) == 0 {
 		image := cv.Status.Desired.Image
 		if len(image) == 0 && cv.Spec.DesiredUpdate != nil {
 			image = cv.Spec.DesiredUpdate.Image
 		}
 		if len(image) == 0 {
-			return fmt.Errorf("the server is not reporting a release image at this time, please specify an image to view")
+			return nil, fmt.Errorf("the server is not reporting a release image at this time, please specify an image to view")
 		}
-		args = []string{image}
+		return []string{image}, nil
+	}
+
+	for i, arg := range args {
+		if _, ok := semanticArgs[arg]; !ok {
+			continue
+		}
+		image, ok := findImageInClusterVersion(cv, arg)
+		if !ok {
+			continue
+		}
+		delete(semanticArgs, arg)
+		klog.V(2).Infof("Replaced argument %q with %q", arg, image)
+		args[i] = image
+	}
+	return args, nil
+}
+
+func findArgumentsFromCluster(f kcmdutil.Factory, args []string) ([]string, error) {
+	semanticArgs := findSemanticVersionArgs(args)
+	if len(semanticArgs) == 0 && len(args) > 0 {
+		return args, nil
+	}
+	klog.V(4).Infof("Found semantic versions: %v", semanticArgs)
+	// attempt to find semantic args from the cluster
+	args, clusterErr := replaceClusterSemanticArgs(f, args, semanticArgs)
+	if len(semanticArgs) == 0 {
+		return args, clusterErr
+	}
+	// if any semantic args remain, try to fetch them from the api endpoint out of a stable channel
+	err := replaceStableSemanticArgs(args, semanticArgs, defaultGraphURL)
+	if len(semanticArgs) == 0 || err != nil {
+		if clusterErr != nil {
+			klog.V(2).Infof("Ignored error retrieving semantic versions from cluster version: %v", err)
+		}
+		return args, err
+	}
+	// if there are any semantic args left, error
+	for arg := range semanticArgs {
+		return nil, fmt.Errorf("the semantic version %q is not present in the cluster version status or in the official versions list, cannot be resolved", arg)
+	}
+	return args, nil
+}
+
+func (o *InfoOptions) Complete(f kcmdutil.Factory, cmd *cobra.Command, args []string) error {
+	args, err := findArgumentsFromCluster(f, args)
+	if err != nil {
+		return err
 	}
 	if len(args) < 1 {
 		return fmt.Errorf("info expects at least one argument, a release image pull spec")
@@ -924,7 +1098,7 @@ func describeReleaseInfo(out io.Writer, release *ReleaseInfo, showCommit, showCo
 	fmt.Fprintf(w, "OS/Arch:\t%s/%s\n", release.Config.OS, release.Config.Architecture)
 	fmt.Fprintf(w, "Manifests:\t%d\n", len(release.ManifestFiles))
 	if len(release.UnknownFiles) > 0 {
-		fmt.Fprintf(w, "Unknown files:\t%d\n", len(release.UnknownFiles))
+		fmt.Fprintf(w, "Metadata files:\t%d\n", len(release.UnknownFiles))
 	}
 
 	fmt.Fprintln(w)

--- a/pkg/cli/admin/release/mirror.go
+++ b/pkg/cli/admin/release/mirror.go
@@ -76,6 +76,10 @@ func NewMirror(f kcmdutil.Factory, parentName string, streams genericclioptions.
 			will print the 'oc image mirror' command that can be used to upload the release to
 			another registry.
 		`),
+		Example: templates.Examples(`
+			# Perform a dry run showing what would be mirrored, including the mirror objects
+			%[1]s 4.2.2 --to myregistry.local/openshift/release --dry-run
+			`),
 		Run: func(cmd *cobra.Command, args []string) {
 			kcmdutil.CheckErr(o.Complete(cmd, f, args))
 			kcmdutil.CheckErr(o.Run())

--- a/pkg/cli/admin/release/mirror.go
+++ b/pkg/cli/admin/release/mirror.go
@@ -135,6 +135,16 @@ func (o *MirrorOptions) Complete(cmd *cobra.Command, f kcmdutil.Factory, args []
 	case len(args) > 1:
 		return fmt.Errorf("only one argument is accepted")
 	}
+
+	args, err := findArgumentsFromCluster(f, []string{o.From})
+	if err != nil {
+		return err
+	}
+	if len(args) != 1 {
+		return fmt.Errorf("only one release image may be mirrored")
+	}
+	o.From = args[0]
+
 	o.ClientFn = func() (imageclient.Interface, string, error) {
 		cfg, err := f.ToRESTConfig()
 		if err != nil {

--- a/pkg/cli/image/imagesource/dryrun.go
+++ b/pkg/cli/image/imagesource/dryrun.go
@@ -1,0 +1,28 @@
+package imagesource
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/reference"
+	registryclient "github.com/docker/distribution/registry/client"
+)
+
+func NewDryRun(ref TypedImageReference) (distribution.Repository, error) {
+	named, err := reference.WithName(ref.Ref.RepositoryName())
+	if err != nil {
+		return nil, err
+	}
+	return registryclient.NewRepository(named, ref.Ref.RegistryURL().String(), dryRunRoundTripper)
+}
+
+var dryRunRoundTripper = errorRoundTripper{errors.New("dry-run repository is not available")}
+
+type errorRoundTripper struct {
+	err error
+}
+
+func (rt errorRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return nil, rt.err
+}

--- a/pkg/cli/image/imagesource/options.go
+++ b/pkg/cli/image/imagesource/options.go
@@ -56,7 +56,7 @@ func (o *Options) ExpandWildcard(ref TypedImageReference) ([]TypedImageReference
 	if err != nil {
 		return nil, err
 	}
-	klog.V(5).Infof("Search for %q found: %v", ref.Ref.Tag, tags)
+	klog.V(5).Infof("Search for %q (%s) found: %v", ref.Ref.Tag, reSearch.String(), tags)
 	refs := make([]TypedImageReference, 0, len(tags))
 	for _, tag := range tags {
 		if !reSearch.MatchString(tag) {

--- a/pkg/cli/image/imagesource/reference.go
+++ b/pkg/cli/image/imagesource/reference.go
@@ -112,3 +112,23 @@ func ParseReference(ref string) (TypedImageReference, error) {
 	}
 	return TypedImageReference{Ref: dst, Type: dstType}, nil
 }
+
+// buildTagSearchRegexp creates a regexp from the provided tag value
+// that can be used to filter tags. It supports standard '*' glob
+// rules.
+func buildTagSearchRegexp(tag string) (*regexp.Regexp, error) {
+	search := tag
+	if (len(search)) == 0 {
+		search = "*"
+	}
+	var reText string
+	for _, part := range strings.Split(search, "*") {
+		if len(part) == 0 {
+			reText += ".*"
+			continue
+		}
+		reText += regexp.QuoteMeta(part)
+	}
+	reText = fmt.Sprintf("^%s$", reText)
+	return regexp.Compile(reText)
+}

--- a/pkg/cli/image/imagesource/reference.go
+++ b/pkg/cli/image/imagesource/reference.go
@@ -121,14 +121,16 @@ func buildTagSearchRegexp(tag string) (*regexp.Regexp, error) {
 	if (len(search)) == 0 {
 		search = "*"
 	}
-	var reText string
+	var parts []string
 	for _, part := range strings.Split(search, "*") {
 		if len(part) == 0 {
-			reText += ".*"
-			continue
+			if len(parts) == 0 || parts[len(parts)-1] != ".*" {
+				parts = append(parts, ".*")
+			}
+		} else {
+			parts = append(parts, regexp.QuoteMeta(part))
 		}
-		reText += regexp.QuoteMeta(part)
 	}
-	reText = fmt.Sprintf("^%s$", reText)
+	reText := fmt.Sprintf("^%s$", strings.Join(parts, ".*"))
 	return regexp.Compile(reText)
 }

--- a/pkg/cli/image/info/info.go
+++ b/pkg/cli/image/info/info.go
@@ -52,6 +52,20 @@ func NewInfo(parentName string, streams genericclioptions.IOStreams) *cobra.Comm
 			Images in manifest list format will be shown for your current operating system.
 			To see the image for a particular OS use the --filter-by-os=OS/ARCH flag.
 			`),
+		Example: templates.Examples(`
+			# Show information about an image
+			%[1]s quay.io/openshift/cli:latest
+
+			# Show information about images matching a wildcard
+			%[1]s quay.io/openshift/cli:4.*
+
+			# Show information about a file mirrored to disk under DIR
+			%[1]s --dir=DIR file://library/busybox:latest
+
+			# Select which image from a multi-OS image to show
+			%[1]s library/busybox:latest --filter-by-os=linux/arm64
+
+			`),
 		Run: func(cmd *cobra.Command, args []string) {
 			kcmdutil.CheckErr(o.Complete(cmd, args))
 			kcmdutil.CheckErr(o.Validate())

--- a/pkg/cli/image/mirror/mappings.go
+++ b/pkg/cli/image/mirror/mappings.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"regexp"
 	"strings"
 	"sync"
 
@@ -257,24 +256,4 @@ func calculateDockerRegistryScopes(tree targetTree) map[contextKey][]auth.Scope 
 		uniqueScopes[registry] = repoScopes
 	}
 	return uniqueScopes
-}
-
-// buildTagSearchRegexp creates a regexp from the provided tag value
-// that can be used to filter tags. It supports standard '*' glob
-// rules.
-func buildTagSearchRegexp(tag string) (*regexp.Regexp, error) {
-	search := tag
-	if (len(search)) == 0 {
-		search = "*"
-	}
-	var reText string
-	for _, part := range strings.Split(search, "*") {
-		if len(part) == 0 {
-			reText += ".*"
-			continue
-		}
-		reText += regexp.QuoteMeta(part)
-	}
-	reText = fmt.Sprintf("^%s$", reText)
-	return regexp.Compile(reText)
 }

--- a/pkg/cli/image/mirror/mirror.go
+++ b/pkg/cli/image/mirror/mirror.go
@@ -480,7 +480,13 @@ func (o *MirrorImageOptions) plan() (*plan, error) {
 						}
 
 						for _, dst := range pushTargets {
-							toRepo, err := o.Repository(ctx, toContexts[contextKeyForReference(dst.ref)], dst.ref, false)
+							var toRepo distribution.Repository
+							var err error
+							if o.DryRun {
+								toRepo, err = imagesource.NewDryRun(dst.ref)
+							} else {
+								toRepo, err = o.Repository(ctx, toContexts[contextKeyForReference(dst.ref)], dst.ref, false)
+							}
 							if err != nil {
 								plan.AddError(retrieverError{src: src.ref, dst: dst.ref, err: fmt.Errorf("unable to connect to %s: %v", dst.ref, err)})
 								continue

--- a/pkg/cli/registry/login/login.go
+++ b/pkg/cli/registry/login/login.go
@@ -39,7 +39,7 @@ var (
 		external registry name (if configured by your administrator). You may also log in
 		using a service account if you have access to its credentials. If you are logged in
 		to the server using a client certificate the command will report an error because
-		Docker commands do not generally allow client certificates.
+		container registries do not generally allow client certificates.
 
 		As an advanced option you may specify the credentials to login with using --auth-basic
 		with USER:PASSWORD. This may not be used with the -z flag.
@@ -62,6 +62,10 @@ var (
 
 # Log in as the default service account in the current namespace
 %[1]s -z default
+
+# Log in to a different registry using BASIC auth credentials
+%[1]s --registry quay.io --auth-basic=USER:PASS
+
 `)
 )
 


### PR DESCRIPTION
Three improvements to simplify life for disconnected users

---

release: Release mirror dry run should work without remote

It should be possible to do

    $ oc adm release mirror --dry-run A --to B

where B is not reachable from the current location. This allows you to get
the correct image content source policy, before mirroring to disk.

---

release: Allow `oc adm release info` to retrieve semantic versions

When connected to a cluster, requesting a semantic version in the argument
to oc adm release info will lookup matching semantic versions in the
ClusterVersion object and return release info if found. Simplifies "show
metadata for next release".

---

image: Allow `oc image info` to lookup images by wildcard

    $ oc image info library/mysql:9*

now finds matching tags based on the wildcard syntax.