### PR TITLE
release: Fix component version display in changelog

### DIFF
--- a/pkg/cli/admin/release/image_mapper.go
+++ b/pkg/cli/admin/release/image_mapper.go
@@ -410,6 +410,11 @@ type ComponentVersion struct {
 	DisplayName string
 }
 
+// String returns the version of this component.
+func (v ComponentVersion) String() string {
+	return v.Version
+}
+
 // ComponentVersions is a map of component names to semantic versions. Names are
 // lowercase alphanumeric and dashes. Semantic versions will have all build
 // labels removed, but prerelease segments are preserved.


### PR DESCRIPTION
```
* Fedora CoreOS upgraded from {31.20191213.0 } to {31.20191213.0 Fedora CoreOS}
```

should be

```
* Fedora CoreOS upgraded from 31.20191213.0 to 31.20191213.0
```

Missed this in the previous PR #209 