### PR TITLE
pkg/cli/admin/upgrade: Display the upstream and channel

### DIFF
--- a/pkg/cli/admin/upgrade/upgrade.go
+++ b/pkg/cli/admin/upgrade/upgrade.go
@@ -302,6 +302,9 @@ func (o *Options) Run() error {
 		} else {
 			fmt.Fprintln(o.ErrOut, "warning: No current status info, see `oc describe clusterversion` for more details")
 		}
+		if len(cv.Spec.Upstream) > 0 && len(cv.Spec.Channel) > 0 { // if these are unset, we notify the user via RetrievedUpdates handling below
+			fmt.Fprintf(o.Out, "Cluster is watching %s for updates in channel %s\n", cv.Spec.Upstream, cv.Spec.Channel)
+		}
 		fmt.Fprintln(o.Out)
 
 		if len(cv.Status.AvailableUpdates) > 0 {


### PR DESCRIPTION
When users want to know what channel they're in, make life more convienent then [pointing them at a bare `oc get clusterversion`][1].

[1]: https://github.com/openshift/openshift-docs/blame/c710f7cf5fe8327d6d4275b8a894efb08cc80342/modules/update-upgrading-cli.adoc#L34-L38