### PR TITLE
Fix build on go 1.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ replace (
 	github.com/ghodss/yaml => github.com/ghodss/yaml v0.0.0-20170327235444-0ca9ea5df545
 	github.com/golang/glog => github.com/openshift/golang-glog v0.0.0-20190322123450-3c92600d7533
 	github.com/onsi/ginkgo => github.com/openshift/onsi-ginkgo v0.0.0-20190125161613-53ca7dc85f60
-	github.com/openshift/api => github.com/openshift/api v0.0.0-0.20191112184635-86def77f6f
+	github.com/openshift/api => github.com/openshift/api v3.9.1-0.20191112184635-86def77f6f90+incompatible
 	github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20191022152013-2823239d2298
 	github.com/openshift/library-go => github.com/openshift/library-go v0.0.0-20191112181215-0597a29991ca
 	github.com/openshift/source-to-image => github.com/openshift/source-to-image v0.0.0-20191031172932-56e8595e83fb

--- a/go.sum
+++ b/go.sum
@@ -468,8 +468,8 @@ github.com/opencontainers/runc v1.0.0-rc8 h1:dDCFes8Hj1r/i5qnypONo5jdOme/8HWZC/a
 github.com/opencontainers/runc v1.0.0-rc8/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runtime-spec v1.0.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.2.2/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
-github.com/openshift/api v0.0.0-0.20191112184635-86def77f6f h1:l5qG0gdw1D7jkYPMsOVzDPBq9isRN+6TEAt6os8/TYM=
-github.com/openshift/api v0.0.0-0.20191112184635-86def77f6f/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
+github.com/openshift/api v3.9.1-0.20191112184635-86def77f6f90+incompatible h1:4bwALQ79iORo/XYv7yZjvygT8ElWSdjJqGd8vZu+WBc=
+github.com/openshift/api v3.9.1-0.20191112184635-86def77f6f90+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/client-go v0.0.0-20191022152013-2823239d2298 h1:wg5VfVIEtKI0yaBNeHNM1N01EjwTGg7JW0Gp+jqnYGQ=
 github.com/openshift/client-go v0.0.0-20191022152013-2823239d2298/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
 github.com/openshift/containers-image v0.0.0-20190130162827-4bc6d24282b1 h1:4cBSRdeuBFOPA7awerBnVFHqyr9uGg5o2+Z2c1dL1e8=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -326,7 +326,7 @@ github.com/opencontainers/image-spec/specs-go
 # github.com/opencontainers/runc v1.0.0-rc8
 github.com/opencontainers/runc/libcontainer/system
 github.com/opencontainers/runc/libcontainer/user
-# github.com/openshift/api v0.0.0-20190916204813-cdbe64fb0c91 => github.com/openshift/api v0.0.0-0.20191112184635-86def77f6f
+# github.com/openshift/api v0.0.0-20190916204813-cdbe64fb0c91 => github.com/openshift/api v3.9.1-0.20191112184635-86def77f6f90+incompatible
 github.com/openshift/api/apps
 github.com/openshift/api/authorization
 github.com/openshift/api/build


### PR DESCRIPTION
Addressing:
```
$ go version
go version go1.13 linux/amd64
$ make build
go: github.com/openshift/api@v0.0.0-0.20191112184635-86def77f6f: invalid pseudo-version: revision is shorter than canonical (86def77f6f90)
make: Nothing to be done for 'build'.
```

When extracting a module from a version control system, the go command now performs additional validation on the requested version string. More information can be found at https://tip.golang.org/doc/go1.13#version-validation