### PR TITLE
Bug 1826533: pkg/cli/admin/upgrade: Warn when --force is used

### DIFF
--- a/pkg/cli/admin/upgrade/upgrade.go
+++ b/pkg/cli/admin/upgrade/upgrade.go
@@ -55,9 +55,9 @@ func New(f kcmdutil.Factory, parentName string, streams genericclioptions.IOStre
 			must pass --allow-upgrade-with-warnings to proceed (see note below on the implications).
 
 			If the cluster reports that the upgrade should not be performed due to a content
-			verification error or an operator blocking upgrades, please verify those errors. Do not
-			upgrade to images that are not appropriately signed without understanding the risks of
-			upgrading your cluster to untrusted code. If you must override this protection use
+			verification error or update precondition failures such as operators blocking upgrades.
+			Do not upgrade to images that are not appropriately signed without understanding the risks
+			of upgrading your cluster to untrusted code. If you must override this protection use
 			the --force flag.
 
 			If there are no versions available, or a bug in the cluster version operator prevents
@@ -185,6 +185,7 @@ func (o *Options) Run() error {
 		update := cv.Status.AvailableUpdates[len(cv.Status.AvailableUpdates)-1]
 		if o.Force {
 			update.Force = true
+			fmt.Fprintln(o.ErrOut, "warning: --force overrides cluster verification of your supplied release image and waives any update precondition failures.")
 		}
 
 		cv.Spec.DesiredUpdate = &update
@@ -260,6 +261,7 @@ func (o *Options) Run() error {
 		switch {
 		case o.Force:
 			update.Force = true
+			fmt.Fprintln(o.ErrOut, "warning: --force overrides cluster verification of your supplied release image and waives any update precondition failures.")
 		case !o.AllowUpgradeWithWarnings:
 			if err := checkForUpgrade(cv); err != nil {
 				return err


### PR DESCRIPTION
Also soften "operator blocking upgrades" to the more generic "update precondition failures", because the cluster-version operator may learn about other preconditions with time.  The warning is intended to raise awareness about `--force` being an "I've exhausted all other options and performed a bunch of undocumented manual verification" safety valve, and not something that anyone should be doing frequently.