### PR TITLE
Bug 1790802: Pass security options for `oc adm catalog mirror`

### DIFF
--- a/pkg/cli/admin/catalog/mirror.go
+++ b/pkg/cli/admin/catalog/mirror.go
@@ -205,6 +205,9 @@ func (o *MirrorCatalogOptions) Complete(cmd *cobra.Command, args []string) error
 
 	var extractor mirror.DatabaseExtractorFunc = func(from string) (string, error) {
 		e := imgextract.NewOptions(o.IOStreams)
+		e.SecurityOptions = o.SecurityOptions
+		e.FilterOptions = o.FilterOptions
+		e.ParallelOptions = o.ParallelOptions
 		e.FileDir = o.FileDir
 		if len(o.FromFileDir) > 0 {
 			e.FileDir = o.FromFileDir


### PR DESCRIPTION
These were being passed to the underlying `mirror` call, but not the underlying `extract` call, which meant that using `--insecure` would fail if talking to an untrusted registry.