### PR TITLE
 Bug 1850931: 'oc image mirror' Add warning when mirroring SchemaVersion:1 images

### DIFF
--- a/pkg/cli/image/manifest/manifest.go
+++ b/pkg/cli/image/manifest/manifest.go
@@ -428,7 +428,7 @@ func ManifestsFromList(ctx context.Context, srcDigest digest.Digest, srcManifest
 	}
 }
 
-// TDOO: remove when quay.io switches to v2 schema
+// TODO: Remove support for v2 schema in 4.9
 func PutManifestInCompatibleSchema(
 	ctx context.Context,
 	srcManifest distribution.Manifest,
@@ -538,7 +538,7 @@ func convertToSchema2(ctx context.Context, blobs distribution.BlobService, srcMa
 	return b.Build(ctx)
 }
 
-// TDOO: remove when quay.io switches to v2 schema
+// TODO: Remove support for v2 schema in 4.9
 func convertToSchema1(ctx context.Context, blobs distribution.BlobService, configJSON []byte, schema2Manifest *schema2.DeserializedManifest, ref reference.Named) (distribution.Manifest, error) {
 	if configJSON == nil {
 		targetDescriptor := schema2Manifest.Target()
@@ -573,7 +573,7 @@ var (
 	privateKey     libtrust.PrivateKey
 )
 
-// TDOO: remove when quay.io switches to v2 schema
+// TODO: Remove support for v2 schema in 4.9
 func loadPrivateKey() (libtrust.PrivateKey, error) {
 	privateKeyLock.Lock()
 	defer privateKeyLock.Unlock()

--- a/pkg/cli/image/mirror/plan.go
+++ b/pkg/cli/image/mirror/plan.go
@@ -341,7 +341,7 @@ func (p *registryPlan) SavedManifest(srcDigest, dstDigest godigest.Digest) {
 	}
 	p.lock.Lock()
 	defer p.lock.Unlock()
-	klog.V(4).Infof("Associated digest %s with converted digest %s", srcDigest, dstDigest)
+	klog.V(2).Infof("Associated digest: %s, Converted digest: %s", srcDigest, dstDigest)
 	p.manifestConversions[srcDigest] = dstDigest
 }
 


### PR DESCRIPTION
Add warning when mirroring SchemaVersion:1 images that digests are not preserved.

Also, update TODOs with functions handling schema conversions to drop support for Schema v1 in future release.
/assign @soltysh 