### PR TITLE
pkg/cli/admin/release: fmt.Errorf -> errors.New when there's no formatting

### DIFF
--- a/pkg/cli/admin/release/extract.go
+++ b/pkg/cli/admin/release/extract.go
@@ -2,6 +2,7 @@ package release
 
 import (
 	"archive/tar"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -108,7 +109,7 @@ type ExtractOptions struct {
 func (o *ExtractOptions) Complete(f kcmdutil.Factory, cmd *cobra.Command, args []string) error {
 	switch {
 	case len(args) == 1 && len(o.From) > 0, len(args) > 1:
-		return fmt.Errorf("you may only specify a single image via --from or argument")
+		return errors.New("you may only specify a single image via --from or argument")
 	}
 	if len(o.From) > 0 {
 		args = []string{o.From}
@@ -118,7 +119,7 @@ func (o *ExtractOptions) Complete(f kcmdutil.Factory, cmd *cobra.Command, args [
 		return err
 	}
 	if len(args) != 1 {
-		return fmt.Errorf("you may only specify a single image via --from or argument")
+		return errors.New("you may only specify a single image via --from or argument")
 	}
 	o.From = args[0]
 
@@ -142,11 +143,11 @@ func (o *ExtractOptions) Run() error {
 
 	switch {
 	case sources > 1:
-		return fmt.Errorf("only one of --tools, --command, --file, or --git may be specified")
+		return errors.New("only one of --tools, --command, --file, or --git may be specified")
 	case len(o.From) == 0:
-		return fmt.Errorf("must specify an image containing a release payload with --from")
+		return errors.New("must specify an image containing a release payload with --from")
 	case o.Directory != "." && len(o.File) > 0:
-		return fmt.Errorf("only one of --to and --file may be set")
+		return errors.New("only one of --to and --file may be set")
 
 	case len(o.GitExtractDir) > 0:
 		return o.extractGit(o.GitExtractDir)
@@ -229,7 +230,7 @@ func (o *ExtractOptions) Run() error {
 			return err
 		}
 		if !verifier.Verified() {
-			err := fmt.Errorf("the release image failed content verification and may have been tampered with")
+			err := errors.New("the release image failed content verification and may have been tampered with")
 			if !o.SecurityOptions.SkipVerification {
 				return err
 			}

--- a/pkg/cli/admin/release/extract_tools.go
+++ b/pkg/cli/admin/release/extract_tools.go
@@ -8,6 +8,7 @@ import (
 	"compress/gzip"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"hash"
 	"io"
@@ -246,9 +247,9 @@ func (o *ExtractOptions) extractCommand(command string) error {
 		case len(command) > 0 && currentOS != "*":
 			return fmt.Errorf("command %q does not support the operating system %q", o.Command, currentOS)
 		case len(command) > 0:
-			return fmt.Errorf("the supported commands are 'oc' and 'openshift-install'")
+			return errors.New("the supported commands are 'oc' and 'openshift-install'")
 		default:
-			return fmt.Errorf("no available commands")
+			return errors.New("no available commands")
 		}
 	}
 
@@ -633,7 +634,7 @@ const (
 // replacement was performed.
 func copyAndReplaceReleaseInfo(w io.Writer, r io.Reader, bufferSize int, releaseInfo string) (bool, error) {
 	if len(releaseInfo)+1 > len(installerReplacement) {
-		return false, fmt.Errorf("the release image pull spec is longer than the maximum replacement length for the binary")
+		return false, errors.New("the release image pull spec is longer than the maximum replacement length for the binary")
 	}
 	if bufferSize < len(installerReplacement) {
 		return false, fmt.Errorf("the buffer size must be greater than %d bytes", len(installerReplacement))
@@ -647,7 +648,7 @@ func copyAndReplaceReleaseInfo(w io.Writer, r io.Reader, bufferSize int, release
 // replacement was performed.
 func copyAndReplaceReleaseVersion(w io.Writer, r io.Reader, bufferSize int, releaseInfo string) (bool, error) {
 	if len(releaseInfo)+1 > len(releaseVersionReplacement) {
-		return false, fmt.Errorf("the release image pull spec is longer than the maximum replacement length for the binary")
+		return false, errors.New("the release image pull spec is longer than the maximum replacement length for the binary")
 	}
 	if bufferSize < len(releaseVersionReplacement) {
 		return false, fmt.Errorf("the buffer size must be greater than %d bytes", len(releaseVersionReplacement))

--- a/pkg/cli/admin/release/git.go
+++ b/pkg/cli/admin/release/git.go
@@ -145,7 +145,7 @@ func gitOutputToError(err error, out string) error {
 	if len(out) == 0 {
 		return err
 	}
-	return fmt.Errorf(out)
+	return errors.New(out)
 }
 
 var (

--- a/pkg/cli/admin/release/image_mapper.go
+++ b/pkg/cli/admin/release/image_mapper.go
@@ -2,6 +2,7 @@ package release
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -112,7 +113,7 @@ func readReleaseImageReferences(data []byte) (*imageapi.ImageStream, error) {
 		return nil, fmt.Errorf("unable to load release image-references: %v", err)
 	}
 	if is.Kind != "ImageStream" || is.APIVersion != "image.openshift.io/v1" {
-		return nil, fmt.Errorf("unrecognized image-references in release payload")
+		return nil, errors.New("unrecognized image-references in release payload")
 	}
 	return is, nil
 }
@@ -370,7 +371,7 @@ func NewComponentVersionsMapper(releaseName string, versions map[string]string, 
 			switch len(missing) {
 			case 1:
 				if len(missing[0]) == 0 {
-					return nil, fmt.Errorf("empty version references are not allowed")
+					return nil, errors.New("empty version references are not allowed")
 				}
 				return nil, fmt.Errorf("unknown version reference %q", missing[0])
 			default:

--- a/pkg/cli/admin/release/signature.go
+++ b/pkg/cli/admin/release/signature.go
@@ -2,14 +2,14 @@ package release
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
 	"time"
 )
 
 // createReleaseSignatureMessage creates the core message to sign the release payload.
 func createReleaseSignatureMessage(signer string, now time.Time, releaseDigest, pullSpec string) ([]byte, error) {
 	if len(signer) == 0 || now.IsZero() || len(releaseDigest) == 0 || len(pullSpec) == 0 {
-		return nil, fmt.Errorf("you must specify a signer, current timestamp, release digest, and pull spec to sign")
+		return nil, errors.New("you must specify a signer, current timestamp, release digest, and pull spec to sign")
 	}
 
 	sig := &signature{


### PR DESCRIPTION
Generated with:

```console
$ sed -i 's/fmt\.Errorf(\("[^"%]*"\))/errors.New(\1)/g' pkg/cli/admin/release/*.go
```

Followed by manually:

* Adding errors imports to the touched files.
* Using `apierrors` for `k8s.io/apimachinery/pkg/api/errors` to distinguish from the standard library package.
* Removing the `fmt` import from `signature.go`, since there were no longer any consumers there.