### PR TITLE
image: If a user specifies both tag and digest, retrieve via digest

### DIFF
--- a/pkg/cli/image/manifest/manifest.go
+++ b/pkg/cli/image/manifest/manifest.go
@@ -189,14 +189,14 @@ var PreferManifestList = distribution.WithManifestMediaTypes([]string{
 // AllManifests returns all non-list manifests, the list manifest (if any), the digest the from refers to, or an error.
 func AllManifests(ctx context.Context, from imagereference.DockerImageReference, repo distribution.Repository) (map[digest.Digest]distribution.Manifest, *manifestlist.DeserializedManifestList, digest.Digest, error) {
 	var srcDigest digest.Digest
-	if len(from.Tag) > 0 {
+	if len(from.ID) > 0 {
+		srcDigest = digest.Digest(from.ID)
+	} else if len(from.Tag) > 0 {
 		desc, err := repo.Tags(ctx).Get(ctx, from.Tag)
 		if err != nil {
 			return nil, nil, "", err
 		}
 		srcDigest = desc.Digest
-	} else if len(from.ID) > 0 {
-		srcDigest = digest.Digest(from.ID)
 	} else {
 		return nil, nil, "", fmt.Errorf("no tag or digest specified")
 	}
@@ -231,14 +231,14 @@ func (m ManifestLocation) String() string {
 // FirstManifest returns the first manifest at the request location that matches the filter function.
 func FirstManifest(ctx context.Context, from imagereference.DockerImageReference, repo distribution.Repository, filterFn FilterFunc) (distribution.Manifest, ManifestLocation, error) {
 	var srcDigest digest.Digest
-	if len(from.Tag) > 0 {
+	if len(from.ID) > 0 {
+		srcDigest = digest.Digest(from.ID)
+	} else if len(from.Tag) > 0 {
 		desc, err := repo.Tags(ctx).Get(ctx, from.Tag)
 		if err != nil {
 			return nil, ManifestLocation{}, err
 		}
 		srcDigest = desc.Digest
-	} else if len(from.ID) > 0 {
-		srcDigest = digest.Digest(from.ID)
 	} else {
 		return nil, ManifestLocation{}, fmt.Errorf("no tag or digest specified")
 	}

--- a/pkg/cli/image/mirror/mappings.go
+++ b/pkg/cli/image/mirror/mappings.go
@@ -185,17 +185,18 @@ func buildTargetTree(mappings []Mapping) targetTree {
 		}
 
 		var current pushTargets
-		if tag := m.Source.Ref.Tag; len(tag) != 0 {
-			current = src.tags[tag]
-			if current == nil {
-				current = make(pushTargets)
-				src.tags[tag] = current
-			}
-		} else {
+		if id := m.Source.Ref.ID; len(id) > 0 {
 			current = src.digests[m.Source.Ref.ID]
 			if current == nil {
 				current = make(pushTargets)
 				src.digests[m.Source.Ref.ID] = current
+			}
+		} else {
+			tag := m.Source.Ref.Tag
+			current = src.tags[tag]
+			if current == nil {
+				current = make(pushTargets)
+				src.tags[tag] = current
 			}
 		}
 

--- a/pkg/helpers/image/helpers.go
+++ b/pkg/helpers/image/helpers.go
@@ -85,8 +85,6 @@ func DockerImageReferenceNameString(r imagev1.DockerImageReference) string {
 	switch {
 	case len(r.Name) == 0:
 		return ""
-	case len(r.Tag) > 0:
-		return r.Name + ":" + r.Tag
 	case len(r.ID) > 0:
 		var ref string
 		if _, err := imageutil.ParseDigest(r.ID); err == nil {
@@ -97,6 +95,8 @@ func DockerImageReferenceNameString(r imagev1.DockerImageReference) string {
 			ref = ":" + r.ID
 		}
 		return r.Name + ref
+	case len(r.Tag) > 0:
+		return r.Name + ":" + r.Tag
 	default:
 		return r.Name
 	}


### PR DESCRIPTION
The digest is more specific and should override tag when we retrieve
image info or perform mirrors. Almost all code uses these two helpers.