### PR TITLE
Bug 1806782: Allow a file:// release argument to release mirror

### DIFF
--- a/pkg/cli/admin/release/extract.go
+++ b/pkg/cli/admin/release/extract.go
@@ -88,7 +88,8 @@ type ExtractOptions struct {
 	SecurityOptions imagemanifest.SecurityOptions
 	ParallelOptions imagemanifest.ParallelOptions
 
-	From string
+	FromDir string
+	From    string
 
 	Tools                  bool
 	Command                string
@@ -167,6 +168,7 @@ func (o *ExtractOptions) Run() error {
 		return err
 	}
 	opts := extract.NewOptions(genericclioptions.IOStreams{Out: o.Out, ErrOut: o.ErrOut})
+	opts.ParallelOptions = o.ParallelOptions
 	opts.SecurityOptions = o.SecurityOptions
 	opts.FileDir = o.FileDir
 

--- a/pkg/cli/admin/release/mirror.go
+++ b/pkg/cli/admin/release/mirror.go
@@ -102,7 +102,7 @@ func NewMirror(f kcmdutil.Factory, parentName string, streams genericclioptions.
 	flags.StringVar(&o.From, "from", o.From, "Image containing the release payload.")
 	flags.StringVar(&o.To, "to", o.To, "An image repository to push to.")
 	flags.StringVar(&o.ToImageStream, "to-image-stream", o.ToImageStream, "An image stream to tag images into.")
-	flags.StringVar(&o.FromDir, "from-dir", o.ToDir, "A directory to import images from.")
+	flags.StringVar(&o.FromDir, "from-dir", o.FromDir, "A directory to import images from.")
 	flags.StringVar(&o.ToDir, "to-dir", o.ToDir, "A directory to export images to.")
 	flags.BoolVar(&o.ToMirror, "to-mirror", o.ToMirror, "Output the mirror mappings instead of mirroring.")
 	flags.BoolVar(&o.DryRun, "dry-run", o.DryRun, "Display information about the mirror without actually executing it.")
@@ -297,10 +297,12 @@ func (o *MirrorOptions) Run() error {
 		// load image references
 		buf := &bytes.Buffer{}
 		extractOpts := NewExtractOptions(genericclioptions.IOStreams{Out: buf, ErrOut: o.ErrOut})
+		extractOpts.ParallelOptions = o.ParallelOptions
 		extractOpts.SecurityOptions = o.SecurityOptions
 		extractOpts.ImageMetadataCallback = func(m *extract.Mapping, dgst, contentDigest digest.Digest, config *dockerv1client.DockerImageConfig) {
 			verifier.Verify(dgst, contentDigest)
 		}
+		extractOpts.FileDir = o.FromDir
 		extractOpts.From = o.From
 		extractOpts.File = "image-references"
 		if err := extractOpts.Run(); err != nil {
@@ -539,6 +541,7 @@ func (o *MirrorOptions) Run() error {
 	opts.SecurityOptions = o.SecurityOptions
 	opts.ParallelOptions = o.ParallelOptions
 	opts.Mappings = mappings
+	opts.FromFileDir = o.FromDir
 	opts.FileDir = o.ToDir
 	opts.DryRun = o.DryRun
 	opts.ManifestUpdateCallback = func(registry string, manifests map[digest.Digest]digest.Digest) error {

--- a/pkg/cli/admin/release/new.go
+++ b/pkg/cli/admin/release/new.go
@@ -387,6 +387,7 @@ func (o *NewOptions) Run() error {
 
 		buf := &bytes.Buffer{}
 		extractOpts := extract.NewOptions(genericclioptions.IOStreams{Out: buf, ErrOut: o.ErrOut})
+		extractOpts.ParallelOptions = o.ParallelOptions
 		extractOpts.SecurityOptions = o.SecurityOptions
 		extractOpts.OnlyFiles = true
 		extractOpts.Mappings = []extract.Mapping{
@@ -922,9 +923,9 @@ func (o *NewOptions) extractManifests(is *imageapi.ImageStream, name string, met
 	verifier := imagemanifest.NewVerifier()
 	var lock sync.Mutex
 	opts := extract.NewOptions(genericclioptions.IOStreams{Out: o.Out, ErrOut: o.ErrOut})
+	opts.ParallelOptions = o.ParallelOptions
 	opts.SecurityOptions = o.SecurityOptions
 	opts.OnlyFiles = true
-	opts.ParallelOptions = o.ParallelOptions
 	opts.ImageMetadataCallback = func(m *extract.Mapping, dgst, contentDigest digest.Digest, config *dockerv1client.DockerImageConfig) {
 		verifier.Verify(dgst, contentDigest)
 
@@ -1048,6 +1049,7 @@ func (o *NewOptions) mirrorImages(is *imageapi.ImageStream) error {
 	opts.ImageStream = copied
 	opts.To = o.Mirror
 	opts.SkipRelease = true
+	opts.ParallelOptions = o.ParallelOptions
 	opts.SecurityOptions = o.SecurityOptions
 
 	if err := opts.Run(); err != nil {
@@ -1178,6 +1180,7 @@ func (o *NewOptions) write(r io.Reader, is *imageapi.ImageStream, now time.Time)
 
 		verifier := imagemanifest.NewVerifier()
 		options := imageappend.NewAppendImageOptions(genericclioptions.IOStreams{Out: ioutil.Discard, ErrOut: o.ErrOut})
+		options.ParallelOptions = o.ParallelOptions
 		options.SecurityOptions = o.SecurityOptions
 		options.DryRun = o.DryRun
 		options.From = toImageBase


### PR DESCRIPTION
This picks #327 and #446 back to release-4.3. #327 picks back cleanly (see #456), and I'm recycling the bot's 95de610 in this PR. #446 does not pick back cleanly, because release-4.3 lacks release-4.4's #426. I've resolved the minor context conflict manually to create dbe3f73.