### PR TITLE
Bug 1800464: fix(catalog): use registry image from openshift quay namespace

### DIFF
--- a/pkg/cli/admin/catalog/build.go
+++ b/pkg/cli/admin/catalog/build.go
@@ -42,9 +42,15 @@ type BuildImageOptions struct {
 	FileDir     string
 }
 
+const defaultFromImage = "quay.io/openshift/origin-operator-registry:latest"
+
 func NewBuildImageOptions(streams genericclioptions.IOStreams) *BuildImageOptions {
+	// Adjust default build opts to use an OpenShift base "from" image
+	defaults := appregistry.DefaultAppregistryBuildOptions()
+	defaults.From = defaultFromImage
+
 	return &BuildImageOptions{
-		AppregistryBuildOptions: appregistry.DefaultAppregistryBuildOptions(),
+		AppregistryBuildOptions: defaults,
 		IOStreams:               streams,
 		ParallelOptions:         imagemanifest.ParallelOptions{MaxPerRegistry: 4},
 	}


### PR DESCRIPTION
Updates the default image used in the `--from` option of `oc adm catalog build` to the official mirror.