### PR TITLE
images/tools: Don't change user

### DIFF
--- a/images/tools/Dockerfile
+++ b/images/tools/Dockerfile
@@ -41,8 +41,6 @@ RUN INSTALL_PKGS="\
   # numactl \
   # numactl-devel \
 
-# The tools image doesn't require a root user.
-USER 1001
 CMD ["/usr/bin/bash"]
 LABEL io.k8s.display-name="OpenShift Tools" \
       io.k8s.description="Contains debugging and diagnostic tools for use with an OpenShift cluster." \


### PR DESCRIPTION
It's not truly necessary and complicates downstream images.  I broke origin tests because it tries to clear the root passwd user.