### PR TITLE
Bug 1821648: Zeroing BearerTokenFile for prune

### DIFF
--- a/pkg/cli/admin/prune/images/images.go
+++ b/pkg/cli/admin/prune/images/images.go
@@ -834,6 +834,7 @@ func getRegistryClient(clientConfig *restclient.Config, registryCABundle string,
 
 	// zero out everything we don't want to use
 	registryClientConfig.BearerToken = ""
+	registryClientConfig.BearerTokenFile = ""
 	registryClientConfig.CertFile = ""
 	registryClientConfig.CertData = []byte{}
 	registryClientConfig.KeyFile = ""


### PR DESCRIPTION
Kubernetes client-go requires only one authentication method to be present
therefore this patch zeroes the content of BearerTokenFile as basic auth
is used during prune.

In a nutshell: or we use token based authentication or basic auth, never
both at the same time.

This is a version of https://github.com/openshift/oc/pull/257