### PR TITLE
make unit tests not ask for gpg store password

### DIFF
--- a/pkg/helpers/source-to-image/git/testhelpers.go
+++ b/pkg/helpers/source-to-image/git/testhelpers.go
@@ -29,7 +29,17 @@ func CreateLocalGitDirectory() (string, error) {
 		return "", err
 	}
 
-	err = cr.RunWithOptions(cmd.CommandOpts{Dir: dir, EnvAppend: []string{"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test", "GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test"}}, "git", "commit", "-m", "testcommit")
+	err = cr.RunWithOptions(
+		cmd.CommandOpts{
+			Dir: dir,
+			EnvAppend: []string{
+				"GIT_AUTHOR_NAME=test",
+				"GIT_AUTHOR_EMAIL=test@test",
+				"GIT_COMMITTER_NAME=test",
+				"GIT_COMMITTER_EMAIL=test@test",
+			},
+		},
+		"git", "commit", "--no-gpg-sign", "-m", "testcommit")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
The tests are attempting to perform a git commit but that might
ask people for their password when running `make test-unit` if
they have signing globally enabled. Add "--no-gpg-sign" to
prevent this.