### PR TITLE
pkg/cli/adm/catalog: Delegate to catalog-approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -10,3 +10,7 @@ aliases:
     - smarterclayton
     - vrutkovs
     - wking
+  catalog-approvers:
+    - ecordell
+  catalog-reviewers:
+    - ecordell

--- a/pkg/cli/admin/catalog/OWNERS
+++ b/pkg/cli/admin/catalog/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - catalog-approvers
+reviewers:
+  - catalog-reviewers


### PR DESCRIPTION
This command is related to building and mirroring the catalog.
Seeding the alias with ecordell for now.