### PR TITLE
TEST UPSTREAM CHANGE: DO NOT MERGE

### DIFF
--- a/vendor/k8s.io/kubectl/pkg/util/rbac/rbac.go
+++ b/vendor/k8s.io/kubectl/pkg/util/rbac/rbac.go
@@ -42,7 +42,11 @@ func CompactRules(rules []rbacv1.PolicyRule) ([]rbacv1.PolicyRule, error) {
 				if existingRule.Verbs == nil {
 					existingRule.Verbs = []string{}
 				}
-				existingRule.Verbs = append(existingRule.Verbs, rule.Verbs...)
+				for _, v := range rule.Verbs {
+					if !isDuplicateVerb(existingRule.Verbs, v) {
+						existingRule.Verbs = append(existingRule.Verbs, v)
+					}
+				}
 			} else {
 				// Copy the rule to accumulate matching simple resource rules into
 				simpleRules[resource] = rule.DeepCopy()
@@ -125,4 +129,14 @@ func (s SortableRuleSlice) Len() int      { return len(s) }
 func (s SortableRuleSlice) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s SortableRuleSlice) Less(i, j int) bool {
 	return strings.Compare(s[i].String(), s[j].String()) < 0
+}
+
+// isDuplicateVerb returns true if verb already exists in list of verbs.
+func isDuplicateVerb(verbs []string, v string) bool {
+	for _, verb := range verbs {
+		if verb == v {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
@soltysh this resolves https://bugzilla.redhat.com/show_bug.cgi?id=1806785  
I'm not so familiar w/ describe code, and/or where the rbacv1.PolicyRule is getting the duplicate verbs for these: 
```
namespaces                                       []         []        [get get list watch]
packagemanifests.packages.operators.coreos.com   []         []        [get list watch get list 
```
The change here 'fixes' the duplicates but is there something I'm missing b4 I open an upstream PR? thanks