### PR TITLE
Bug 1777030: Update support tools container image

### DIFF
--- a/pkg/cli/debug/debug.go
+++ b/pkg/cli/debug/debug.go
@@ -765,7 +765,7 @@ func (o *DebugOptions) approximatePodTemplateForObject(object runtime.Object) (*
 			}
 		}
 		if len(o.Image) == 0 {
-			image = "registry.redhat.io/rhel7/support-tools"
+			image = "registry.redhat.io/rhel8/support-tools"
 		}
 		zero := int64(0)
 		isTrue := true


### PR DESCRIPTION
The RHEL7 support tools image is only built for AMD64, but there will
soon be a need for an image that works on System Z (and eventually
Power). Changing to the RHEL8 image gets us the additional
architectures. Additionally, RHCOS has moved to RHEL8 content, so it's
best to keep the support tools in sync.