### PR TITLE
Bug 1796182: remove destination digests if present

### DIFF
--- a/pkg/cli/admin/catalog/mirror.go
+++ b/pkg/cli/admin/catalog/mirror.go
@@ -139,7 +139,17 @@ func (o *MirrorCatalogOptions) Complete(cmd *cobra.Command, args []string) error
 				klog.Warningf("couldn't parse %s, skipping mirror", from)
 				continue
 			}
-			toRef, err := imagesource.ParseDestinationReference(to)
+			// remove destination digest if present
+			toRef, err := imagesource.ParseReference(to)
+			if err != nil {
+				klog.Warningf("couldn't parse %s, skipping mirror", to)
+				continue
+			}
+			if toRef.Type == imagesource.DestinationRegistry && len(toRef.Ref.ID) != 0 {
+				to = toRef.Ref.AsRepository().String()
+			}
+
+			toRef, err = imagesource.ParseDestinationReference(to)
 			if err != nil {
 				klog.Warningf("couldn't parse %s, skipping mirror", to)
 				continue


### PR DESCRIPTION
Fixes an issue where destination image references contained digests which the imagesource parser can't handle explicitly.

This is a manual backport for an issue that was already resolved in master but could not be cleanly cherry-picked.

This resolves https://bugzilla.redhat.com/show_bug.cgi?id=1796182