### PR TITLE
Bug 1801253: Enforce golang only at 1.13.4 level

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/mtrmac/gpgme v0.0.0-20170102180018-b2432428689c // indirect
 	github.com/opencontainers/go-digest v1.0.0-rc1
 	github.com/openshift/api v0.0.0-20200205133042-34f0ec8dab87
-	github.com/openshift/build-machinery-go v0.0.0-20200206145628-a8567613b05c
+	github.com/openshift/build-machinery-go v0.0.0-20200210090402-3b072832771e
 	github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240
 	github.com/openshift/library-go v0.0.0-20200206134157-b4c763d94dcf
 	github.com/operator-framework/operator-registry v1.5.4

--- a/go.sum
+++ b/go.sum
@@ -608,8 +608,8 @@ github.com/openshift/api v0.0.0-20200116145750-0e2ff1e215dd/go.mod h1:fT6U/JfG8u
 github.com/openshift/api v0.0.0-20200205133042-34f0ec8dab87 h1:L/fZlWB7DdYCd09r9LvBa44xRH42Dx80ybxfN1h5C8Y=
 github.com/openshift/api v0.0.0-20200205133042-34f0ec8dab87/go.mod h1:fT6U/JfG8uZzemTRwZA2kBDJP5nWz7v05UHnty/D+pk=
 github.com/openshift/build-machinery-go v0.0.0-20200205161356-ef115f5adc73/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=
-github.com/openshift/build-machinery-go v0.0.0-20200206145628-a8567613b05c h1:qCxKo4e0Zsv+oQtX0a2qmG+zJOWdtuWsMwm3wUtDxjs=
-github.com/openshift/build-machinery-go v0.0.0-20200206145628-a8567613b05c/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=
+github.com/openshift/build-machinery-go v0.0.0-20200210090402-3b072832771e h1:qlMmBDqBavn7p4Y22teVEkJCnU9YAwhABHeXanAirWE=
+github.com/openshift/build-machinery-go v0.0.0-20200210090402-3b072832771e/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=
 github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240 h1:XYfJWv2Ch+qInGLDEedHRtDsJwnxyU1L8U7SY56NcA8=
 github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240/go.mod h1:4riOwdj99Hd/q+iAcJZfNCsQQQMwURnZV6RL4WHYS5w=
 github.com/openshift/containers-image v0.0.0-20190130162819-76de87591e9d h1:PSyWWs0lnNFruaF7BbQHUNxst7vsqjCNMjpy6jNJLs0=

--- a/vendor/github.com/openshift/build-machinery-go/make/lib/golang.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/lib/golang.mk
@@ -17,7 +17,7 @@ GOFMT_FLAGS ?=-s -l
 GOLINT ?=golint
 
 go_version :=$(shell $(GO) version | sed -E -e 's/.*go([0-9]+.[0-9]+.[0-9]+).*/\1/')
-GO_REQUIRED_MIN_VERSION ?=1.13.5
+GO_REQUIRED_MIN_VERSION ?=1.13.4
 ifneq "$(GO_REQUIRED_MIN_VERSION)" ""
 $(call require_minimal_version,$(GO),GO_REQUIRED_MIN_VERSION,$(go_version))
 endif

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -405,7 +405,7 @@ github.com/openshift/api/template/v1
 github.com/openshift/api/unidling/v1alpha1
 github.com/openshift/api/user
 github.com/openshift/api/user/v1
-# github.com/openshift/build-machinery-go v0.0.0-20200206145628-a8567613b05c
+# github.com/openshift/build-machinery-go v0.0.0-20200210090402-3b072832771e
 github.com/openshift/build-machinery-go
 github.com/openshift/build-machinery-go/make
 github.com/openshift/build-machinery-go/make/lib


### PR DESCRIPTION
ART builder are still on 1.13.4

picks up https://github.com/openshift/build-machinery-go/pull/7

/cc @mfojtik @soltysh 