### PR TITLE
bug 1840411: oc project: rewrite context after kubeconfig is read

### DIFF
--- a/pkg/cli/project/project.go
+++ b/pkg/cli/project/project.go
@@ -106,13 +106,13 @@ func (o *ProjectOptions) Complete(f genericclioptions.RESTClientGetter, cmd *cob
 		return fmt.Errorf("unable to get value for --context flag: %v", err)
 	}
 
-	if o.Context != "" {
-		o.Config.CurrentContext = o.Context
-	}
-
 	o.Config, err = f.ToRawKubeConfigLoader().RawConfig()
 	if err != nil {
 		return err
+	}
+
+	if o.Context != "" {
+		o.Config.CurrentContext = o.Context
 	}
 
 	o.RESTConfig, err = f.ToRESTConfig()


### PR DESCRIPTION
```
$ oc config get-contexts
CURRENT   NAME                                                                                     CLUSTER                                                       AUTHINFO                                                                   NAMESPACE
          admin                                                                                    jchaloup-20200618                                             admin                                                                      
          admin-groupb                                                                             test0616                                                      admin-groupb                                                               
          hongkliu-test/api-jchaloup-20200618-group-b-devcluster-openshift-com:6443/system:admin   api-jchaloup-20200618-group-b-devcluster-openshift-com:6443   system:admin/api-jchaloup-20200618-group-b-devcluster-openshift-com:6443   hongkliu-test
*         testtest/api-test0616-group-b-devcluster-openshift-com:6443/system:admin                 api-test0616-group-b-devcluster-openshift-com:6443            system:admin                                                               testtest
```

```
$ oc project --context=hongkliu-test/api-jchaloup-20200618-group-b-devcluster-openshift-com:6443/system:admin
Using project "hongkliu-test" on server "https://api.jchaloup-20200618.group-b.devcluster.openshift.com:6443".
$ oc project
Using project "testtest" on server "https://api.test0616.group-b.devcluster.openshift.com:6443".
$ oc project --context=admin
No project has been set. Pass a project name to make that the default.
$ oc project --context=admin-groupb
No project has been set. Pass a project name to make that the default.
```