### PR TITLE
Bug 1835011: improve error for 'oc project' and 'oc status' when project doesn't exist

### DIFF
--- a/pkg/cli/project/project.go
+++ b/pkg/cli/project/project.go
@@ -167,10 +167,8 @@ func (o ProjectOptions) Run() error {
 			}
 
 			switch err := ConfirmProjectAccess(currentProject, client, kubeclient); {
-			case kapierrors.IsForbidden(err):
-				return fmt.Errorf("you do not have rights to view project %q", currentProject)
-			case kapierrors.IsNotFound(err):
-				return fmt.Errorf("the project %q specified in your config does not exist", currentProject)
+			case kapierrors.IsForbidden(err), kapierrors.IsNotFound(err):
+				return fmt.Errorf("you do not have rights to view project %q specified in your config or the project doesn't exist", currentProject)
 			case err != nil:
 				return err
 			}

--- a/pkg/cli/status/status.go
+++ b/pkg/cli/status/status.go
@@ -152,10 +152,8 @@ func (o *StatusOptions) Complete(f kcmdutil.Factory, cmd *cobra.Command, baseCLI
 		}
 		_, err = projectClient.Projects().Get(context.TODO(), namespace, metav1.GetOptions{})
 		switch {
-		case kapierrors.IsForbidden(err):
-			return fmt.Errorf("you do not have rights to view project %q", namespace)
-		case kapierrors.IsNotFound(err):
-			return fmt.Errorf("the project %q specified in your config does not exist", namespace)
+		case kapierrors.IsForbidden(err), kapierrors.IsNotFound(err):
+			return fmt.Errorf("you do not have rights to view project %q specified in your config or the project doesn't exist", namespace)
 		case err != nil:
 			return err
 		}


### PR DESCRIPTION
This PR clarifies error message for `oc status` and `oc project` when run from context of a deleted namespace. 

/assign @soltysh 
/cc @ingvagabund 

closed https://github.com/openshift/oc/pull/417, opened this