### PR TITLE
pkg/cli/admin/upgrade: Delegate to update-approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,12 @@
+# See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#OWNERS_ALIASES
+
+aliases:
+  update-approvers:
+    - abhinavdahiya
+    - crawford
+    - jottofar
+    - LalatenduMohanty
+    - sdodson
+    - smarterclayton
+    - vrutkovs
+    - wking

--- a/pkg/cli/admin/upgrade/OWNERS
+++ b/pkg/cli/admin/upgrade/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - update-approvers


### PR DESCRIPTION
These to subcommands interact with the cluster-version operator, which is now maintained by the updates team.  I'm seeding the alias with the content from [the CVO][1].  I've left the `component` property (added to the root `OWNERS` in e83f2ac9ae, #367) off for now, because the tooling around that only consumes entries at the repo level.

[1]: https://github.com/openshift/cluster-version-operator/blob/914467c03b5bc25dbe4c9295c420fdb2598db821/OWNERS