### PR TITLE
Bug 1861559: Only schedule must-gather pod on Linux nodes

### DIFF
--- a/pkg/cli/admin/mustgather/mustgather.go
+++ b/pkg/cli/admin/mustgather/mustgather.go
@@ -520,6 +520,7 @@ func (o *MustGatherOptions) newPod(node, image string) *corev1.Pod {
 					},
 				},
 			},
+			NodeSelector:                  map[string]string{corev1.LabelOSStable: "linux"},
 			TerminationGracePeriodSeconds: &zero,
 			Tolerations: []corev1.Toleration{
 				{


### PR DESCRIPTION
oc adm must-gather is creating a pod which is getting scheduled on
Windows nodes. This commit changes the podspec to include a linux
node selector.