### PR TITLE
Bug 1825791: Fix a large number of silly things in login

### DIFF
--- a/pkg/cli/login/loginoptions.go
+++ b/pkg/cli/login/loginoptions.go
@@ -373,7 +373,7 @@ func (o *LoginOptions) SaveConfig() (bool, error) {
 		globalExistedBefore = false
 	}
 
-	newConfig, err := cliconfig.CreateConfig(o.Project, o.Config)
+	newConfig, err := cliconfig.CreateConfig(o.Project, o.Username, o.Config)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/cli/login/loginoptions.go
+++ b/pkg/cli/login/loginoptions.go
@@ -269,7 +269,7 @@ func (o *LoginOptions) gatherProjectInfo() error {
 	projectsList, err := projectClient.Projects().List(context.TODO(), metav1.ListOptions{})
 	// if we're running on kube (or likely kube), just set it to "default"
 	if kerrors.IsNotFound(err) || kerrors.IsForbidden(err) {
-		fmt.Fprintf(o.Out, "Using \"default\".  You can switch projects with:\n\n '%s project <projectname>'\n", o.CommandName)
+		fmt.Fprintf(o.Out, "Using \"default\" namespace.  You can switch namespaces with:\n\n %s project <projectname>\n", o.CommandName)
 		o.Project = "default"
 		return nil
 	}

--- a/pkg/cli/login/loginoptions.go
+++ b/pkg/cli/login/loginoptions.go
@@ -80,18 +80,16 @@ func NewLoginOptions(streams genericclioptions.IOStreams) *LoginOptions {
 
 // Gather all required information in a comprehensive order.
 func (o *LoginOptions) GatherInfo() error {
+	defer o.prepareAndDisplayMOTD()
+
 	if err := o.gatherAuthInfo(); err != nil {
-		// Display MOTD even if authentication failed
-		o.prepareAndDisplayMOTD()
 		return err
 	}
 	if err := o.gatherProjectInfo(); err != nil {
-		// Display MOTD even project info gathering failed
-		o.prepareAndDisplayMOTD()
 		return err
 	}
 
-	return o.prepareAndDisplayMOTD()
+	return nil
 }
 
 // getClientConfig returns back the current clientConfig as we know it.  If there is no clientConfig, it builds one with enough information

--- a/pkg/helpers/kubeconfig/smart_merge.go
+++ b/pkg/helpers/kubeconfig/smart_merge.go
@@ -1,7 +1,6 @@
 package kubeconfig
 
 import (
-	"context"
 	"crypto/x509"
 	"fmt"
 	"net"
@@ -12,13 +11,9 @@ import (
 
 	x509request "k8s.io/apiserver/pkg/authentication/request/x509"
 
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/third_party/forked/golang/netutil"
 	restclient "k8s.io/client-go/rest"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-
-	userv1typedclient "github.com/openshift/client-go/user/clientset/versioned/typed/user/v1"
 )
 
 // getClusterNicknameFromConfig returns host:port of the clientConfig.Host, with .'s replaced by -'s
@@ -34,73 +29,26 @@ func getClusterNicknameFromConfig(clientCfg *restclient.Config) (string, error) 
 	return strings.Replace(hostPort, ".", "-", -1), nil
 }
 
-// getUserNicknameFromConfig returns "username(as known by the server)/getClusterNicknameFromConfig".  This allows tab completion for switching users to
-// work easily and obviously.
-func getUserNicknameFromConfig(clientCfg *restclient.Config) (string, error) {
-	userPartOfNick, err := getUserPartOfNickname(clientCfg)
-	if err != nil {
-		return "", err
-	}
-
-	clusterNick, err := getClusterNicknameFromConfig(clientCfg)
-	if err != nil {
-		return "", err
-	}
-
-	return userPartOfNick + "/" + clusterNick, nil
-}
-
-func getUserPartOfNickname(clientCfg *restclient.Config) (string, error) {
-	userClient, err := userv1typedclient.NewForConfig(clientCfg)
-	if err != nil {
-		return "", err
-	}
-	userInfo, err := userClient.Users().Get(context.TODO(), "~", metav1.GetOptions{})
-	if kerrors.IsNotFound(err) || kerrors.IsForbidden(err) {
-		// if we're talking to kube (or likely talking to kube), take a best guess consistent with login
-		switch {
-		case len(clientCfg.BearerToken) > 0:
-			userInfo.Name = clientCfg.BearerToken
-		case len(clientCfg.Username) > 0:
-			userInfo.Name = clientCfg.Username
-		}
-	} else if err != nil {
-		return "", err
-	}
-
-	return userInfo.Name, nil
-}
-
 // getContextNicknameFromConfig returns "namespace/getClusterNicknameFromConfig/username(as known by the server)".  This allows tab completion for switching projects/context
 // to work easily.  First tab is the most selective on project.  Second stanza in the next most selective on cluster name.  The chances of a user trying having
 // one projects on a single server that they want to operate against with two identities is low, so username is last.
-func getContextNicknameFromConfig(namespace string, clientCfg *restclient.Config) (string, error) {
-	userPartOfNick, err := getUserPartOfNickname(clientCfg)
-	if err != nil {
-		return "", err
-	}
-
+func getContextNicknameFromConfig(namespace, userName string, clientCfg *restclient.Config) (string, error) {
 	clusterNick, err := getClusterNicknameFromConfig(clientCfg)
 	if err != nil {
 		return "", err
 	}
 
-	return namespace + "/" + clusterNick + "/" + userPartOfNick, nil
+	return namespace + "/" + clusterNick + "/" + userName, nil
 }
 
 // CreateConfig takes a clientCfg and builds a config (kubeconfig style) from it.
-func CreateConfig(namespace string, clientCfg *restclient.Config) (*clientcmdapi.Config, error) {
+func CreateConfig(namespace, userName string, clientCfg *restclient.Config) (*clientcmdapi.Config, error) {
 	clusterNick, err := getClusterNicknameFromConfig(clientCfg)
 	if err != nil {
 		return nil, err
 	}
 
-	userNick, err := getUserNicknameFromConfig(clientCfg)
-	if err != nil {
-		return nil, err
-	}
-
-	contextNick, err := getContextNicknameFromConfig(namespace, clientCfg)
+	contextNick, err := getContextNicknameFromConfig(namespace, userName, clientCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +65,7 @@ func CreateConfig(namespace string, clientCfg *restclient.Config) (*clientcmdapi
 	if len(credentials.ClientKey) == 0 {
 		credentials.ClientKeyData = clientCfg.TLSClientConfig.KeyData
 	}
-	config.AuthInfos[userNick] = credentials
+	config.AuthInfos[userName] = credentials
 
 	cluster := clientcmdapi.NewCluster()
 	cluster.Server = clientCfg.Host
@@ -130,7 +78,7 @@ func CreateConfig(namespace string, clientCfg *restclient.Config) (*clientcmdapi
 
 	context := clientcmdapi.NewContext()
 	context.Cluster = clusterNick
-	context.AuthInfo = userNick
+	context.AuthInfo = userName
 	context.Namespace = namespace
 	config.Contexts[contextNick] = context
 	config.CurrentContext = contextNick

--- a/pkg/helpers/project/whoami.go
+++ b/pkg/helpers/project/whoami.go
@@ -2,6 +2,9 @@ package project
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,9 +26,11 @@ func WhoAmI(clientConfig *restclient.Config) (*userv1.User, error) {
 	if kerrors.IsNotFound(err) || kerrors.IsForbidden(err) {
 		switch {
 		case len(clientConfig.BearerToken) > 0:
-			// the user has already been willing to provide the token on the CLI, so they probably
-			// don't mind using it again if they switch to and from this user
-			return &userv1.User{ObjectMeta: metav1.ObjectMeta{Name: clientConfig.BearerToken}}, nil
+			// convert their token to a hash instead of printing it
+			h := sha256.New()
+			h.Write([]byte(clientConfig.BearerToken))
+			tokenName := fmt.Sprintf("token-%s", base64.RawURLEncoding.EncodeToString(h.Sum(nil)[:9]))
+			return &userv1.User{ObjectMeta: metav1.ObjectMeta{Name: tokenName}}, nil
 
 		case len(clientConfig.Username) > 0:
 			return &userv1.User{ObjectMeta: metav1.ObjectMeta{Name: clientConfig.Username}}, nil


### PR DESCRIPTION
While trying to use login with tokens (for `oc adm oauth create token`) I realized we had atrophied a bit and it deserved a cleanup.

The primary fix is avoiding printing the token to the screen (the comment was optimistic) and the secondary fix is calling `users.Get("~")` repeatedly to get the same darn data.