### PR TITLE
release: Hide empty metadata fields in release info

### DIFF
--- a/pkg/cli/admin/release/info.go
+++ b/pkg/cli/admin/release/info.go
@@ -1204,14 +1204,28 @@ func describeReleaseInfo(out io.Writer, release *ReleaseInfo, showCommit, showCo
 			fmt.Fprintf(w, "  Upgrades:\t<none>\n")
 		}
 		var keys []string
-		for k := range m.Metadata {
+		for k, v := range m.Metadata {
+			switch t := v.(type) {
+			case string:
+				if len(t) == 0 {
+					continue
+				}
+			case []interface{}:
+				if len(t) == 0 {
+					continue
+				}
+			case map[string]interface{}:
+				if len(t) == 0 {
+					continue
+				}
+			}
 			keys = append(keys, k)
 		}
 		sort.Strings(keys)
 		writeTabSection(w, func(w io.Writer) {
+			fmt.Fprintf(w, "  Metadata:\n")
 			for _, k := range keys {
-				fmt.Fprintf(w, "  Metadata:\n")
-				fmt.Fprintf(w, "    %s:\t%s\n", k, m.Metadata[k])
+				fmt.Fprintf(w, "    %s:\t%v\n", k, m.Metadata[k])
 			}
 		})
 	}


### PR DESCRIPTION
If a metadata field has an empty string, map, or array, there isn't
huge value in showing it to a human viewer. The data will still be
present in `-o json`.

Correct a bug where `Metadata:` is printed multiple times, one per
key.