### PR TITLE
Bug 1838838: oc adm group sync - search outside base dn warning - RFC 2307

### DIFF
--- a/pkg/helpers/groupsync/rfc2307/ldapinterface.go
+++ b/pkg/helpers/groupsync/rfc2307/ldapinterface.go
@@ -6,6 +6,7 @@ import (
 	"gopkg.in/ldap.v2"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog"
 
 	"github.com/openshift/library-go/pkg/security/ldapclient"
 	ldapquery "github.com/openshift/library-go/pkg/security/ldapquery"
@@ -91,6 +92,12 @@ func (e *LDAPInterface) ExtractMembers(ldapGroupUID string) ([]*ldap.Entry, erro
 		memberEntry, err := e.userEntryFor(ldapMemberUID)
 		if err == nil {
 			members = append(members, memberEntry)
+			continue
+		}
+
+		if ldapquery.IsQueryOutOfBoundsError(err) {
+			// Ignore OutOfBounds and continue, don't return or handle error here to allow for extracting other members
+			klog.Infof("membership lookup for user %q in group %q skipped because of %q", ldapGroupUID, ldapMemberUID, err.Error())
 			continue
 		}
 


### PR DESCRIPTION
While testing, noticed that https://github.com/openshift/oc/pull/405 only covered for ActiveDirectory, but  with RFC 2307, out of bounds search was still resulting in error, not warning. 