### PR TITLE
override FileDir with FromFileDir if set in Complete

### DIFF
--- a/pkg/cli/image/mirror/mirror.go
+++ b/pkg/cli/image/mirror/mirror.go
@@ -167,8 +167,14 @@ func (o *MirrorImageOptions) Complete(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	dir := o.FileDir
+	if len(o.FromFileDir) > 0 {
+		dir = o.FromFileDir
+	}
+
 	opts := &imagesource.Options{
-		FileDir:             o.FileDir,
+		FileDir:             dir,
 		Insecure:            o.SecurityOptions.Insecure,
 		AttemptS3BucketCopy: o.AttemptS3BucketCopy,
 		RegistryContext:     registryContext,


### PR DESCRIPTION
`Complete` gives error `error: you must specify at least one source image to pull and the destination to push to as SRC=DST or SRC DST [DST2 DST3 ...]` if only `--from-dir` is specified even though it is supposed to override `--dir`.

This adds the override logic to Complete like what happens during `Run().plan.Repository`.

