### PR TITLE
use filepath not path to manipulate filepaths

### DIFF
--- a/pkg/cli/admin/mustgather/mustgather.go
+++ b/pkg/cli/admin/mustgather/mustgather.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"math/rand"
 	"os"
-	"path"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
@@ -352,13 +352,13 @@ func (o *MustGatherOptions) log(format string, a ...interface{}) {
 func (o *MustGatherOptions) copyFilesFromPod(pod *corev1.Pod) error {
 	streams := o.IOStreams
 	streams.Out = newPrefixWriter(streams.Out, fmt.Sprintf("[%s] OUT", pod.Name))
-	destDir := path.Join(o.DestDir, regexp.MustCompile("[^A-Za-z0-9]+").ReplaceAllString(pod.Status.InitContainerStatuses[0].ImageID, "-"))
+	destDir := filepath.Join(o.DestDir, regexp.MustCompile("[^A-Za-z0-9]+").ReplaceAllString(pod.Status.InitContainerStatuses[0].ImageID, "-"))
 	if err := os.MkdirAll(destDir, 0775); err != nil {
 		return err
 	}
 	rsyncOptions := &rsync.RsyncOptions{
 		Namespace:     pod.Namespace,
-		Source:        &rsync.PathSpec{PodName: pod.Name, Path: path.Clean(o.SourceDir) + "/"},
+		Source:        &rsync.PathSpec{PodName: pod.Name, Path: filepath.Clean(o.SourceDir) + "/"},
 		ContainerName: "copy",
 		Destination:   &rsync.PathSpec{PodName: "", Path: destDir},
 		Client:        o.Client,
@@ -500,7 +500,7 @@ func (o *MustGatherOptions) newPod(node, image string) *corev1.Pod {
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "must-gather-output",
-							MountPath: path.Clean(o.SourceDir),
+							MountPath: filepath.Clean(o.SourceDir),
 							ReadOnly:  false,
 						},
 					},
@@ -514,7 +514,7 @@ func (o *MustGatherOptions) newPod(node, image string) *corev1.Pod {
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "must-gather-output",
-							MountPath: path.Clean(o.SourceDir),
+							MountPath: filepath.Clean(o.SourceDir),
 							ReadOnly:  false,
 						},
 					},

--- a/pkg/cli/admin/release/git.go
+++ b/pkg/cli/admin/release/git.go
@@ -10,7 +10,6 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -135,7 +134,7 @@ func sourceLocationAsRelativePath(dir, location string) (string, error) {
 	if strings.HasSuffix(gitPath, ".git") {
 		gitPath = strings.TrimSuffix(gitPath, ".git")
 	}
-	gitPath = path.Clean(gitPath)
+	gitPath = filepath.Clean(gitPath)
 	basePath := filepath.Join(dir, u.Host, filepath.FromSlash(gitPath))
 	return basePath, nil
 }

--- a/pkg/cli/set/volume.go
+++ b/pkg/cli/set/volume.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"path"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -662,7 +662,7 @@ func (o *VolumeOptions) setVolumeMount(spec *corev1.PodSpec, info *resource.Info
 
 	for _, c := range containers {
 		for _, m := range c.VolumeMounts {
-			if path.Clean(m.MountPath) == path.Clean(opts.MountPath) && m.Name != o.Name {
+			if filepath.Clean(m.MountPath) == filepath.Clean(opts.MountPath) && m.Name != o.Name {
 				return fmt.Errorf("volume mount '%s' already exists for container '%s'", opts.MountPath, c.Name)
 			}
 		}
@@ -674,11 +674,11 @@ func (o *VolumeOptions) setVolumeMount(spec *corev1.PodSpec, info *resource.Info
 		}
 		volumeMount := &corev1.VolumeMount{
 			Name:      o.Name,
-			MountPath: path.Clean(opts.MountPath),
+			MountPath: filepath.Clean(opts.MountPath),
 			ReadOnly:  opts.ReadOnly,
 		}
 		if len(opts.SubPath) > 0 {
-			volumeMount.SubPath = path.Clean(opts.SubPath)
+			volumeMount.SubPath = filepath.Clean(opts.SubPath)
 		}
 		c.VolumeMounts = append(c.VolumeMounts, *volumeMount)
 	}
@@ -699,7 +699,7 @@ func (o *VolumeOptions) getVolumeName(spec *corev1.PodSpec, singleResource bool)
 			matchCount := 0
 			for _, c := range containers {
 				for _, m := range c.VolumeMounts {
-					if path.Clean(m.MountPath) == path.Clean(opts.MountPath) {
+					if filepath.Clean(m.MountPath) == filepath.Clean(opts.MountPath) {
 						name = m.Name
 						matchCount++
 						break


### PR DESCRIPTION
from go docs:
```
from "path" overview:
Package path implements utility routines for manipulating slash-separated paths.
The path package should only be used for paths separated by forward slashes, such as the paths in URLs. This package does not deal with Windows paths with drive letters or backslashes; to manipulate operating system paths, use the path/filepath package.
```
```
"path/filepath" overview:
Package filepath implements utility routines for manipulating filename paths in a way compatible with the target operating system-defined file paths.
The filepath package uses either forward slashes or backslashes, depending on the operating system. To process paths such as URLs that always use forward slashes regardless of the operating system, see the path package.
```