### PR TITLE
Bug 1748061: copy gotdotenv and add ability to override underlying scanner buffer …

### DIFF
--- a/pkg/helpers/newapp/app/env.go
+++ b/pkg/helpers/newapp/app/env.go
@@ -1,14 +1,15 @@
 package app
 
 import (
+	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
+	"regexp"
 	"sort"
 	"strings"
-
-	"github.com/joho/godotenv"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -155,13 +156,15 @@ func LoadEnvironmentFile(filename string, stdin io.Reader) (Environment, error) 
 
 	// godotenv successfuly returns empty map when given path to a directory,
 	// remove this once https://github.com/joho/godotenv/pull/22 is merged
-	if info, err := os.Stat(filename); err == nil && info.IsDir() {
+	info, err := os.Stat(filename)
+	if err == nil && info.IsDir() {
 		return nil, fmt.Errorf("Cannot read variables from %q: is a directory", filename)
 	} else if err != nil {
 		return nil, fmt.Errorf("Cannot stat %q: %s", filename, err)
 	}
 
-	env, err := godotenv.Read(filename)
+	size := info.Size()
+	env, err := read(size, filename)
 	if err != nil {
 		return nil, fmt.Errorf("Cannot read variables from file %q: %s", errorFilename, err)
 	}
@@ -172,6 +175,175 @@ func LoadEnvironmentFile(filename string, stdin io.Reader) (Environment, error) 
 	}
 	return env, nil
 }
+
+// this is the start of a block of code that was copied from github.com/joho/godotenv;
+// we diverted from that repo because the code did not account for files larger than 64K,
+// and changes to their code we require either changes to the parameters on public methods/API
+// or creation of methods like 'ReadWithSize' and 'ParseWithSize' to propoagate the size information;
+// Convincing upstream of such klunky changes was untenable.
+func read(size int64, filenames ...string) (envMap map[string]string, err error) {
+	filenames = filenamesOrDefault(filenames)
+	envMap = make(map[string]string)
+
+	for _, filename := range filenames {
+		individualEnvMap, individualErr := readFile(size, filename)
+
+		if individualErr != nil {
+			err = individualErr
+			return // return early on a spazout
+		}
+
+		for key, value := range individualEnvMap {
+			envMap[key] = value
+		}
+	}
+
+	return
+}
+func filenamesOrDefault(filenames []string) []string {
+	if len(filenames) == 0 {
+		return []string{".env"}
+	}
+	return filenames
+}
+
+func readFile(size int64, filename string) (envMap map[string]string, err error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+
+	return parse(size, file)
+}
+
+func parse(size int64, r io.Reader) (envMap map[string]string, err error) {
+	envMap = make(map[string]string)
+
+	var lines []string
+	scanner := bufio.NewScanner(r)
+	// changing the buf size is what we are changing from godotenv
+	if size > bufio.MaxScanTokenSize {
+		quotientOnly := size / bufio.MaxScanTokenSize
+		// bump by one to move past any remainder
+		quotientOnly++
+		buf := make([]byte, quotientOnly*bufio.MaxScanTokenSize)
+		scanner.Buffer(buf, int(quotientOnly*bufio.MaxScanTokenSize))
+	}
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+
+	if err = scanner.Err(); err != nil {
+		return
+	}
+
+	for _, fullLine := range lines {
+		if !isIgnoredLine(fullLine) {
+			var key, value string
+			key, value, err = parseLine(fullLine)
+
+			if err != nil {
+				return
+			}
+			envMap[key] = value
+		}
+	}
+	return
+}
+
+func isIgnoredLine(line string) bool {
+	trimmedLine := strings.Trim(line, " \n\t")
+	return len(trimmedLine) == 0 || strings.HasPrefix(trimmedLine, "#")
+}
+
+func parseLine(line string) (key string, value string, err error) {
+	if len(line) == 0 {
+		err = errors.New("zero length string")
+		return
+	}
+
+	// ditch the comments (but keep quoted hashes)
+	if strings.Contains(line, "#") {
+		segmentsBetweenHashes := strings.Split(line, "#")
+		quotesAreOpen := false
+		var segmentsToKeep []string
+		for _, segment := range segmentsBetweenHashes {
+			if strings.Count(segment, "\"") == 1 || strings.Count(segment, "'") == 1 {
+				if quotesAreOpen {
+					quotesAreOpen = false
+					segmentsToKeep = append(segmentsToKeep, segment)
+				} else {
+					quotesAreOpen = true
+				}
+			}
+
+			if len(segmentsToKeep) == 0 || quotesAreOpen {
+				segmentsToKeep = append(segmentsToKeep, segment)
+			}
+		}
+
+		line = strings.Join(segmentsToKeep, "#")
+	}
+
+	firstEquals := strings.Index(line, "=")
+	firstColon := strings.Index(line, ":")
+	splitString := strings.SplitN(line, "=", 2)
+	if firstColon != -1 && (firstColon < firstEquals || firstEquals == -1) {
+		//this is a yaml-style line
+		splitString = strings.SplitN(line, ":", 2)
+	}
+
+	if len(splitString) != 2 {
+		err = errors.New("Can't separate key from value")
+		return
+	}
+
+	// Parse the key
+	key = splitString[0]
+	if strings.HasPrefix(key, "export") {
+		key = strings.TrimPrefix(key, "export")
+	}
+	key = strings.Trim(key, " ")
+
+	// Parse the value
+	value = parseValue(splitString[1])
+	return
+}
+
+func parseValue(value string) string {
+
+	// trim
+	value = strings.Trim(value, " ")
+
+	// check if we've got quoted values or possible escapes
+	if len(value) > 1 {
+		first := string(value[0:1])
+		last := string(value[len(value)-1:])
+		if first == last && strings.ContainsAny(first, `"'`) {
+			// pull the quotes off the edges
+			value = value[1 : len(value)-1]
+			// handle escapes
+			escapeRegex := regexp.MustCompile(`\\.`)
+			value = escapeRegex.ReplaceAllStringFunc(value, func(match string) string {
+				c := strings.TrimPrefix(match, `\`)
+				switch c {
+				case "n":
+					return "\n"
+				case "r":
+					return "\r"
+				default:
+					return c
+				}
+			})
+		}
+	}
+
+	return value
+}
+
+// this is the end of the block of code we copied from github.com/joho/godotenv
+// that has fixes for creating Scanners on large files
 
 // ParseAndCombineEnvironment parses key=value records from slice of strings
 // (typically obtained from the command line) and from given files and combines


### PR DESCRIPTION
…for big files

/assign @adambkaplan 

this is what would be required to fix https://bugzilla.redhat.com/show_bug.cgi?id=1748061

or alternatively, we submit an PR to github.com/joho/godotenv to add this capability and see if they accept it

Per my question in the bug, do we want to take this on given there is a customer case, or close as wontfix ... still waiting from feedback in bug on their feelings wrt to the workaround of using `--param` instead of `--param-file`