### PR TITLE
Bug 1866380: must-gather ImagePullPolicy should be 'Always'

### DIFF
--- a/pkg/cli/admin/mustgather/mustgather.go
+++ b/pkg/cli/admin/mustgather/mustgather.go
@@ -494,9 +494,10 @@ func (o *MustGatherOptions) newPod(node, image string) *corev1.Pod {
 			},
 			InitContainers: []corev1.Container{
 				{
-					Name:    "gather",
-					Image:   image,
-					Command: []string{"/usr/bin/gather"},
+					Name:            "gather",
+					Image:           image,
+					ImagePullPolicy: corev1.PullAlways,
+					Command:         []string{"/usr/bin/gather"},
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "must-gather-output",
@@ -508,9 +509,10 @@ func (o *MustGatherOptions) newPod(node, image string) *corev1.Pod {
 			},
 			Containers: []corev1.Container{
 				{
-					Name:    "copy",
-					Image:   image,
-					Command: []string{"/bin/bash", "-c", "trap : TERM INT; sleep infinity & wait"},
+					Name:            "copy",
+					Image:           image,
+					ImagePullPolicy: corev1.PullAlways,
+					Command:         []string{"/bin/bash", "-c", "trap : TERM INT; sleep infinity & wait"},
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "must-gather-output",


### PR DESCRIPTION
/assign @soltysh 

`oc adm must-gather` should use `ImagePullPolicy: "Always"`? 
 issue this PR resolves: 
```
Run oc adm must-gather --image docker.io/sallyom/must-gather:local then look at pod yaml of must-gather pod:
(pod yaml snippet)
start with:
      image: docker.io/sallyom/must-gather:local
      imageID: docker.io/sallyom/must-gather@sha256:b20516b99edb0dd40010f4084b16117e936863dd25ea24b363489

committed and pushed new image id to docker.io/sallyom/must-gather:local

    with "IfNotPresent" imagePullPolicy:
      image: docker.io/sallyom/must-gather:local
      imageID: docker.io/sallyom/must-gather@sha256:b20516b99edb0dd40010f4084b16117e936863dd25ea24b36348961cb4a
    with "Always" imagePullPolicy:
      image: docker.io/sallyom/must-gather:local
      imageID: docker.io/sallyom/must-gather@sha256:21aed5526cbc8db38c350cc74c57510f09b8b37425326c20ce2f9e7931b
```
