### PR TITLE
Bug 1713263: pkg/cli/admin/upgrade: allow users to force when updating to latest

### DIFF
--- a/pkg/cli/admin/upgrade/upgrade.go
+++ b/pkg/cli/admin/upgrade/upgrade.go
@@ -180,9 +180,13 @@ func (o *Options) Run() error {
 		}
 
 		sortSemanticVersions(cv.Status.AvailableUpdates)
-		update := cv.Status.AvailableUpdates[len(cv.Status.AvailableUpdates)-1]
-		cv.Spec.DesiredUpdate = &update
 
+		update := cv.Status.AvailableUpdates[len(cv.Status.AvailableUpdates)-1]
+		if o.Force {
+			update.Force = true
+		}
+
+		cv.Spec.DesiredUpdate = &update
 		_, err := o.Client.ConfigV1().ClusterVersions().Update(cv)
 		if err != nil {
 			return fmt.Errorf("Unable to upgrade to latest version %s: %v", update.Version, err)


### PR DESCRIPTION
--force is used when
a) the release image is not verified.
b) the operators are blocking upgrades.

For cases when the users are using custom update channel, the release-image is probably not going to be verified by Red Hat signature, but the users should be allowed to update to the latest
available update by skipping the verification step.

And for cases where the users want to upgrade to the latest upgrade, even when the operators are blocking updates should be achievable by setting the force flag.

/assign @smarterclayton 