### PR TITLE
Bug 1822253: Remove invalid character from manifest meta.name field

### DIFF
--- a/pkg/cli/admin/catalog/mirror.go
+++ b/pkg/cli/admin/catalog/mirror.go
@@ -272,6 +272,8 @@ func WriteManifests(name, dir string, mapping map[string]string) error {
 		}
 	}()
 
+	name = strings.ReplaceAll(name, "/", "-")
+
 	icsp := operatorv1alpha1.ImageContentSourcePolicy{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: operatorv1alpha1.GroupVersion.String(),


### PR DESCRIPTION
```oc adm catalog mirror``` uses the path from source registry to generate the
field "meta.name" including all characters, even ones invalid for field meta.name

This patch replaces / by -

Really starting golang and ocp. I don't know if there is some builtin function to sanitize this field.

fix #378