### PR TITLE
pkg/cli/admin/upgrade: Reject by-tag pullspecs

### DIFF
--- a/pkg/cli/admin/upgrade/upgrade.go
+++ b/pkg/cli/admin/upgrade/upgrade.go
@@ -122,8 +122,11 @@ func (o *Options) Complete(f kcmdutil.Factory, cmd *cobra.Command, args []string
 		if len(ref.Registry) == 0 && len(ref.Namespace) == 0 {
 			return fmt.Errorf("--to-image must be a valid image pull spec: no registry or repository specified")
 		}
-		if len(ref.ID) == 0 && len(ref.Tag) == 0 {
-			return fmt.Errorf("--to-image must be a valid image pull spec: no tag or digest specified")
+		if len(ref.Tag) > 0 {
+			return fmt.Errorf("--to-image must be a valid by-digest image pull spec: tags are vulnerable to manipulation by malicious or compromised registries")
+		}
+		if len(ref.ID) == 0 {
+			return fmt.Errorf("--to-image must be a valid by-digest image pull spec: no digest specified")
 		}
 	}
 


### PR DESCRIPTION
The cluster-version operator [requires][1] [by-digest pullspecs][2] [since verification landed in the CVO][3].  `oc` could translate by-tag pullspecs into by-digest pullspecs before updating the ClusterVersion
object, but we might want it to perform some local validation first (e.g. checking that the tag matched the version name compiled into `release-metadata`).  Until we have `oc`-side translation (which we may never have), add a client-side guard that explains the limitation so the user can find a by-digest pullspec themselves.  That might be annoying, but it's nicer than happily passing the by-tag pullspec into ClusterVersion and waiting for them to notice the generic [`the image may not be safe to use`][4] failure message.

[1]: https://github.com/openshift/cluster-version-operator/blob/a45fa12c42047b24a70d8edaa17b85a7eaf6ad38/pkg/cvo/updatepayload.go#L87-L91
[2]: https://github.com/openshift/cluster-version-operator/blob/a45fa12c42047b24a70d8edaa17b85a7eaf6ad38/pkg/verify/verify.go#L218-L220
[3]: https://github.com/openshift/cluster-version-operator/commit/55e3cb450ff5ee188dc8351fd2a045122c40ae37#diff-15212450f32771cf972f0f81d63c78c0R212
[4]: https://github.com/openshift/cluster-version-operator/blob/a45fa12c42047b24a70d8edaa17b85a7eaf6ad38/pkg/payload/task.go#L188-L189