### PR TITLE
bug 1843853: [release-4.2] Introduce MOTD for login command (backport from 4.3)

### DIFF
--- a/pkg/helpers/motd/motd.go
+++ b/pkg/helpers/motd/motd.go
@@ -1,0 +1,43 @@
+package motd
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/klog"
+)
+
+// Display the necessary MOTD if it's configured in the system.
+// Note that the MOTD comes from the "motd" configMap, which
+// should be in the "openshift" namespace. This needs to be configured
+// by the deployer.
+func DisplayMOTD(coreClient corev1client.CoreV1Interface, out io.Writer) error {
+	motdcm, err := coreClient.ConfigMaps("openshift").Get("motd", metav1.GetOptions{})
+	if kerrors.IsNotFound(err) || kerrors.IsForbidden(err) {
+		// NOTE(jaosorior): If no motd is configured, it's fine. No need to
+		// print anything. If we get a "Forbidden" error, this is because no
+		// role binding has been configured yet. So we need to ignore the
+		// error for now (until the role binding is included by default).
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	motd, ok := motdcm.Data["message"]
+
+	if !ok {
+		klog.V(4).Infof("Unable to display MOTD. It exists but is misconfigured.")
+		return nil
+	}
+
+	// Add newline if needed
+	if !strings.HasSuffix(motd, "\n") {
+		motd = motd + "\n"
+	}
+	fmt.Fprintf(out, "\n%s", motd)
+	return nil
+}

--- a/pkg/helpers/motd/motd_test.go
+++ b/pkg/helpers/motd/motd_test.go
@@ -1,0 +1,51 @@
+package motd
+
+import (
+	"bytes"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func configmap(namespace, name, key, content string) *v1.ConfigMap {
+	return &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			key: content,
+		},
+	}
+}
+
+func TestDisplayMOTD(t *testing.T) {
+	var tests = []struct {
+		description string
+		expected    string
+		obj         runtime.Object
+	}{
+		{"Correctly displays message", "\nThis is a legal notice\n", configmap("openshift", "motd", "message", "This is a legal notice")},
+		{"No message because of malformed notice (misspelled key)", "", configmap("openshift", "motd", "mesage", "This is a legal notice")},
+		{"No message because of misconfigured notice (wrong name)", "", configmap("openshift", "bad-name", "message", "This is a legal notice")},
+		{"No message because notice not found in namespace", "", configmap("default", "motd", "message", "This is a legal notice")},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			clientSet := fake.NewSimpleClientset(test.obj)
+			var output bytes.Buffer
+			if err := DisplayMOTD(clientSet.CoreV1(), &output); err != nil {
+				t.Errorf("Unexpected error: %s", err)
+				return
+			}
+			if output.String() != test.expected {
+				t.Errorf("The output is not correct! Got: %s -- Wanted: %s", output.String(), test.expected)
+				return
+			}
+		})
+	}
+}


### PR DESCRIPTION
Backport of #67 for 4.2
Bugzilla for reference [#1843853](https://bugzilla.redhat.com/show_bug.cgi?id=1843853)
---
Due to legal requirements, some deployments need to display a legal
notice for users "entering" a system.

This legal notice can range from telling the user that they are entering
a government system and are being monitored, to just displaying the
rules of usage in the system. We'll implement this requirements in the
form of a "message of the day" (MOTD).

This is required by law by several countries, with the intent that in
case the user attacks the system and needs to be prosecuted, the message
can be used as proof that the attacker knew against whom the attack was being
executed.

In this PR, the "oc login" command will search for the motd
ConfigMap, which would ideally be configured in the "openshift"
namespace.

If the notice is not present, or the user has no rights to access that
ConfigMap, the command will not fail.

Note that the legal notice will be displayed for the login command
regardless if the user is authenticated or not.

As a separate PR, the (empty) ConfigMap and the needed ClusterRole and
ClusterRoleBinding will be populated by default in the deployment.