### PR TITLE
Revert "Bug 1777031: Update support tools container image"

### DIFF
--- a/pkg/cli/debug/debug.go
+++ b/pkg/cli/debug/debug.go
@@ -765,7 +765,7 @@ func (o *DebugOptions) approximatePodTemplateForObject(object runtime.Object) (*
 			}
 		}
 		if len(o.Image) == 0 {
-			image = "registry.redhat.io/rhel8/support-tools"
+			image = "registry.redhat.io/rhel7/support-tools"
 		}
 		zero := int64(0)
 		isTrue := true


### PR DESCRIPTION
Reverts openshift/oc#196

Apparently we can't support RHEL8 container images on RHEL7 nodes, so this isn't going to work on RHEL7 workers.