### PR TITLE
Bug 1823143: Try user-given registry/repository for oc adm release extract|info|mirror  before defaulting to referenced image

### DIFF
--- a/pkg/cli/admin/release/helpers.go
+++ b/pkg/cli/admin/release/helpers.go
@@ -1,0 +1,37 @@
+package release
+
+import (
+	"context"
+
+	"k8s.io/klog"
+
+	"github.com/openshift/library-go/pkg/image/reference"
+	"github.com/openshift/library-go/pkg/image/registryclient"
+	"github.com/openshift/oc/pkg/cli/image/imagesource"
+	imagemanifest "github.com/openshift/oc/pkg/cli/image/manifest"
+)
+
+func verifyImageExists(fromContext *registryclient.Context, fileDir string, insecure bool, include imagemanifest.FilterFunc, ref reference.DockerImageReference) bool {
+	from := imagesource.TypedImageReference{Type: imagesource.DestinationRegistry, Ref: ref}
+	ctx := context.Background()
+	fromOptions := &imagesource.Options{
+		FileDir:         fileDir,
+		Insecure:        insecure,
+		RegistryContext: fromContext,
+	}
+
+	repo, err := fromOptions.Repository(ctx, from)
+	if err != nil {
+		klog.V(2).Infof("unable to connect to image repository %s: %v", from.String(), err)
+		return false
+	}
+	_, _, err = imagemanifest.FirstManifest(ctx, from.Ref, repo, include)
+	if err != nil {
+		if imagemanifest.IsImageNotFound(err) {
+			return false
+		}
+		klog.V(2).Infof("unable to read image %s: %v", from.String(), err)
+		return false
+	}
+	return true
+}

--- a/pkg/cli/admin/release/info.go
+++ b/pkg/cli/admin/release/info.go
@@ -775,6 +775,28 @@ func (o *InfoOptions) LoadReleaseInfo(image string, retrieveImages bool) (*Relea
 				errs = append(errs, err)
 				return true, nil
 			}
+			// try to verify user-passed image first, in case of mirrored images this will
+			// exist, and if so, use this instead of the release image-reference. If this doesn't
+			// exist, proceed with release image-reference from the readReleaseImageReference above
+			newRef := ref.Ref.AsRepository()
+			// Try the registry/repo passed from the user first.  If image does not exist,
+			// proceed with the release info from the release image-references, from readReleaseImageReference above
+			for _, tag := range is.Spec.Tags {
+				// tagRef is the sha of each component in the release image-reference.
+				// If can't get digest ID, skip this tag, this happens when user has built a payload by
+				// replacing component images in the release with a new image
+				tagRef, err := imagereference.Parse(tag.From.Name)
+				if err != nil {
+					continue
+				}
+				newRef.ID = tagRef.ID
+				// If the user-given registry/repo/name:digest exists, replace with that, if not keep the
+				// is.Spec.Tag from release image-reference
+				if verifyImageExists(opts, newRef) {
+					tag.From.Name = newRef.String()
+				}
+			}
+
 			release.References = is
 		case "release-metadata":
 			data, err := ioutil.ReadAll(r)
@@ -873,6 +895,35 @@ func (o *InfoOptions) LoadReleaseInfo(image string, retrieveImages bool) (*Relea
 	sort.Strings(release.Warnings)
 
 	return release, nil
+}
+
+func verifyImageExists(opts *extract.Options, ref imagereference.DockerImageReference) bool {
+	from := imagesource.TypedImageReference{Type: imagesource.DestinationRegistry, Ref: ref}
+	ctx := context.Background()
+	fromContext, err := opts.SecurityOptions.Context()
+	if err != nil {
+		return false
+	}
+	fromOptions := &imagesource.Options{
+		FileDir:         opts.FileDir,
+		Insecure:        opts.SecurityOptions.Insecure,
+		RegistryContext: fromContext,
+	}
+
+	repo, err := fromOptions.Repository(ctx, from)
+	if err != nil {
+		klog.V(2).Infof("unable to connect to image repository %s: %v", from.String(), err)
+		return false
+	}
+	_, _, err = imagemanifest.FirstManifest(ctx, from.Ref, repo, opts.FilterOptions.Include)
+	if err != nil {
+		if imagemanifest.IsImageNotFound(err) {
+			return false
+		}
+		klog.V(2).Infof("unable to read image %s: %v", from.String(), err)
+		return false
+	}
+	return true
 }
 
 func readComponentVersions(is *imageapi.ImageStream) (ComponentVersions, []error) {


### PR DESCRIPTION
When working with mirrored release payloads, a release from a mirrored registry,
`mylocalregistry/ocp/release:4.5.0-0.nightly-2020-04-18-093630` mirrored from
`registry.svc.ci.openshift.org/ocp/release:4.5.0-0.nightly-2020-04-18-093630` -
In both, the tags reference `quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:2eb0a51...`.
In `oc adm release extract`, always try extracting from the user-given release first.  If this fails, then fall back to the release image-references.  In disconnected environments, currently, oc adm release extract fails when the given release is mirrored from a connected registry. 

Different from mirrored, when working with a tagged release that was uploaded to another repository, such as `quay.io/sallyom/release:new`, since that release wasn't mirrored, the underlying images still point to the original tag. In this case, `oc adm release extract --command openshift-install` will try the sallyom/release image but since that image does not exist, proceed to use the underlying tagged installer image - that will succeed as long as the user has access to the original release image. Note many devs build release w/ substitutions for one or a few component images, and this is the way they sometimes push images around. 

**To test this PR, do something like this:**
```
$ podman run -p 5000:5000 -d registry:2
$ oc adm release mirror --insecure=true -a ~/pull-secret --from=registry.svc.ci.openshift.org/ocp/release:4.5.0-0.nightly-2020-04-29-144201 --to localhost:5000/ocp/release
$ oc adm release --insecure=true extract --command openshift-install localhost:5000/ocp/release:4.5.0-0.nightly-2020-04-29-144201 -v=2  
```
you'll find the failure from master, fixed w /this PR

Scenarios i tested:
* build new release w/ substituting some component images from a ci/nightly/whatever, then extract or info from that
* extract from release that was mirrored from ci or nightly and is now in disconnected registry - verify this image is extracted from disconnected registry with -v=2
* pull down a release from ci, tag it as mine, push to my quay, extract from that
* extract or info from a ci image (no openshift-release-dev/ocp-v4.0-art-dev reference) - if you can access registry.svc.ci images this succeeds, if not, you'll get unauthorized
* mirror a release from local file or from localregistry to remote registry

Bugs that are resolved with these changes (or the equivalent):
- https://bugzilla.redhat.com/show_bug.cgi?id=1823143
- https://bugzilla.redhat.com/show_bug.cgi?id=1812814
- https://bugzilla.redhat.com/show_bug.cgi?id=1806779 (& backport to 4.3)