### PR TITLE
Bug 1851817: fix filter-by-os parsing for oc adm catalog mirror

### DIFF
--- a/pkg/cli/admin/catalog/mirror.go
+++ b/pkg/cli/admin/catalog/mirror.go
@@ -135,6 +135,13 @@ func (o *MirrorCatalogOptions) Complete(cmd *cobra.Command, args []string) error
 	src := args[0]
 	dest := args[1]
 
+	if err := o.FilterOptions.Complete(cmd.Flags()); err != nil {
+		return err
+	}
+	if err := o.FilterOptions.Validate(); err != nil {
+		return err
+	}
+
 	srcRef, err := imagesource.ParseReference(src)
 	if err != nil {
 		return err


### PR DESCRIPTION
Didn't `Complete` the options, which was skipping parsing the flag into a regex, causing matches to fail.