### PR TITLE
Bug 1748777: oc: don't print usage info if pass a bad flag, only suggest to pass --help

### DIFF
--- a/pkg/helpers/cmd/templater.go
+++ b/pkg/helpers/cmd/templater.go
@@ -30,6 +30,7 @@ func ActsAsRootCommand(cmd *cobra.Command, filters []string, groups ...ktemplate
 		CommandGroups: groups,
 		Filtered:      filters,
 	}
+	cmd.SetFlagErrorFunc(templater.FlagErrorFunc())
 	cmd.SetUsageFunc(templater.UsageFunc())
 	cmd.SetHelpFunc(templater.HelpFunc())
 	return templater
@@ -56,6 +57,18 @@ type templater struct {
 	RootCmd       *cobra.Command
 	ktemplates.CommandGroups
 	Filtered []string
+}
+
+func (templater *templater) FlagErrorFunc(exposedFlags ...string) func(*cobra.Command, error) error {
+	return func(c *cobra.Command, err error) error {
+		c.SilenceUsage = true
+		switch c.CalledAs() {
+		case "options":
+			return fmt.Errorf("%s\nRun '%s' without flags.", err, c.CommandPath())
+		default:
+			return fmt.Errorf("%s\nSee '%s --help' for usage.", err, c.CommandPath())
+		}
+	}
 }
 
 func (templater *templater) ExposeFlags(cmd *cobra.Command, flags ...string) FlagExposer {


### PR DESCRIPTION
This PR completes this fix for oc: https://github.com/openshift/kubernetes-kubectl/pull/3

/assign @soltysh 