### PR TITLE
Bug 1788016: Suppress nil pointer dereference for job spec

### DIFF
--- a/pkg/helpers/describe/projectstatus.go
+++ b/pkg/helpers/describe/projectstatus.go
@@ -964,6 +964,9 @@ func describeStandaloneJob(f formatter, node graphview.Job) []string {
 
 func describeJobStatus(job *batchv1.Job) string {
 	timeAt := strings.ToLower(formatRelativeTime(job.CreationTimestamp.Time))
+	if job.Spec.Completions == nil {
+		return ""
+	}
 	return fmt.Sprintf("created %s ago %d/%d completed %d running", timeAt, job.Status.Succeeded, *job.Spec.Completions, job.Status.Active)
 }
 


### PR DESCRIPTION
If job spec pointer dereference is nil, the result will be empty string instead of showing wrong result or runtime error.

Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1788016

/assign @sallyom 