### PR TITLE
Revert "Bug 1777030: Update support tools container image"

### DIFF
--- a/pkg/cli/debug/debug.go
+++ b/pkg/cli/debug/debug.go
@@ -815,7 +815,7 @@ func (o *DebugOptions) approximatePodTemplateForObject(object runtime.Object) (*
 			}
 		}
 		if len(o.Image) == 0 {
-			image = "registry.redhat.io/rhel8/support-tools"
+			image = "registry.redhat.io/rhel7/support-tools"
 		}
 		zero := int64(0)
 		isTrue := true


### PR DESCRIPTION
Reverts openshift/oc#185

Apparently we can't support RHEL8 container images on RHEL7 nodes, so this isn't going to work on RHEL7 workers.