### PR TITLE
Bug 1775875: pkg/cli/admin/release/extract_tools: Pass []replacements to copyAndReplace

### DIFF
--- a/pkg/cli/admin/release/extract_tools_test.go
+++ b/pkg/cli/admin/release/extract_tools_test.go
@@ -2,188 +2,234 @@ package release
 
 import (
 	"bytes"
-	"encoding/hex"
-	"math/rand"
-	"strings"
 	"testing"
 )
 
-func Test_copyAndReplaceReleaseImage(t *testing.T) {
-	baseLen := len(installerReplacement)
+func Test_copyAndReplace(t *testing.T) {
+	buffer := 4
 	tests := []struct {
 		name         string
-		r            *bytes.Buffer
-		buffer       int
-		releaseImage string
-		wantIndex    int
-		wantErr      bool
+		input        string
+		replacements []replacement
+		expected     string
+		error        string
 	}{
-		{buffer: 10, wantErr: true, wantIndex: -1},
-		{buffer: baseLen, wantErr: false, wantIndex: -1},
-
-		{releaseImage: "test:latest", r: fakeInput(1024, 0), wantIndex: 1024, name: "end of file"},
-		{releaseImage: "test:latest", r: fakeInput(2*1024, 0), wantIndex: 2 * 1024},
-
-		{releaseImage: "test:latest", r: fakeInput(1024-1, 0, 1), wantIndex: 1024 - 1},
-		{releaseImage: "test:latest", r: fakeInput(0, 1), wantIndex: 0},
-
-		{releaseImage: "test:latest", r: fakeInput(baseLen, 0), wantIndex: baseLen},
-		{releaseImage: "test:latest", r: fakeInput(baseLen*2, 0), wantIndex: baseLen * 2},
-		{releaseImage: "test:latest", r: fakeInput(baseLen-1, 0), wantIndex: baseLen - 1},
-		{releaseImage: "test:latest", r: fakeInput(baseLen*2-1, 0), wantIndex: baseLen*2 - 1},
-		{releaseImage: "test:latest", r: fakeInput(baseLen+1, 0), wantIndex: baseLen + 1},
-		{releaseImage: "test:latest", r: fakeInput(baseLen*2+1, 0), wantIndex: baseLen*2 + 1},
-
-		{releaseImage: strings.Repeat("a", baseLen), wantIndex: -1, wantErr: true},
-		{releaseImage: strings.Repeat("a", baseLen+1), wantIndex: -1, wantErr: true},
-
-		{releaseImage: strings.Repeat("a", baseLen-1), r: fakeInput(baseLen, 0), wantIndex: baseLen},
-		{releaseImage: strings.Repeat("a", baseLen-2), r: fakeInput(baseLen, 0), wantIndex: baseLen},
-		{releaseImage: strings.Repeat("a", baseLen-1), r: fakeInput(1, baseLen, 0), wantIndex: 1 + baseLen},
-		{releaseImage: strings.Repeat("a", baseLen-2), r: fakeInput(1, 0, baseLen), wantIndex: 1},
-
-		{releaseImage: strings.Repeat("a", baseLen-1), r: fakeInput(baseLen*2, 0), wantIndex: baseLen * 2},
-		{releaseImage: strings.Repeat("a", baseLen-2), r: fakeInput(baseLen*2, 0), wantIndex: baseLen * 2},
-		{releaseImage: strings.Repeat("a", baseLen-1), r: fakeInput(1, baseLen*2, 0), wantIndex: 1 + baseLen*2},
-		{releaseImage: strings.Repeat("a", baseLen-2), r: fakeInput(1, 0, baseLen*2), wantIndex: 1},
+		{
+			name:  "buffer too small",
+			input: "1234",
+			replacements: []replacement{
+				{
+					name:   "rep-A",
+					marker: []byte("aaaaa"),
+					value:  "A",
+				},
+			},
+			error: "the buffer size must be greater than 5 bytes to find rep-A",
+		},
+		{
+			name:     "buffer too large",
+			input:    "123",
+			expected: "123",
+		},
+		{
+			name:  "value too large",
+			input: "1234",
+			replacements: []replacement{
+				{
+					name:   "rep-A",
+					marker: []byte("aa"),
+					value:  "AA",
+				},
+			},
+			error: "the rep-A value has 2 bytes, but the maximum replacement length is 1",
+		},
+		{
+			name:     "A beginning of file",
+			input:    "aa345678",
+			expected: "A\x00345678",
+			replacements: []replacement{
+				{
+					name:   "rep-A",
+					marker: []byte("aa"),
+					value:  "A",
+				},
+			},
+		},
+		{
+			name:     "A end of buffer",
+			input:    "12aa5678",
+			expected: "12A\x005678",
+			replacements: []replacement{
+				{
+					name:   "rep-A",
+					marker: []byte("aa"),
+					value:  "A",
+				},
+			},
+		},
+		{
+			name:     "A cross buffer",
+			input:    "123aa678",
+			expected: "123A\x00678",
+			replacements: []replacement{
+				{
+					name:   "rep-A",
+					marker: []byte("aa"),
+					value:  "A",
+				},
+			},
+		},
+		{
+			name:     "A beginning of buffer",
+			input:    "1234aa78",
+			expected: "1234A\x0078",
+			replacements: []replacement{
+				{
+					name:   "rep-A",
+					marker: []byte("aa"),
+					value:  "A",
+				},
+			},
+		},
+		{
+			name:     "A end of file",
+			input:    "123456aa",
+			expected: "123456A\x00",
+			replacements: []replacement{
+				{
+					name:   "rep-A",
+					marker: []byte("aa"),
+					value:  "A",
+				},
+			},
+		},
+		{
+			name:     "A buffer too large",
+			input:    "12345aa",
+			expected: "12345A\x00",
+			replacements: []replacement{
+				{
+					name:   "rep-A",
+					marker: []byte("aa"),
+					value:  "A",
+				},
+			},
+		},
+		{
+			name:     "AB beginning of file",
+			input:    "aabb5678",
+			expected: "A\x00B\x005678",
+			replacements: []replacement{
+				{
+					name:   "rep-A",
+					marker: []byte("aa"),
+					value:  "A",
+				},
+				{
+					name:   "rep-B",
+					marker: []byte("bb"),
+					value:  "B",
+				},
+			},
+		},
+		{
+			name:     "BA beginning of file",
+			input:    "bbaa5678",
+			expected: "B\x00A\x005678",
+			replacements: []replacement{
+				{
+					name:   "rep-A",
+					marker: []byte("aa"),
+					value:  "A",
+				},
+				{
+					name:   "rep-B",
+					marker: []byte("bb"),
+					value:  "B",
+				},
+			},
+		},
+		{
+			name:     "AB end of buffer",
+			input:    "1234aabb",
+			expected: "1234A\x00B\x00",
+			replacements: []replacement{
+				{
+					name:   "rep-A",
+					marker: []byte("aa"),
+					value:  "A",
+				},
+				{
+					name:   "rep-B",
+					marker: []byte("bb"),
+					value:  "B",
+				},
+			},
+		},
+		{
+			name:     "AB cross buffer",
+			input:    "123aa6bb",
+			expected: "123A\x006B\x00",
+			replacements: []replacement{
+				{
+					name:   "rep-A",
+					marker: []byte("aa"),
+					value:  "A",
+				},
+				{
+					name:   "rep-B",
+					marker: []byte("bb"),
+					value:  "B",
+				},
+			},
+		},
+		{
+			name:     "AB end of file",
+			input:    "1234aabb",
+			expected: "1234A\x00B\x00",
+			replacements: []replacement{
+				{
+					name:   "rep-A",
+					marker: []byte("aa"),
+					value:  "A",
+				},
+				{
+					name:   "rep-B",
+					marker: []byte("bb"),
+					value:  "B",
+				},
+			},
+		},
+		{
+			name:     "BA end of file",
+			input:    "1234bbaa",
+			expected: "1234B\x00A\x00",
+			replacements: []replacement{
+				{
+					name:   "rep-A",
+					marker: []byte("aa"),
+					value:  "A",
+				},
+				{
+					name:   "rep-B",
+					marker: []byte("bb"),
+					value:  "B",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			r := bytes.NewReader([]byte(tt.input))
 			w := &bytes.Buffer{}
-			if tt.buffer == 0 {
-				tt.buffer = 1024
+			err := copyAndReplace(nil, w, r, buffer, tt.replacements, "test")
+			if (err == nil && tt.error != "") || (err != nil && err.Error() != tt.error) {
+				t.Fatalf("unexpected error: %v != %v", err, tt.error)
 			}
-			if tt.r == nil {
-				tt.r = &bytes.Buffer{}
-			}
-
-			src := tt.r.Bytes()
-			original := make([]byte, len(src))
-			copy(original, src)
-
-			got, err := copyAndReplaceReleaseInfo(w, tt.r, tt.buffer, tt.releaseImage)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("copyAndReplaceReleaseImage() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			if got != (tt.wantIndex != -1) {
-				t.Fatalf("copyAndReplaceReleaseImage() = %v, want %v", got, tt.wantIndex != -1)
-			}
-			if got {
-				if len(w.Bytes()) != len(original) {
-					t.Fatalf("mismatched lengths: %d vs %d \n%s\n%s", len(original), w.Len(), hex.Dump(original), hex.Dump(w.Bytes()))
-				}
-				index := bytes.Index(w.Bytes(), []byte(tt.releaseImage+"\x00"))
-				if index != tt.wantIndex {
-					t.Errorf("expected index %d, got index %d\n%s", tt.wantIndex, index, hex.Dump(w.Bytes()))
-				}
-			} else {
-				if !bytes.Equal(w.Bytes(), original) {
-					t.Fatalf("unexpected response body:\n%s\n%s", hex.Dump(original), hex.Dump(w.Bytes()))
-				}
+			actual := w.String()
+			if actual != tt.expected {
+				t.Fatalf("unexpected response body: %q != %q", actual, tt.expected)
 			}
 		})
 	}
-}
-
-func fakeInput(lengths ...int) *bytes.Buffer {
-	buf := &bytes.Buffer{}
-	for _, l := range lengths {
-		if l == 0 {
-			buf.WriteString(installerReplacement)
-		} else {
-			b := byte(rand.Intn(256))
-			buf.Write(bytes.Repeat([]byte{b}, l))
-		}
-	}
-	return buf
-}
-
-func Test_copyAndReplaceReleaseVersion(t *testing.T) {
-	baseLen := len(releaseVersionReplacement)
-	tests := []struct {
-		name         string
-		r            *bytes.Buffer
-		buffer       int
-		releaseImage string
-		wantIndex    int
-		wantErr      bool
-	}{
-		{buffer: 10, wantErr: true, wantIndex: -1},
-		{buffer: baseLen, wantErr: false, wantIndex: -1},
-
-		{releaseImage: "test:latest", r: fakeInputVersion(1024, 0), wantIndex: 1024, name: "end of file"},
-		{releaseImage: "test:latest", r: fakeInputVersion(2*1024, 0), wantIndex: 2 * 1024},
-
-		{releaseImage: "test:latest", r: fakeInputVersion(1024-1, 0, 1), wantIndex: 1024 - 1},
-		{releaseImage: "test:latest", r: fakeInputVersion(0, 1), wantIndex: 0},
-
-		{releaseImage: "test:latest", r: fakeInputVersion(baseLen, 0), wantIndex: baseLen},
-		{releaseImage: "test:latest", r: fakeInputVersion(baseLen*2, 0), wantIndex: baseLen * 2},
-		{releaseImage: "test:latest", r: fakeInputVersion(baseLen-1, 0), wantIndex: baseLen - 1},
-		{releaseImage: "test:latest", r: fakeInputVersion(baseLen*2-1, 0), wantIndex: baseLen*2 - 1},
-		{releaseImage: "test:latest", r: fakeInputVersion(baseLen+1, 0), wantIndex: baseLen + 1},
-		{releaseImage: "test:latest", r: fakeInputVersion(baseLen*2+1, 0), wantIndex: baseLen*2 + 1},
-
-		{releaseImage: strings.Repeat("a", baseLen), wantIndex: -1, wantErr: true},
-		{releaseImage: strings.Repeat("a", baseLen+1), wantIndex: -1, wantErr: true},
-
-		{releaseImage: strings.Repeat("a", baseLen-1), r: fakeInputVersion(baseLen, 0), wantIndex: baseLen},
-		{releaseImage: strings.Repeat("a", baseLen-2), r: fakeInputVersion(baseLen, 0), wantIndex: baseLen},
-		{releaseImage: strings.Repeat("a", baseLen-1), r: fakeInputVersion(1, baseLen, 0), wantIndex: 1 + baseLen},
-		{releaseImage: strings.Repeat("a", baseLen-2), r: fakeInputVersion(1, 0, baseLen), wantIndex: 1},
-
-		{releaseImage: strings.Repeat("a", baseLen-1), r: fakeInputVersion(baseLen*2, 0), wantIndex: baseLen * 2},
-		{releaseImage: strings.Repeat("a", baseLen-2), r: fakeInputVersion(baseLen*2, 0), wantIndex: baseLen * 2},
-		{releaseImage: strings.Repeat("a", baseLen-1), r: fakeInputVersion(1, baseLen*2, 0), wantIndex: 1 + baseLen*2},
-		{releaseImage: strings.Repeat("a", baseLen-2), r: fakeInputVersion(1, 0, baseLen*2), wantIndex: 1},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			w := &bytes.Buffer{}
-			if tt.buffer == 0 {
-				tt.buffer = 1024
-			}
-			if tt.r == nil {
-				tt.r = &bytes.Buffer{}
-			}
-
-			src := tt.r.Bytes()
-			original := make([]byte, len(src))
-			copy(original, src)
-
-			got, err := copyAndReplaceReleaseVersion(w, tt.r, tt.buffer, tt.releaseImage)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("copyAndReplaceReleaseVersion() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			if got != (tt.wantIndex != -1) {
-				t.Fatalf("copyAndReplaceReleaseVersion) = %v, want %v", got, tt.wantIndex != -1)
-			}
-			if got {
-				if len(w.Bytes()) != len(original) {
-					t.Fatalf("mismatched lengths: %d vs %d \n%s\n%s", len(original), w.Len(), hex.Dump(original), hex.Dump(w.Bytes()))
-				}
-				index := bytes.Index(w.Bytes(), []byte(tt.releaseImage+"\x00"))
-				if index != tt.wantIndex {
-					t.Errorf("expected index %d, got index %d\n%s", tt.wantIndex, index, hex.Dump(w.Bytes()))
-				}
-			} else {
-				if !bytes.Equal(w.Bytes(), original) {
-					t.Fatalf("unexpected response body:\n%s\n%s", hex.Dump(original), hex.Dump(w.Bytes()))
-				}
-			}
-		})
-	}
-}
-
-func fakeInputVersion(lengths ...int) *bytes.Buffer {
-	buf := &bytes.Buffer{}
-	for _, l := range lengths {
-		if l == 0 {
-			buf.WriteString(releaseVersionReplacement)
-		} else {
-			b := byte(rand.Intn(256))
-			buf.Write(bytes.Repeat([]byte{b}, l))
-		}
-	}
-	return buf
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -62,10 +62,10 @@ func Get() version.Info {
 //
 // 1. Extract a release binary that contains a cli image
 // 2. Identify the release name, add a NUL terminator byte (0x00) to the end, calculate length
-// 3. Length must be less than 300 bytes
+// 3. Length must be less than the marker length
 // 4. Search through the cli binary for `\x00_RELEASE_VERSION_LOCATION_\x00<PADDING_TO_LENGTH>`
-//    where padding is the ASCII character X and length is the total length of the image
-// 5. Overwrite that chunk of the bytes if found, otherwise return error.
+//    where padding is the ASCII character X and length is the total length of the marker
+// 5. Overwrite the beginning of the marker with the release name and a NUL terminator byte (0x00)
 
 var (
 	// defaultReleaseInfoPadded may be replaced in the binary with Release Metadata: Version that overrides defaultVersion as


### PR DESCRIPTION
This is everything from #165 except setting `InjectReleaseVersion` for the installers, because @abhinavdahiya [wants some time][1] to look into the ecosystem around that.  @sallyom, this also lets us fix the existing bugs described in #165 while avoiding [your concerns][2] about warnings when running code that expects to inject release versions into the installer before the installer has the marker to recieve them.

/assign @soltysh

[1]: https://github.com/openshift/installer/pull/2682#issuecomment-554725150
[2]: https://github.com/openshift/oc/pull/165#issuecomment-555026307