### PR TITLE
pkg/cli/image/imagesource/file: Use relative paths in symlinks

### DIFF
--- a/pkg/cli/image/imagesource/file.go
+++ b/pkg/cli/image/imagesource/file.go
@@ -210,10 +210,15 @@ func atomicLink(path string, sourcePath string) error {
 // atomicWrite performs an atomic symlink and move of a file. It expects the destination
 // to be a file or to be missing.
 func atomicSymlink(path string, sourcePath string) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
 		return err
 	}
-	if err := os.Symlink(sourcePath, path+".download"); err != nil {
+	relSource, err := filepath.Rel(dir, sourcePath)
+	if err != nil {
+		return err
+	}
+	if err := os.Symlink(relSource, path+".download"); err != nil {
 		return err
 	}
 	return os.Rename(path+".download", path)


### PR DESCRIPTION
Fix:

```console
$ oc version --client
Client Version: openshift-clients-4.3.0-201910250623-88-g6a937dfe
$ oc adm release mirror --to-dir=mirror quay.io/openshift-release-dev/ocp-release:4.3.0-x86_64
To upload local images to a registry, run:

    oc image mirror --from-dir=mirror file://openshift/release:4.3.0* REGISTRY/REPOSITORY

$ oc image mirror --from-dir=mirror file://openshift/release:4.3.0* registry.svc.ci.openshift.org/wking/whatever
error: you must specify at least one source image to pull and the destination to push to as SRC=DST or SRC DST [DST2 DST3 ...]
$ ls -l mirror/v2/openshift/release/manifests/
total 808
lrwxrwxrwx. 1 wking wking  109 Mar 12 21:27 4.3.0 -> mirror/v2/openshift/release/manifests/sha256:3a516480dfd68e0f87f702b4d7bdd6f6a0acfdac5cd2e9767b838ceede34d70d
...
```

when that symlinks should really be `4.3.0` -> `sha256:3a516480...` (in the same directory).

This allows for relative paths in `--to-dir`, but even with absolute paths in `--to-dir`, there is a benefit to creating a directory structure that can be shifted around (e.g. unmounted and then remounted to a different location) without breaking the symlinks.