### PR TITLE
Bug 1788088: When "oc status" run, "panic: runtime error: invalid memory address or nil pointer dereference" is shown

### DIFF
--- a/pkg/helpers/describe/projectstatus.go
+++ b/pkg/helpers/describe/projectstatus.go
@@ -964,6 +964,9 @@ func describeStandaloneJob(f formatter, node graphview.Job) []string {
 
 func describeJobStatus(job *batchv1.Job) string {
 	timeAt := strings.ToLower(FormatRelativeTime(job.CreationTimestamp.Time))
+	if job.Spec.Completions == nil {
+		return ""
+	}
 	return fmt.Sprintf("created %s ago %d/%d completed %d running", timeAt, job.Status.Succeeded, *job.Spec.Completions, job.Status.Active)
 }
 


### PR DESCRIPTION
* Bugzilla: [When "oc status" run, "panic: runtime error: invalid memory address or nil pointer dereference" is shown](https://bugzilla.redhat.com/show_bug.cgi?id=1788016)

* Version: v4.2

* Description: 
  If job spec pointer dereference is nil, the result will be empty string instead of showing wrong result or runtime error.

e.g.>
```
// There is a result without no problem as follows.
$ oc status
In project test on server https://api.ocp4.example.com:6443

job/pi manages perl
  created 25 minutes ago 1/1 completed 0 running

// If job spec pointer is nil, the result is empty string instead of runtime error.
$ oc status
In project test on server https://api.ocp4.example.com:6443

job/pi manages perl
```
