### PR TITLE
Bug 1819688: login: choose the CAs based on the remote server cert

### DIFF
--- a/pkg/cli/login/loginoptions_test.go
+++ b/pkg/cli/login/loginoptions_test.go
@@ -3,6 +3,7 @@ package login
 import (
 	"crypto/tls"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -275,7 +276,7 @@ func TestPreserveErrTypeAuthInfo(t *testing.T) {
 	invoked := make(chan struct{}, 3)
 	oauthResponse := []byte{}
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		select {
 		case invoked <- struct{}{}:
 			t.Logf("saw %s request for path: %s", r.Method, r.URL.String())
@@ -313,6 +314,9 @@ func TestPreserveErrTypeAuthInfo(t *testing.T) {
 
 		Config: &restclient.Config{
 			Host: server.URL,
+			TLSClientConfig: restclient.TLSClientConfig{
+				CAData: pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.Certificate().Raw}),
+			},
 		},
 
 		IOStreams: genericclioptions.NewTestIOStreamsDiscard(),

--- a/pkg/helpers/tokencmd/request_token.go
+++ b/pkg/helpers/tokencmd/request_token.go
@@ -397,39 +397,54 @@ func request(rt http.RoundTripper, requestURL string, requestHeaders http.Header
 	return rt.RoundTrip(req)
 }
 
+// transportWithSystemRoots tries to retrieve the serving certificate from the
+// issuer, validates it against the system roots and if the validation passes,
+// returns transport using just system roots, otherwise it returns a transport
+// that uses the CA from kubeconfig
 func transportWithSystemRoots(issuer string, clientConfig *restclient.Config) (http.RoundTripper, error) {
-	// copy the config so we can freely mutate it
-	configWithSystemRoots := restclient.CopyConfig(clientConfig)
-
-	// explicitly unset CA cert information
-	// this will make the transport use the system roots or OS specific verification
-	// this is required to have reasonable behavior on windows (cannot get system roots)
-	// in general there is no good with to say "I want system roots plus this CA bundle"
-	// so we just try system roots first before using the kubeconfig CA bundle
-	configWithSystemRoots.CAFile = ""
-	configWithSystemRoots.CAData = nil
-
-	systemRootsRT, err := restclient.TransportFor(configWithSystemRoots)
+	issuerURL, err := url.Parse(issuer)
 	if err != nil {
 		return nil, err
 	}
 
-	// build a request to probe the OAuth server CA
-	req, err := http.NewRequest(http.MethodHead, issuer, nil)
+	// perform the retrieval with insecure transport, otherwise oauth-server
+	// logs remote tls error which is confusing during troubleshooting
+	config := tls.Config{
+		Certificates:       []tls.Certificate{},
+		InsecureSkipVerify: true,
+		ServerName:         issuerURL.Hostname(),
+	}
+
+	port := issuerURL.Port()
+	if len(port) == 0 {
+		port = "443"
+	}
+	conn, err := tls.Dial("tcp", net.JoinHostPort(issuerURL.Hostname(), port), &config)
 	if err != nil {
 		return nil, err
 	}
+	conn.Close()
 
-	// see if get a certificate error when using the system roots
-	// we perform the check using this transport (instead of the kubeconfig based one)
-	// because it is most likely to work with a route (which is what the OAuth server uses in 4.0+)
-	// note that both transports are "safe" to use (in the sense that they have valid TLS configurations)
-	// thus the fallback case is not an "unsafe" operation
-	_, err = systemRootsRT.RoundTrip(req)
+	_, err = verifyServerCertChain(issuerURL.Hostname(), conn.ConnectionState().PeerCertificates)
 	switch err.(type) {
 	case nil:
+		// copy the config so we can freely mutate it
+		configWithSystemRoots := restclient.CopyConfig(clientConfig)
+
+		// explicitly unset CA cert information
+		// this will make the transport use the system roots or OS specific verification
+		// this is required to have reasonable behavior on windows (cannot get system roots)
+		// in general there is no good with to say "I want system roots plus this CA bundle"
+		// so we just try system roots first before using the kubeconfig CA bundle
+		configWithSystemRoots.CAFile = ""
+		configWithSystemRoots.CAData = nil
+
 		// no error meaning the system roots work with the OAuth server
 		klog.V(4).Info("using system roots as no error was encountered")
+		systemRootsRT, err := restclient.TransportFor(configWithSystemRoots)
+		if err != nil {
+			return nil, err
+		}
 		return systemRootsRT, nil
 	case x509.UnknownAuthorityError, x509.HostnameError, x509.CertificateInvalidError, x509.SystemRootsError,
 		tls.RecordHeaderError, *net.OpError:
@@ -448,4 +463,22 @@ func transportWithSystemRoots(issuer string, clientConfig *restclient.Config) (h
 		klog.V(4).Infof("unexpected error during system roots probe: %v", err)
 		return nil, err
 	}
+}
+
+// verifyCertChain uses the system trust bundle in order to perform validation
+// of a certificate chain
+func verifyServerCertChain(dnsName string, chain []*x509.Certificate) ([][]*x509.Certificate, error) {
+	if len(chain) == 0 {
+		return nil, fmt.Errorf("the server presented an empty certificate chain")
+	}
+	intermediates := x509.NewCertPool()
+
+	for _, c := range chain[1:] {
+		intermediates.AddCert(c)
+	}
+
+	return chain[0].Verify(x509.VerifyOptions{
+		Intermediates: intermediates,
+		DNSName:       dnsName,
+	})
 }


### PR DESCRIPTION
The previous check to help decide which CA to use when
performing a login is performed in such a way that fails in most
cases, causing the oauth-server to log `remote error: bad certificate`.

This commit fixes that by retrieving the server cert, closing the
connection and extracting the logic for certificate verification
locally without ruining the handshake with the server.