### PR TITLE
Bug 1842582: Don't include digest in source for ICSP when mirroring a catalog

### DIFF
--- a/pkg/cli/admin/catalog/mirror.go
+++ b/pkg/cli/admin/catalog/mirror.go
@@ -398,13 +398,18 @@ func generateICSP(out io.Writer, name string, mapping map[string]Target) ([]byte
 			fmt.Fprintf(out, "no digest mapping available for %s, skip writing to ImageContentSourcePolicy\n", k)
 			continue
 		}
+		fromRef, err := imagesource.ParseReference(k)
+		if err != nil {
+			fmt.Fprintf(out, "error parsing source reference for %s, skip writing to ImageContentSourcePolicy\n", v)
+			continue
+		}
 		toRef, err := imagesource.ParseReference(v.WithDigest)
 		if err != nil {
 			fmt.Fprintf(out, "error parsing target reference for %s, skip writing to ImageContentSourcePolicy\n", v)
 			continue
 		}
 		icsp.Spec.RepositoryDigestMirrors = append(icsp.Spec.RepositoryDigestMirrors, operatorv1alpha1.RepositoryDigestMirrors{
-			Source:  k,
+			Source:  fromRef.Ref.AsRepository().String(),
 			Mirrors: []string{toRef.Ref.AsRepository().String()},
 		})
 	}

--- a/pkg/cli/admin/catalog/mirror_test.go
+++ b/pkg/cli/admin/catalog/mirror_test.go
@@ -123,7 +123,7 @@ spec:
   repositoryDigestMirrors:
   - mirrors:
     - quay.io/olmtest/strimzi-operator
-    source: docker.io/strimzi/operator@sha256:d134a9865524c29fcf75bbc4469013bc38d8a15cb5f41acfddb6b9e492f556e4
+    source: docker.io/strimzi/operator
 `,
 			),
 		},
@@ -151,7 +151,7 @@ spec:
   repositoryDigestMirrors:
   - mirrors:
     - quay.io/olmtest/strimzi-operator
-    source: docker.io/strimzi/operator@sha256:d134a9865524c29fcf75bbc4469013bc38d8a15cb5f41acfddb6b9e492f556e4
+    source: docker.io/strimzi/operator
 `,
 			),
 		},


### PR DESCRIPTION
This fixes a regression introduced in 4.5, where ICSP sources were generated with digests. This causes unnecessary churn on clusters when no new repos have been added during a catalog update.