### PR TITLE
bug 1829243: Revert "run inspect in parallel"

### DIFF
--- a/pkg/cli/admin/inspect/inspect.go
+++ b/pkg/cli/admin/inspect/inspect.go
@@ -205,8 +205,14 @@ func (o *InspectOptions) Run() error {
 	}
 
 	// finally, gather polymorphic resources specified by the user
+	allErrs := []error{}
 	ctx := NewResourceContext()
-	allErrs := ParallelInspectResource(infos, ctx, o)
+	for _, info := range infos {
+		err := InspectResource(info, ctx, o)
+		if err != nil {
+			allErrs = append(allErrs, err)
+		}
+	}
 
 	// now gather all the events into a single file and produce a unified file
 	if err := CreateEventFilterPage(o.destDir); err != nil {
@@ -224,10 +230,11 @@ func (o *InspectOptions) Run() error {
 // gatherConfigResourceData gathers all config.openshift.io resources
 func (o *InspectOptions) gatherConfigResourceData(destDir string, ctx *resourceContext) error {
 	// determine if we've already collected configResourceData
-	if ctx.visited(configResourceDataKey) {
+	if ctx.visited.Has(configResourceDataKey) {
 		klog.V(1).Infof("Skipping previously-collected config.openshift.io resource data")
 		return nil
 	}
+	ctx.visited.Insert(configResourceDataKey)
 
 	klog.V(1).Infof("Gathering config.openshift.io resource data...\n")
 
@@ -266,10 +273,11 @@ func (o *InspectOptions) gatherConfigResourceData(destDir string, ctx *resourceC
 // gatherOperatorResourceData gathers all kubeapiserver.operator.openshift.io resources
 func (o *InspectOptions) gatherOperatorResourceData(destDir string, ctx *resourceContext) error {
 	// determine if we've already collected operatorResourceData
-	if ctx.visited(operatorResourceDataKey) {
+	if ctx.visited.Has(operatorResourceDataKey) {
 		klog.V(1).Infof("Skipping previously-collected operator.openshift.io resource data")
 		return nil
 	}
+	ctx.visited.Insert(operatorResourceDataKey)
 
 	// ensure destination path exists
 	if err := os.MkdirAll(destDir, os.ModePerm); err != nil {

--- a/pkg/cli/admin/inspect/util.go
+++ b/pkg/cli/admin/inspect/util.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"sync"
 
 	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -24,33 +23,13 @@ import (
 
 // resourceContext is used to keep track of previously seen objects
 type resourceContext struct {
-	lock sync.Mutex
-
-	alreadyVisited sets.String
+	visited sets.String
 }
 
 func NewResourceContext() *resourceContext {
 	return &resourceContext{
-		alreadyVisited: sets.NewString(),
+		visited: sets.NewString(),
 	}
-}
-
-// visited returns whether or not an item already has already been visited and adds it to the list
-func (r *resourceContext) visited(resource string) bool {
-	r.lock.Lock()
-	defer r.lock.Unlock()
-
-	ret := r.alreadyVisited.Has(resource)
-	r.alreadyVisited.Insert(resource)
-	return ret
-}
-
-// visited returns whether or not an item already has already been visited and does NOT add it to the list
-func (r *resourceContext) peekVisited(resource string) bool {
-	r.lock.Lock()
-	defer r.lock.Unlock()
-
-	return r.alreadyVisited.Has(resource)
 }
 
 func objectReferenceToString(ref *configv1.ObjectReference) string {


### PR DESCRIPTION
This reverts commit 7ec02e2eacdf66c5a6b77e44ee779398d5aee80b.

https://github.com/openshift/origin/pull/25239 nerfed a test that demonstrated that we broke must gather. We need to fix must-gather, not nerf the test for our data collection.  

looking at it, https://github.com/openshift/oc/pull/449 appears to be a good candidate, though it's not obvious why at first glance.