### PR TITLE
Enable all Linux arches in cli-artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ GO_BUILD_PACKAGES :=$(strip \
 GO_BUILD_FLAGS :=-tags 'include_gcs include_oss containers_image_openpgp gssapi'
 GO_BUILD_FLAGS_DARWIN :=-tags 'include_gcs include_oss containers_image_openpgp'
 GO_BUILD_FLAGS_WINDOWS :=-tags 'include_gcs include_oss containers_image_openpgp'
+GO_BUILD_FLAGS_LINUX_CROSS :=-tags 'include_gcs include_oss containers_image_openpgp'
 
 OUTPUT_DIR :=_output
 CROSS_BUILD_BINDIR :=$(OUTPUT_DIR)/bin
@@ -79,7 +80,23 @@ cross-build-windows-amd64:
 	+@GOOS=windows GOARCH=amd64 $(MAKE) --no-print-directory build GO_BUILD_PACKAGES:=./cmd/oc GO_BUILD_FLAGS:="$(GO_BUILD_FLAGS_WINDOWS)" GO_BUILD_BINDIR:=$(CROSS_BUILD_BINDIR)/windows_amd64
 .PHONY: cross-build-windows-amd64
 
-cross-build: cross-build-darwin-amd64 cross-build-windows-amd64
+cross-build-linux-amd64:
+	+@GOOS=linux GOARCH=amd64 $(MAKE) --no-print-directory build GO_BUILD_PACKAGES:=./cmd/oc GO_BUILD_FLAGS:="$(GO_BUILD_FLAGS_LINUX_CROSS)" GO_BUILD_BINDIR:=$(CROSS_BUILD_BINDIR)/linux_amd64
+.PHONY: cross-build-linux-amd64
+
+cross-build-linux-arm64:
+	+@GOOS=linux GOARCH=arm64 $(MAKE) --no-print-directory build GO_BUILD_PACKAGES:=./cmd/oc GO_BUILD_FLAGS:="$(GO_BUILD_FLAGS_LINUX_CROSS)" GO_BUILD_BINDIR:=$(CROSS_BUILD_BINDIR)/linux_arm64
+.PHONY: cross-build-linux-arm64
+
+cross-build-linux-ppc64le:
+	+@GOOS=linux GOARCH=ppc64le $(MAKE) --no-print-directory build GO_BUILD_PACKAGES:=./cmd/oc GO_BUILD_FLAGS:="$(GO_BUILD_FLAGS_LINUX_CROSS)" GO_BUILD_BINDIR:=$(CROSS_BUILD_BINDIR)/linux_ppc64le
+.PHONY: cross-build-linux-ppc64le
+
+cross-build-linux-s390x:
+	+@GOOS=linux GOARCH=s390x $(MAKE) --no-print-directory build GO_BUILD_PACKAGES:=./cmd/oc GO_BUILD_FLAGS:="$(GO_BUILD_FLAGS_LINUX_CROSS)" GO_BUILD_BINDIR:=$(CROSS_BUILD_BINDIR)/linux_s390x
+.PHONY: cross-build-linux-s390x
+
+cross-build: cross-build-darwin-amd64 cross-build-windows-amd64 cross-build-linux-amd64 cross-build-linux-arm64 cross-build-linux-ppc64le cross-build-linux-s390x
 .PHONY: cross-build
 
 clean-cross-build:

--- a/images/cli-artifacts/Dockerfile.rhel
+++ b/images/cli-artifacts/Dockerfile.rhel
@@ -4,11 +4,11 @@ FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/oc
 COPY . .
 RUN yum install -y --setopt=skip_missing_names_on_install=False gpgme-devel libassuan-devel
-RUN make cross-build-darwin-amd64 cross-build-windows-amd64 --warn-undefined-variables
+RUN make cross-build --warn-undefined-variables
 
 FROM registry.svc.ci.openshift.org/ocp/4.2:cli
-COPY --from=builder /go/src/github.com/openshift/oc/_output/bin/darwin_amd64/oc /usr/share/openshift/mac/oc
-COPY --from=builder /go/src/github.com/openshift/oc/_output/bin/windows_amd64/oc.exe /usr/share/openshift/windows/oc.exe
+COPY --from=builder /go/src/github.com/openshift/oc/_output/bin/ /usr/share/openshift/
+RUN mkdir /usr/share/openshift/mac /usr/share/openshift/windows && ln /usr/share/openshift/darwin_amd64/oc /usr/share/openshift/mac/oc && ln /usr/share/openshift/windows_amd64/oc.exe /usr/share/openshift/windows/oc.exe
 LABEL io.k8s.display-name="OpenShift Clients" \
       io.k8s.description="OpenShift is a platform for developing, building, and deploying containerized applications." \
       io.openshift.tags="openshift,cli"

--- a/oc.spec
+++ b/oc.spec
@@ -100,7 +100,7 @@ GOARCH=s390x
 
 %ifarch x86_64
   # Create Binaries for all supported arches
-  %{make} cross-build GO_BUILD_PACKAGES:='./cmd/oc'
+  %{make} cross-build-darwin-amd64 cross-build-windows-amd64 GO_BUILD_PACKAGES:='./cmd/oc'
 %endif
 
 %install


### PR DESCRIPTION
In order for console-operator deployment to succeed, cli-artifacts needs to be available on all arches for downloads-openshift-console.  However, in that case, /usr/bin/oc (inherited from cli) is a native binary, and we want to provide all primary Linux architectures to match those on mirror.openshift.com.

In order to do so, this provides cross-compiled Linux binaries for multiple architectures.  Cross-compiling oc fails with gssapi enabled, therefore it is disabled in the cross builds.

Because this affects cluster deployment, we are looking to get this into 4.2 and later branches (we can provide separate PRs for stable branches as needed).