### PR TITLE
Bug 1802580: return ProjectRequestMessage if it is set with login,project cmds

### DIFF
--- a/pkg/cli/login/loginoptions.go
+++ b/pkg/cli/login/loginoptions.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
 	"net"
 	"os"
@@ -266,6 +267,29 @@ func (o *LoginOptions) gatherProjectInfo() error {
 		return err
 	}
 
+	canRequest, err := loginutil.CanRequestProjects(o.Config, o.DefaultNamespace)
+	if err != nil {
+		return err
+	}
+	// check if ProjectRequestMessage is set
+	if !canRequest {
+		msg := ""
+		res, err := projectClient.RESTClient().Get().Resource("projectrequests").DoRaw(context.TODO())
+		if err != nil && res != nil {
+			// if err != nil, try to extract ProjectRequestMessage from status if set
+			status := metav1.Status{}
+			err := json.Unmarshal(res, &status)
+			if err != nil {
+				return err
+			}
+			if len(status.Details.Causes) != 0 && status.Details.Causes[0].Message != "" {
+				msg = status.Details.Causes[0].Message
+			}
+			// now return redirected error from !canRequest with the extracted ProjectRequestMessage if set
+			fmt.Fprintf(o.Out, errors.NoProjectsExistMessage(canRequest, msg, o.CommandName))
+			return nil
+		}
+	}
 	projectsList, err := projectClient.Projects().List(context.TODO(), metav1.ListOptions{})
 	// if we're running on kube (or likely kube), just set it to "default"
 	if kerrors.IsNotFound(err) || kerrors.IsForbidden(err) {
@@ -294,11 +318,7 @@ func (o *LoginOptions) gatherProjectInfo() error {
 
 	switch len(projectsItems) {
 	case 0:
-		canRequest, err := loginutil.CanRequestProjects(o.Config, o.DefaultNamespace)
-		if err != nil {
-			return err
-		}
-		msg := errors.NoProjectsExistMessage(canRequest, o.CommandName)
+		msg := errors.NoProjectsExistMessage(canRequest, "", o.CommandName)
 		fmt.Fprintf(o.Out, msg)
 		o.Project = ""
 

--- a/pkg/cli/project/project.go
+++ b/pkg/cli/project/project.go
@@ -158,14 +158,16 @@ func (o ProjectOptions) Run() error {
 		currentProject = currentContext.Namespace
 	}
 
+	client, kubeclient, err := o.ClientFn()
+	if err != nil {
+		return err
+	}
+	if err := client.RESTClient().Get().Resource("projectrequests").Do(context.TODO()).Into(&metav1.Status{}); err != nil {
+		return err
+	}
 	// No argument provided, we will just print info
 	if len(o.ProjectName) == 0 {
 		if len(currentProject) > 0 {
-			client, kubeclient, err := o.ClientFn()
-			if err != nil {
-				return err
-			}
-
 			switch err := ConfirmProjectAccess(currentProject, client, kubeclient); {
 			case kapierrors.IsForbidden(err):
 				return fmt.Errorf("you do not have rights to view project %q", currentProject)

--- a/pkg/helpers/describe/projectstatus.go
+++ b/pkg/helpers/describe/projectstatus.go
@@ -205,7 +205,7 @@ func (d *ProjectStatusDescriber) Describe(namespace, name string) (string, error
 			// the user has not created any projects, and is therefore using a
 			// default namespace that they cannot list projects from.
 			if kapierrors.IsForbidden(err) && len(d.RequestedNamespace) == 0 && len(d.CurrentNamespace) == 0 {
-				return loginerrors.NoProjectsExistMessage(d.CanRequestProjects, d.CommandBaseName), nil
+				return loginerrors.NoProjectsExistMessage(d.CanRequestProjects, "", d.CommandBaseName), nil
 			}
 			if !kapierrors.IsNotFound(err) {
 				return "", err

--- a/pkg/helpers/errors/login.go
+++ b/pkg/helpers/errors/login.go
@@ -52,8 +52,11 @@ func kubeConfigSolution(isExplicitFile bool) string {
 }
 
 // NoProjectsExistMessage returns a message indicating that no projects have been created by the current user.
-func NoProjectsExistMessage(canRequestProjects bool, commandName string) string {
+func NoProjectsExistMessage(canRequestProjects bool, projReqMsg, commandName string) string {
 	if !canRequestProjects {
+		if len(projReqMsg) != 0 {
+			return fmt.Sprintf("%s\n", projReqMsg)
+		}
 		return fmt.Sprintf("You don't have any projects. Contact your system administrator to request a project.\n")
 	}
 	return fmt.Sprintf(`You don't have any projects. You can try to create a new project, by running


### PR DESCRIPTION
This PR updates return msg to users that cannot create projects for `oc login`, `oc new-project`, and `oc project`
If ProjectRequestMessage is set, and user without self-provisioner clusterrole logs in or tries to create  projects, return the ProjectRequestMessage. This is consistent with console.  

If no ProjectRequestMessage set, then return the same message for login|project|new-project: 
```console
$ oc project
You may not request a new project via this API.
```
`oc project` without this PR is misleading:
```console
$ oc project
No project has been set. Pass a project name to make that the default.
```

see comment below to set projectRequestMsg and remove self-provisioner clusterrole