### PR TITLE
debug: Correctly default the tools image now that it is on the cluster

### DIFF
--- a/pkg/cli/debug/debug.go
+++ b/pkg/cli/debug/debug.go
@@ -865,7 +865,7 @@ func (o *DebugOptions) approximatePodTemplateForObject(object runtime.Object) (*
 				image = istag.Image.DockerImageReference
 			}
 		}
-		if len(o.Image) == 0 {
+		if len(image) == 0 {
 			image = "registry.redhat.io/rhel7/support-tools"
 		}
 		zero := int64(0)


### PR DESCRIPTION
Now debug uses openshift/tools:latest which is provided by the payload.