### PR TITLE
pkg/cli/admin/release/extract: Drop extractTools

### DIFF
--- a/pkg/cli/admin/release/extract.go
+++ b/pkg/cli/admin/release/extract.go
@@ -151,7 +151,7 @@ func (o *ExtractOptions) Run() error {
 	case len(o.GitExtractDir) > 0:
 		return o.extractGit(o.GitExtractDir)
 	case o.Tools:
-		return o.extractTools()
+		return o.extractCommand("")
 	case len(o.Command) > 0:
 		return o.extractCommand(o.Command)
 	}

--- a/pkg/cli/admin/release/extract_tools.go
+++ b/pkg/cli/admin/release/extract_tools.go
@@ -53,11 +53,6 @@ type extractTarget struct {
 	Mapping extract.Mapping
 }
 
-// extractTools extracts all referenced commands as archives in the target dir.
-func (o *ExtractOptions) extractTools() error {
-	return o.extractCommand("")
-}
-
 var (
 	readmeInstallUnix = heredoc.Doc(`
 	# OpenShift Install
@@ -138,7 +133,7 @@ var (
 	`)
 )
 
-// extractTools extracts specific commands out of images referenced by the release image.
+// extractCommand extracts specific commands out of images referenced by the release image.
 // TODO: in the future the metadata this command contains might be loaded from the release
 //   image, but we must maintain compatibility with older payloads if so
 func (o *ExtractOptions) extractCommand(command string) error {


### PR DESCRIPTION
This function was a hold-over from the refactor in openshift/origin@a63351b9bb (openshift/origin#22439) that added `extractCommand`.  Doesn't seem to be worth keeping a separate function for this when we could just call `extractCommand` directly.