### PR TITLE
Bug 1788156: With 'oc adm release new' allow a component image substitution w/ a multi-arch component image

### DIFF
--- a/pkg/cli/admin/release/new.go
+++ b/pkg/cli/admin/release/new.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -993,6 +994,10 @@ func (o *NewOptions) extractManifests(is *imageapi.ImageStream, name string, met
 				var labels map[string]string
 				if imageConfig.Config != nil {
 					labels = imageConfig.Config.Labels
+					// when user provides an override, the platform spec of the release payload will be passed to extract and
+					// used to set the os/arch of the override image if it is a manifestList.  This is an unsupported release configuration.
+					opts.FilterOptions.FilterByOS = fmt.Sprintf("^%s/%s$", imageConfig.OS, imageConfig.Architecture)
+					opts.FilterOptions.OSFilter = regexp.MustCompile(opts.FilterOptions.FilterByOS)
 				}
 				if tag.Annotations == nil {
 					tag.Annotations = make(map[string]string)

--- a/pkg/cli/image/mirror/mirror.go
+++ b/pkg/cli/image/mirror/mirror.go
@@ -514,7 +514,6 @@ func (o *MirrorImageOptions) plan() (*plan, error) {
 			})
 
 			canonicalFrom := srcRepo.Named()
-
 			rq.Queue(func(w workqueue.Work) {
 				for key := range src.digests {
 					srcDigestString, pushTargets := key, src.digests[key]


### PR DESCRIPTION
This PR will allow:
* `oc adm release new --from-release anything --to anythingelse component=multi-arch-image` 
    * this currently fails bc `oc image extract` can't handle DeserializedManifestList with 
       `oc adm release new` flow

Note: `oc image extract|info|append` can handle multi-arch images, it defaults to extract system os/arch unless `--filter-by-os` is passed.  It doesn't, however, work with `--filter-by-os=.*` or with any expandable regex, as it can only handle a literal single filter (linux/amd64 not linux/* ). This PR updates logic around choosing a single manifest from a manifest list w/ `oc image append|info|extract`. 


See sample commands with improved output[ in comments below.](https://github.com/openshift/oc/pull/513#issuecomment-725061916)

Also resolves https://bugzilla.redhat.com/show_bug.cgi?id=1906276