### PR TITLE
oc rsh: properly shadow position of --

### DIFF
--- a/pkg/cli/rsh/rsh.go
+++ b/pkg/cli/rsh/rsh.go
@@ -133,6 +133,16 @@ func (o *RshOptions) Complete(f kcmdutil.Factory, cmd *cobra.Command, args []str
 		o.TTY = term.IsTerminal(o.In)
 	}
 
+	// Value of argsLenAtDash is -1 since cmd.ArgsLenAtDash() assumes all the flags
+	// of flag.FlagSet were parsed. The opposite is true. Thus, it needs to be computed manually.
+	// In case the command is present, the first item in args is a pod name,
+	// the rest is a command and its arguments.
+	// Kubectl exec expects the command to be preceded by '--'.
+	// Oc rsh always provides the command as the second item of args.
+	if len(args) > 1 {
+		argsLenAtDash = 1
+	}
+
 	if err := o.ExecOptions.Complete(f, cmd, args, argsLenAtDash); err != nil {
 		return err
 	}


### PR DESCRIPTION
As of k8s 1.18, kubectl exec expects the command preceded by '--' as seen from the help:
```
Usage:
  kubectl exec (POD | TYPE/NAME) [-c CONTAINER] [flags] -- COMMAND [args...] [options]
```

If '--' is not present, kubectl exec prints the following informative message:
```
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl kubectl exec [POD] -- [COMMAND] instead.
```

The message is still informative though given oc rsh does not require additional '--',
it's confusing.

In more detail 1.18 rebase brings the following lines in kubectl exec code:
```
if argsLenAtDash > -1 {
	p.Command = argsIn[argsLenAtDash:]
} else if len(argsIn) > 1 {
	fmt.Fprint(p.ErrOut, "kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl kubectl exec [POD] -- [COMMAND] instead.\n")
	p.Command = argsIn[1:]
} else if len(argsIn) > 0 && len(p.FilenameOptions.Filenames) != 0 {
	fmt.Fprint(p.ErrOut, "kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl kubectl exec [POD] -- [COMMAND] instead.\n")
	p.Command = argsIn[0:]
	p.ResourceName = ""
}
```

From `oc rsh` help:
```
$ ./oc rsh --help
Open a remote shell session to a container
 ...
Options:
  -c, --container='': Container name; defaults to first container
  -T, --no-tty=false: Disable pseudo-terminal allocation
      --pod-running-timeout=1m0s: The length of time (like 5s, 2m, or 3h, higher than zero) to wait
until at least one pod is running
      --shell='/bin/sh': Path to the shell command
  -t, --tty=false: Force a pseudo-terminal to be allocated

Use "oc options" for a list of global command-line options (applies to all commands).
```
there's no `--filename` option present (as it in `kubectl exec`), Thus, no need to assume `else if len(argsIn) > 0 && len(p.FilenameOptions.Filenames) != 0` branch gets executed. Leaving only `else if len(argsIn) > 1` case which, when `argsLenAtDash` is set to `1`, the first if branch is executed and thus skipping the deprecated message.