### PR TITLE
oc version: tips about ways to get component version details

### DIFF
--- a/pkg/cli/version/version.go
+++ b/pkg/cli/version/version.go
@@ -40,7 +40,15 @@ var (
         # Print the OpenShift client, kube-apiserver, and openshift-apiserver version numbers for the current context.
         %[1]s version --short
         # Print the OpenShift client version information for the current context.
-        %[1]s version --client`)
+        %[1]s version --client
+
+        # Other ways to get version info on OpenShift cluster components:
+        # Current cluster version & upgrades are controlled by 'clusterversion.config.openshift.io' resource.
+        %[1]s get clusterversion
+        # Operators controlling cluster components are controlled by 'clusteroperators.config.openshift.io' resources.
+        %[1]s get clusteroperators
+        # Fetch build info for current version, including component repositories and commits.
+        %[1]s adm release info --commit-urls`)
 )
 
 type VersionOptions struct {
@@ -164,6 +172,7 @@ func (o *VersionOptions) Run() error {
 		if versionInfo.ServerVersion != nil {
 			fmt.Fprintf(o.Out, "Kubernetes Version: %s\n", serverVersion.GitVersion)
 		}
+		fmt.Fprintln(o.Out, "Use 'oc adm release info --commit-urls' for details on server components.")
 	case "yaml":
 		marshalled, err := yaml.Marshal(&versionInfo)
 		if err != nil {


### PR DESCRIPTION
Followup to tip from https://github.com/openshift/origin/issues/22901#issuecomment-496985180.  
I think now that openshift 4 has many moving parts, it's currently hard for end users to know how to get more details than `oc version`.
This is an attempt to make these more discoverable, especially `oc adm release info --commit-urls` which is marvellous :sparkles:.

- I don't know if outputting a tip at the end of `oc version` call is helpful or too much noise?
  (`-o yaml` and `-o json` modes not affected)
- IIUC from logging, `adm release info` works by querying Quay.  Is it likely in private/disconnected/proxied environments for `oc` to have connectivity to the cluster API but not to Quay, in which case it'll fail?
- Who has permissions to succeed with this command?  Which of these tips are likely to fail for users?
  - `oc version` itself hits `/version` (works even anonymously) and `/apis/config.openshift.io/v1/clusteroperators/openshift-apiserver` (needs system:cluster-readers), but the latter is optional.
  - `oc get clusterversion`, `oc get clusteroperators` similarly require system:cluster-readers (as of 4.2.8).
  - `oc adm release info` starts from hitting `/apis/config.openshift.io/v1/clusterversions/version`, so I guess similarly won't work for regular users?

I think the help text is good to have anyway.  Should I drop the stdout tip?