### PR TITLE
release: Changelog fails when new image added

### DIFF
--- a/pkg/cli/admin/release/info.go
+++ b/pkg/cli/admin/release/info.go
@@ -1761,6 +1761,10 @@ func releaseDiffContentChanges(diff *ReleaseDiff) ([]CodeChange, []ImageChange, 
 		oldRepo, newRepo := from.Annotations[annotationBuildSourceLocation], to.Annotations[annotationBuildSourceLocation]
 		oldCommit, newCommit := from.Annotations[annotationBuildSourceCommit], to.Annotations[annotationBuildSourceCommit]
 
+		if len(newRepo) == 0 || len(oldRepo) == 0 {
+			continue
+		}
+
 		var alternateRepos []string
 		if len(oldRepo) > 0 && oldRepo != newRepo {
 			alternateRepos = append(alternateRepos, oldRepo)


### PR DESCRIPTION
We added a new image and the changelog generation failed on that
repo because we had no `oldRepo` set, which caused the command
to exit in 4.5. This guards the loop to exclude those from change
log generation, which will keep them on the new images section.

The `special-resource-operator` is breaking this right now in changelogs

https://openshift-release.svc.ci.openshift.org/releasestream/4.5.0-0.ci/release/4.5.0-0.ci-2020-03-09-193951?from=4.5.0-0.ci-2020-03-08-014740

Unable to show full changelog: could not generate a changelog: fatal: repository '' does not exist error: exit status 128

With this PR it succeeds with:

```
### New images

* [special-resource-operator](https://github.com/openshift-psap/special-resource-operator) git [b9bcdca4](https://github.com/openshift-psap/special-resource-operator/commit/b9bcdca4db2fd4ffb2ab5e36c5ddfcf9f9b91325) `sha256:ad00a0cd1710a3c72971d94728809b24664f3f021fc1f3e178f327270e8b76db`
```

To repro,

```
oc adm release info --changelog ~/projects/origin2/ registry.svc.ci.openshift.org/ocp/release:4.5.0-0.ci-2020-03-08-014740 registry.svc.ci.openshift.org/ocp/release:4.5.0-0.ci-2020-03-09-193951
```