### PR TITLE
`set volume` does not work with `--local`

### DIFF
--- a/pkg/cli/set/volume.go
+++ b/pkg/cli/set/volume.go
@@ -494,6 +494,7 @@ func (o *VolumeOptions) RunVolume() error {
 				return err
 			}
 		}
+		return nil
 	}
 
 	allErrs := []error{}


### PR DESCRIPTION
When `--local` is set `info.Mapping` is nil, which causes panics in the
command. Use the external patches method and remove the old helper that no
longer works, and fix places in the error path where we assume mapping is
present. This was missed when the upstream changed.

Also fix bug where --local causes the object to be printed twice.

Needs a test/cmd test