### PR TITLE
Bug 1771552: Bug 1771553: Bug 1771549: Bug 1798549: oc debug

### DIFF
--- a/pkg/helpers/conditions/conditions.go
+++ b/pkg/helpers/conditions/conditions.go
@@ -7,18 +7,19 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	watchtools "k8s.io/client-go/tools/watch"
-	"k8s.io/klog"
 	krun "k8s.io/kubectl/pkg/cmd/run"
 )
 
 // ErrContainerTerminated is returned by PodContainerRunning in the intermediate
 // state where the pod indicates it's still running, but its container is already terminated
 var ErrContainerTerminated = fmt.Errorf("container terminated")
+var ErrNonZeroExitCode = fmt.Errorf("non-zero exit code from debug container")
 
 // PodContainerRunning returns false until the named container has ContainerStatus running (at least once),
 // and will return an error if the pod is deleted, runs to completion, or the container pod is not available.
-func PodContainerRunning(containerName string) watchtools.ConditionFunc {
+func PodContainerRunning(containerName string, coreClient corev1client.CoreV1Interface) watchtools.ConditionFunc {
 	return func(event watch.Event) (bool, error) {
 		switch event.Type {
 		case watch.Deleted:
@@ -28,13 +29,28 @@ func PodContainerRunning(containerName string) watchtools.ConditionFunc {
 		case *corev1.Pod:
 			switch t.Status.Phase {
 			case corev1.PodRunning, corev1.PodPending:
-				if t.Status.ContainerStatuses[0].State.Waiting != nil {
-					if t.Status.ContainerStatuses[0].State.Waiting.Reason == "CreateContainerError" {
-						klog.V(0).Info(t.Status.ContainerStatuses[0].State.Waiting.Message)
-						return false, fmt.Errorf(t.Status.ContainerStatuses[0].State.Waiting.Message)
+				for _, s := range t.Status.ContainerStatuses {
+					if s.State.Waiting != nil {
+						// Return error here if pod is pending and container status indicates a failure
+						// otherwise, user would have to wait the timeout period (15 min)
+						// for pod to exit.
+						if s.State.Waiting.Reason == "CreateContainerError" || s.State.Waiting.Reason == "ImagePullBackOff" {
+							return false, fmt.Errorf(s.State.Waiting.Message)
+						}
 					}
 				}
 			case corev1.PodFailed, corev1.PodSucceeded:
+				for _, s := range t.Status.ContainerStatuses {
+					if s.State.Terminated != nil {
+						exitCode := s.State.Terminated.ExitCode
+						if exitCode != 0 {
+							// User will get more information about non-zero exit code from pod logs retrieval
+							// in debug.go.  Here we mark the non-zero exit to separate success logs
+							// from failed container logs.
+							return false, ErrNonZeroExitCode
+						}
+					}
+				}
 				return false, krun.ErrPodCompleted
 			default:
 				return false, nil


### PR DESCRIPTION
/assign @soltysh 

1 commit:
* [Bug 1771552](https://bugzilla.redhat.com/show_bug.cgi?id=1771552)
In case of bad command passed to oc debug, user will now get information about why the command failed to run, and also will not have to wait the Timeout (15 min)  to get the output.  

2 commit:
* [Bug 1771553](https://bugzilla.redhat.com/show_bug.cgi?id=1771553)
If container exit code != 0, debug cmd should report non-zero
* [Bug 1771549](https://bugzilla.redhat.com/show_bug.cgi?id=1771549)
oc debug pod logs should go to stderr if container exit code != 0
* [Bug 1798549](https://bugzilla.redhat.com/show_bug.cgi?id=1798549)
oc debug node/nodename should fail quickly if debug pod image pull fails