### PR TITLE
oc set serviceacount: fix help statements

### DIFF
--- a/pkg/cli/set/set.go
+++ b/pkg/cli/set/set.go
@@ -177,10 +177,10 @@ Update ServiceAccount of pod template resources.
 
 	setServiceaccountExample = ktemplates.Examples(`
 # Set Deployment nginx-deployment's ServiceAccount to serviceaccount1
-%[1]s set serviceaccount deployment nginx-deployment serviceaccount1
+%[1]s serviceaccount deployment nginx-deployment serviceaccount1
 
 # Print the result (in yaml format) of updated nginx deployment with serviceaccount from local file, without hitting apiserver
-%[1]s set sa -f nginx-deployment.yaml serviceaccount1 --local --dry-run -o yaml
+%[1]s sa -f nginx-deployment.yaml serviceaccount1 --local --dry-run -o yaml
 `)
 )
 


### PR DESCRIPTION
Removes the extra `set` word in the help statements for `oc set serviceacount --help`