### PR TITLE
Bug 1867792: Allow prune to move on with Removed registry

### DIFF
--- a/pkg/cli/admin/prune/imageprune/helper.go
+++ b/pkg/cli/admin/prune/imageprune/helper.go
@@ -40,6 +40,10 @@ func (ba isByAge) Less(i, j int) bool {
 	return ba[i].CreationTimestamp.After(ba[j].CreationTimestamp.Time)
 }
 
+// ErrRegistryHostNotFound is an error returned when we could not find an image from where we can
+// derive the image registry host.
+var ErrRegistryHostNotFound = fmt.Errorf("no image found from where we can derive registry host")
+
 // DetermineRegistryHost returns registry host embedded in a pull-spec of the latest unmanaged image or the
 // latest imagestream from the provided lists. If no such pull-spec is found, error is returned.
 func DetermineRegistryHost(images *imagev1.ImageList, imageStreams *imagev1.ImageStreamList) (string, error) {
@@ -73,7 +77,7 @@ func DetermineRegistryHost(images *imagev1.ImageList, imageStreams *imagev1.Imag
 	}
 
 	if len(pullSpec) == 0 {
-		return "", fmt.Errorf("no managed image found")
+		return "", ErrRegistryHostNotFound
 	}
 
 	ref, err := reference.Parse(pullSpec)

--- a/pkg/cli/admin/prune/images/images.go
+++ b/pkg/cli/admin/prune/images/images.go
@@ -436,7 +436,14 @@ func (o PruneImagesOptions) Run() error {
 		if len(registryHost) == 0 {
 			registryHost, err = imageprune.DetermineRegistryHost(allImages, allStreams)
 			if err != nil {
-				return fmt.Errorf("unable to determine registry: %v", err)
+				if err != imageprune.ErrRegistryHostNotFound {
+					return fmt.Errorf("unable to determine registry: %v", err)
+				}
+				// if we can't determine the registry host (ErrNoImageFound) and
+				// we need to prune it as well, bail out immediately.
+				if o.PruneRegistry != nil && *o.PruneRegistry {
+					return fmt.Errorf("unable to find the remote registry host: %v", err)
+				}
 			}
 		}
 


### PR DESCRIPTION
Pruner attempts to derive internal image registry host from the last
unmanaged image or from the last image stream created. In some cases
OpenShift may not contain any of those (for instance in a fresh install
with Removed registry), this makes pruner to fail even with the flag
--prune-registry set to false.

This commit allows the pruner job to move on with the --prune-registry
flag set to false even when we can't derive the internal registry host.