### PR TITLE
fix(oc): fixes invalid compdef reference to kubectl for zsh

### DIFF
--- a/contrib/completions/zsh/oc
+++ b/contrib/completions/zsh/oc
@@ -1,4 +1,4 @@
-#compdef kubectl
+#compdef oc
 
 
 __kubectl_bash_source() {


### PR DESCRIPTION
This commit fixes invalid compdef reference to kubectl for zsh
completion script. This prevents zsh to autoload the completions from
FPATH.

Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>