### PR TITLE
Verify imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ image-ocp-recycler: image-ocp-cli
 update: update-generated-completions
 .PHONY: update
 
-verify: verify-cli-conventions verify-generated-completions
+verify: verify-cli-conventions verify-generated-completions verify-imports
 .PHONY: verify
 
 verify-cli-conventions:
@@ -71,6 +71,9 @@ verify-generated-completions: build
 	hack/verify-generated-completions.sh
 .PHONY: verify-generated-completions
 
+verify-imports:
+	hack/verify-imports.sh
+.PHONY: verify-imports
 
 cross-build-darwin-amd64:
 	+@GOOS=darwin GOARCH=amd64 $(MAKE) --no-print-directory build GO_BUILD_PACKAGES:=./cmd/oc GO_BUILD_FLAGS:="$(GO_BUILD_FLAGS_DARWIN)" GO_BUILD_BINDIR:=$(CROSS_BUILD_BINDIR)/darwin_amd64

--- a/hack/verify-imports.sh
+++ b/hack/verify-imports.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# This script verifies that package trees
+# conform to our import restrictions
+
+FORBIDDEN=$(
+    go list -f $'{{with $package := .ImportPath}}{{range $.Imports}}{{$package}} imports {{.}}\n{{end}}{{end}}' ./... |
+    grep "k8s.io/kubernetes" |
+    # the next imports need to disappear to be able to get rid of k/k dependency
+    grep -v "k8s.io/kubernetes/pkg/credentialprovider" |
+    grep -v "k8s.io/kubernetes/pkg/apis/rbac/v1" |
+    # below imports will be automatically gone when kubectl is in staging
+    grep -v "k8s.io/kubernetes/pkg/api/legacyscheme" |
+    grep -v "k8s.io/kubernetes/pkg/kubectl"
+)
+if [ -n "${FORBIDDEN}" ]; then
+    echo "Forbidden dependencies:"
+    echo
+    echo "${FORBIDDEN}" | sed 's/^/  /'
+    echo
+    exit 1
+fi
+
+TEST_FORBIDDEN=$(
+    go list -f $'{{with $package := .ImportPath}}{{range $.TestImports}}{{$package}} imports {{.}}\n{{end}}{{end}}' ./... |
+    grep "k8s.io/kubernetes" |
+    # the next imports need to disappear to be able to get rid of k/k dependency
+    grep -v "k8s.io/kubernetes/pkg/credentialprovider" |
+    grep -v "k8s.io/kubernetes/pkg/apis/rbac/v1" |
+    # below imports will be automatically gone when kubectl is in staging
+    grep -v "k8s.io/kubernetes/pkg/api/legacyscheme" |
+    grep -v "k8s.io/kubernetes/pkg/kubectl"
+)
+if [ -n "${TEST_FORBIDDEN}" ]; then
+    echo "Forbidden dependencies in test code:"
+    echo
+    echo "${TEST_FORBIDDEN}" | sed 's/^/  /'
+    echo
+    exit 1
+fi

--- a/tools/genman/gen_man.go
+++ b/tools/genman/gen_man.go
@@ -5,12 +5,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-
-	"k8s.io/kubernetes/cmd/genutils"
 
 	"github.com/openshift/oc/pkg/cli"
 	mangen "github.com/openshift/oc/tools/genman/md2man"
@@ -40,11 +39,23 @@ func genCmdMan(cmdName string, cmd *cobra.Command) {
 		os.Exit(1)
 	}
 
-	outDir, err := genutils.OutDir(path)
+	outDir, err := filepath.Abs(path)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to get output directory: %v\n", err)
 		os.Exit(1)
 	}
+
+	stat, err := os.Stat(outDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to get output directory: %v\n", err)
+		os.Exit(1)
+	}
+
+	if !stat.IsDir() {
+		fmt.Fprintf(os.Stderr, "failed to get output directory: %v\n", err)
+		os.Exit(1)
+	}
+	outDir = outDir + "/"
 
 	// Set environment variables used by openshift so the output is consistent,
 	// regardless of where we run.


### PR DESCRIPTION
This should help us track k/k imports ensuring nobody adds new.
If you look at `hack/verify-imports.sh` script you'll notice there's only 2 big offenders:
- `k8s.io/kubernetes/pkg/credentialprovider`
- `k8s.io/kubernetes/pkg/apis/rbac/v1`

But IIRC those need to be solved upstream too, I'll need to look into it. The next 2 imports should disappear.

/assign @sallyom 
