### PR TITLE
make oc adm inspect run in parallel and remove rate limits

### DIFF
--- a/pkg/cli/admin/inspect/inspect.go
+++ b/pkg/cli/admin/inspect/inspect.go
@@ -205,14 +205,8 @@ func (o *InspectOptions) Run() error {
 	}
 
 	// finally, gather polymorphic resources specified by the user
-	allErrs := []error{}
 	ctx := NewResourceContext()
-	for _, info := range infos {
-		err := InspectResource(info, ctx, o)
-		if err != nil {
-			allErrs = append(allErrs, err)
-		}
-	}
+	allErrs := ParallelInspectResource(infos, ctx, o)
 
 	// now gather all the events into a single file and produce a unified file
 	if err := CreateEventFilterPage(o.destDir); err != nil {
@@ -230,11 +224,10 @@ func (o *InspectOptions) Run() error {
 // gatherConfigResourceData gathers all config.openshift.io resources
 func (o *InspectOptions) gatherConfigResourceData(destDir string, ctx *resourceContext) error {
 	// determine if we've already collected configResourceData
-	if ctx.visited.Has(configResourceDataKey) {
+	if ctx.visited(configResourceDataKey) {
 		klog.V(1).Infof("Skipping previously-collected config.openshift.io resource data")
 		return nil
 	}
-	ctx.visited.Insert(configResourceDataKey)
 
 	klog.V(1).Infof("Gathering config.openshift.io resource data...\n")
 
@@ -273,11 +266,10 @@ func (o *InspectOptions) gatherConfigResourceData(destDir string, ctx *resourceC
 // gatherOperatorResourceData gathers all kubeapiserver.operator.openshift.io resources
 func (o *InspectOptions) gatherOperatorResourceData(destDir string, ctx *resourceContext) error {
 	// determine if we've already collected operatorResourceData
-	if ctx.visited.Has(operatorResourceDataKey) {
+	if ctx.visited(operatorResourceDataKey) {
 		klog.V(1).Infof("Skipping previously-collected operator.openshift.io resource data")
 		return nil
 	}
-	ctx.visited.Insert(operatorResourceDataKey)
 
 	// ensure destination path exists
 	if err := os.MkdirAll(destDir, os.ModePerm); err != nil {


### PR DESCRIPTION
This allows `oc adm inspect co` to run 90 seconds for me locally against my aws cluster.

/assign @soltysh 