### PR TITLE
Bug 1773257: pkg/cli/admin/release/extract_tools: Inject release version into installer

### DIFF
--- a/pkg/cli/admin/release/extract_tools.go
+++ b/pkg/cli/admin/release/extract_tools.go
@@ -180,18 +180,20 @@ func (o *ExtractOptions) extractCommand(command string) error {
 			Command: "openshift-install",
 			Mapping: extract.Mapping{Image: "installer-artifacts", From: "usr/share/openshift/mac/openshift-install"},
 
-			Readme:             readmeInstallUnix,
-			InjectReleaseImage: true,
-			ArchiveFormat:      "openshift-install-mac-%s.tar.gz",
+			Readme:               readmeInstallUnix,
+			InjectReleaseImage:   true,
+			InjectReleaseVersion: true,
+			ArchiveFormat:        "openshift-install-mac-%s.tar.gz",
 		},
 		{
 			OS:      "linux",
 			Command: "openshift-install",
 			Mapping: extract.Mapping{Image: "installer", From: "usr/bin/openshift-install"},
 
-			Readme:             readmeInstallUnix,
-			InjectReleaseImage: true,
-			ArchiveFormat:      "openshift-install-linux-%s.tar.gz",
+			Readme:               readmeInstallUnix,
+			InjectReleaseImage:   true,
+			InjectReleaseVersion: true,
+			ArchiveFormat:        "openshift-install-linux-%s.tar.gz",
 		},
 		{
 			OS:       "linux",
@@ -199,9 +201,10 @@ func (o *ExtractOptions) extractCommand(command string) error {
 			Optional: true,
 			Mapping:  extract.Mapping{Image: "baremetal-installer", From: "usr/bin/openshift-install"},
 
-			Readme:             readmeInstallUnix,
-			InjectReleaseImage: true,
-			ArchiveFormat:      "openshift-baremetal-install-linux-%s.tar.gz",
+			Readme:               readmeInstallUnix,
+			InjectReleaseImage:   true,
+			InjectReleaseVersion: true,
+			ArchiveFormat:        "openshift-baremetal-install-linux-%s.tar.gz",
 		},
 	}
 


### PR DESCRIPTION
We've been injecting the release version into oc since 13215d7176 (Bug
1715001: when extracting tools from payload, 'oc version' should
report payload version, 2019-09-10, #88), but we want to inject it
into the installer to to avoid potential confusion from:

```console
$ oc adm release extract --command=openshift-install quay.io/openshift-release-dev/ocp-release:4.2.7
$ ./openshift-install version
./openshift-install v4.2.5
built from commit 425e4ff0037487e32571258640b39f56d5ee5572
release image quay.io/openshift-release-dev/ocp-release@sha256:bac62983757570b9b8f8bc84c740782984a255c16372b3e30cfc8b52c0a187b9
```

This commit refactors the split helpers from f55426f91b (Bug 1763728:
fix 'oc adm release extract' version injection, 2019-10-17, #131) with
a single helper that takes a replacement slice.  I've also pushed the
unmatched warning down into the replacement helper itself so we don't
have to return a slice of replacements that did or did not match.

Now that replacements are no longer baked in, I've made the unit test
a bit more readable by dispensing with the fakeInput helpers and just
hard-coding small input/output strings in the test-case definitions.

There's also the "`oc` is overwriting its own
`...RELEASE_VERSION_LOCATION...`" constant issue, previously fixed by
ded896daab (Bug 1768516: fix extracted-oc adm extract oc, 2019-11-08, #155).
In this commit, I've avoidied that by using ! as the leading character
in the marker constants and replacing it with a null byte when
constructing replacements in extractCommand.  With a single
replacement per marker, we need our marker constant to never match; I
dunno what the previous doubled constant was about (but see the
len(value) point next for why the previous doubled marker worked at
all).

I've also fixed some additional bugs:

* The previous implementation only used len(value) of the marker when
  searching the incoming bytes.  Especially for short strings like
  version replacement, this meant we were only looking for five bytes
  for 4.2.7, which is \x00_REL.  That's not very specific.  It does
  not distinquish between \x00_RELEASE_IMAGE_LOCATION_\x00XX... and
  \x00_RELEASE_VERSION_LOCATION_\x00XX....  It doesn't even
  distinguish between the defaultVersionPadded and
  defaultVersionPrefix constants in pkg/version.  With this commit, we
  search for the full marker, regardless of len(value).

* The previous implementation had:

    ```go
    nextOffset := end - len(marker)
    ...
    _, wErr := w.Write(buf[:end-nextOffset])
    ...
    copy(buf[:nextOffset], buf[end-nextOffset:end])
    offset = nextOffset
    ```

    That was problematic for a few reasons:

    * It didn't write much data.  Substituting for `nextOffset`, we were
      writing to:

        ```
          end - nextOffset
        = end - (end - len(marker))
        = len(marker)
			  ```

        this makes the buffer size largely meaningless, and means lots of
        inefficient, small reads/writes.  With this commit, we have a
        writeTo variable that is everything except the *last* `len(marker)`.

    * It ignored the amound of data written.  You can *want* to write 1k
        bytes but only actually write 50 bytes with a given `Write` call.
        That didn't happen often before; because of the previous list
        entry we were only attempting to write a hundred or so bytes at a
        time.  But now that we are trying to write the bulk of the buffer
        size, it happens more often.  With this commit, we keep attempting
        `Write` until it errors out on us or we finish pushing all the bytes
        we no longer need.

Because 13215d7176, f55426f91b, and ded896daab all touched the version
marker, this commit will mean that oc build with this commit and later
will not inject version names into oc built before ded896daab.  But
that's ok, because 4.2 binaries have no version markers (just a
`RELEASE_IMAGE_LOCATION` constant for the installer's marker).  And we
haven't cut 4.3 yet.  So with this commit and no future changes to the
oc marker, we'll be able to inject the version name into all supported
oc which are prepared to receive injected version names.

In action extracting from [4.3.0-0.nightly-2019-11-13-233341][1]:

```console
$ go build -o oc-mine ./cmd/oc
$ ./oc-mine adm release extract --command=oc quay.io/openshift-release-dev/ocp-release-nightly@sha256:502d184ac8742073cb3007a0ad9abe8672b0a2db37331cfbfb4cb1b564c893fd
$ ./oc version --client
Client Version: 4.3.0-0.nightly-2019-11-13-233341
```

CC @sallyom

[1]: https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/4.3.0-0.nightly-2019-11-13-233341/release.txt