### PR TITLE
Bug 1771329: only build adm catalog command for linux

### DIFF
--- a/pkg/cli/admin/admin.go
+++ b/pkg/cli/admin/admin.go
@@ -126,7 +126,6 @@ func NewCommandAdmin(name, fullName string, f kcmdutil.Factory, streams genericc
 		release.NewCmd(f, fullName, streams),
 		buildchain.NewCmdBuildChain(name, fullName+" "+buildchain.BuildChainRecommendedCommandName, f, streams),
 		verifyimagesignature.NewCmdVerifyImageSignature(name, fullName+" "+verifyimagesignature.VerifyRecommendedName, f, streams),
-		catalog.NewCmd(streams),
 
 		// part of every root command
 		kubectlwrappers.NewCmdConfig(fullName, "config", f, streams),
@@ -135,6 +134,7 @@ func NewCommandAdmin(name, fullName string, f kcmdutil.Factory, streams genericc
 		// hidden
 		options.NewCmdOptions(streams),
 	)
+	catalog.AddCommand(streams, cmds)
 
 	return cmds
 }

--- a/pkg/cli/admin/catalog/catalog.go
+++ b/pkg/cli/admin/catalog/catalog.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package catalog
 
 import (
@@ -8,7 +10,13 @@ import (
 	"k8s.io/kubectl/pkg/util/templates"
 )
 
-func NewCmd(streams genericclioptions.IOStreams) *cobra.Command {
+func init() {
+	addCommand = func(streams genericclioptions.IOStreams, cmd *cobra.Command) {
+		cmd.AddCommand(newCmd(streams))
+	}
+}
+
+func newCmd(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "catalog",
 		Short: "Tools for managing the OpenShift OLM Catalogs",

--- a/pkg/cli/admin/catalog/cmd.go
+++ b/pkg/cli/admin/catalog/cmd.go
@@ -1,0 +1,19 @@
+package catalog
+
+import (
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+var addCommand func(streams genericclioptions.IOStreams, cmd *cobra.Command)
+
+// AddCommand adds the catalog subcommand to the given command.
+// The subcommand is only added when built on supporting OSes (linux).
+func AddCommand(streams genericclioptions.IOStreams, cmd *cobra.Command) {
+	if addCommand == nil {
+		return
+	}
+
+	addCommand(streams, cmd)
+}


### PR DESCRIPTION
Constrain `oc adm catalog` subcommand to linux builds. 

This temporarily addresses an [issue with cross-compiling the subcommand](https://bugzilla.redhat.com/show_bug.cgi?id=1771329 ) for mac and windows in 4.3.