### PR TITLE
Bug 1792330: collect endpoints for namespaces

### DIFF
--- a/pkg/cli/admin/inspect/namespace.go
+++ b/pkg/cli/admin/inspect/namespace.go
@@ -19,10 +19,11 @@ func namespaceResourcesToCollect() []schema.GroupResource {
 	return []schema.GroupResource{
 		// this is actually a group which collects most useful things
 		{Resource: "all"},
-		{Resource: "events"},
 		{Resource: "configmaps"},
-		{Resource: "secrets"},
+		{Resource: "events"},
+		{Resource: "endpoints"},
 		{Resource: "persistentvolumeclaims"},
+		{Resource: "secrets"},
 	}
 }
 


### PR DESCRIPTION
we want this so we can see if things like etcd have valid endpoints.

@soltysh needs a pick into 4.3, so you'll want to do a bug dance.  Also, I suspect that you really want to find a way to easily wire this into a service get, not a general namespace blast.

/assign @soltysh 