### PR TITLE
bug 1826676: oc status: check if the current project exists before printing status

### DIFF
--- a/pkg/cli/project/project.go
+++ b/pkg/cli/project/project.go
@@ -168,9 +168,9 @@ func (o ProjectOptions) Run() error {
 
 			switch err := ConfirmProjectAccess(currentProject, client, kubeclient); {
 			case kapierrors.IsForbidden(err):
-				return fmt.Errorf("you do not have rights to view project %q.", currentProject)
+				return fmt.Errorf("you do not have rights to view project %q", currentProject)
 			case kapierrors.IsNotFound(err):
-				return fmt.Errorf("the project %q specified in your config does not exist.", currentProject)
+				return fmt.Errorf("the project %q specified in your config does not exist", currentProject)
 			case err != nil:
 				return err
 			}


### PR DESCRIPTION
It can happen a project is no longer available when running the status.
Right now, oc status considers "namespaces XXX not found" error message
as valid and keeps querying for services, deployment, etc. over
on-existing namespace.

New output for non-existing namespaces:
```
$ oc status
error: the project "jenkins-csb-skynet" specified in your config does not exist.
```