### PR TITLE
Use relative symlinks for disk mirroring

### DIFF
--- a/pkg/cli/image/imagesource/file.go
+++ b/pkg/cli/image/imagesource/file.go
@@ -239,7 +239,7 @@ func (s *fileManifestService) Put(ctx context.Context, manifest distribution.Man
 	for _, option := range options {
 		if opt, ok := option.(distribution.WithTagOption); ok {
 			tagPath := filepath.Join(s.r.basePath, "v2", s.r.repoPath, "manifests", opt.Tag)
-			if err := atomicSymlink(tagPath, manifestPath); err != nil {
+			if err := atomicSymlink(tagPath, dgst.String()); err != nil {
 				return "", err
 			}
 		}


### PR DESCRIPTION
Presently disk mirroring via `oc adm release mirror ... --to-dir` creates absolute symlinks in the mirrored release. This means that the absolute path to manifests needs to recreated when transferring the mirrored content into a disconnected environment, or changing the symlinks from absolute to relative.

This PR instead creates relative symlinks in `v2/openshift/release/manifests`, allowing the content to be transferred without modifications.