### PR TITLE
image/mirror: Allow `--continue-on-error` for mirror

### DIFF
--- a/contrib/completions/bash/oc
+++ b/contrib/completions/bash/oc
@@ -13239,6 +13239,8 @@ _oc_image_mirror()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--continue-on-error")
+    local_nonpersistent_flags+=("--continue-on-error")
     flags+=("--dir=")
     two_word_flags+=("--dir")
     local_nonpersistent_flags+=("--dir=")

--- a/contrib/completions/zsh/oc
+++ b/contrib/completions/zsh/oc
@@ -13381,6 +13381,8 @@ _oc_image_mirror()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--continue-on-error")
+    local_nonpersistent_flags+=("--continue-on-error")
     flags+=("--dir=")
     two_word_flags+=("--dir")
     local_nonpersistent_flags+=("--dir=")


### PR DESCRIPTION
Mirrors are complex and it should be possible to mirror "as much as
possible". Adding the flag will still exit with error, but we will
go the full distance.