### PR TITLE
Bug 1880865: fix part 1 of issue https://github.com/openshift/oc/issues/496

### DIFF
--- a/pkg/cli/login/loginoptions.go
+++ b/pkg/cli/login/loginoptions.go
@@ -133,6 +133,9 @@ func (o *LoginOptions) getClientConfig() (*restclient.Config, error) {
 		clientConfig.CAData = caData
 	}
 
+	// if user has selected option --insecure-skip-tls-verify=true, TLS server certificate verification should not be attempted
+	clientConfig.Insecure = o.InsecureTLS
+
 	// try to TCP connect to the server to make sure it's reachable, and discover
 	// about the need of certificates or insecure TLS
 	if err := dialToServer(*clientConfig); err != nil {


### PR DESCRIPTION
Issue:

- Observed behaviour: Cannot login to an openshift cluster due to TLS Handshake timeout even with option --insecure-skip-tls-verify=true (See description of the root cause here: https://github.com/openshift/oc/issues/496)

- Expected behaviour: Connection should succeed