### PR TITLE
Bug 1867792: Allow prune to move on with Removed registry

### DIFF
--- a/pkg/cli/admin/prune/images/images.go
+++ b/pkg/cli/admin/prune/images/images.go
@@ -432,11 +432,11 @@ func (o PruneImagesOptions) Run() error {
 
 	registryPinger = &imageprune.DryRunRegistryPinger{}
 	registryClientFactory = imageprune.FakeRegistryClientFactory
-	if o.Confirm {
+	if o.Confirm && o.PruneRegistry != nil && *o.PruneRegistry {
 		if len(registryHost) == 0 {
 			registryHost, err = imageprune.DetermineRegistryHost(allImages, allStreams)
 			if err != nil {
-				return fmt.Errorf("unable to determine registry: %v", err)
+				return fmt.Errorf("unable to find the remote registry host: %v", err)
 			}
 		}
 
@@ -454,12 +454,9 @@ func (o PruneImagesOptions) Run() error {
 			return err
 		}
 
-		// we only need to ping the registry if we are going to access it.
-		if o.PruneRegistry != nil && *o.PruneRegistry {
-			registryPinger = &imageprune.DefaultRegistryPinger{
-				Client:   registryClient,
-				Insecure: insecure,
-			}
+		registryPinger = &imageprune.DefaultRegistryPinger{
+			Client:   registryClient,
+			Insecure: insecure,
 		}
 	}
 

--- a/pkg/cli/admin/prune/images/images_test.go
+++ b/pkg/cli/admin/prune/images/images_test.go
@@ -39,6 +39,42 @@ import (
 
 var logLevel = flag.Int("loglevel", 0, "")
 
+func TestPruneWithoutImagesWithRegistryAccess(t *testing.T) {
+	pruneRegistry := true
+	opts := &PruneImagesOptions{
+		Namespace:     "foo",
+		AppsClient:    &fakeappsv1client.FakeAppsV1{Fake: &(fakeappsclient.NewSimpleClientset().Fake)},
+		BuildClient:   &fakebuildv1client.FakeBuildV1{Fake: &(fakebuildclient.NewSimpleClientset().Fake)},
+		ImageClient:   &fakeimagev1client.FakeImageV1{Fake: &(fakeimageclient.NewSimpleClientset().Fake)},
+		KubeClient:    fakekubernetes.NewSimpleClientset(),
+		Out:           ioutil.Discard,
+		ErrOut:        os.Stderr,
+		Confirm:       true,
+		PruneRegistry: &pruneRegistry,
+	}
+
+	if err := opts.Run(); err == nil {
+		t.Errorf("expected 'unable to find the remote registry host' error, nil received instead")
+	}
+}
+
+func TestPruneWithoutImagesNoRegistryAccess(t *testing.T) {
+	opts := &PruneImagesOptions{
+		Namespace:   "foo",
+		AppsClient:  &fakeappsv1client.FakeAppsV1{Fake: &(fakeappsclient.NewSimpleClientset().Fake)},
+		BuildClient: &fakebuildv1client.FakeBuildV1{Fake: &(fakebuildclient.NewSimpleClientset().Fake)},
+		ImageClient: &fakeimagev1client.FakeImageV1{Fake: &(fakeimageclient.NewSimpleClientset().Fake)},
+		KubeClient:  fakekubernetes.NewSimpleClientset(),
+		Out:         ioutil.Discard,
+		ErrOut:      os.Stderr,
+		Confirm:     true,
+	}
+
+	if err := opts.Run(); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
 func TestImagePruneNamespaced(t *testing.T) {
 	var level klog.Level
 	level.Set(fmt.Sprint(*logLevel))


### PR DESCRIPTION
Pruner attempts to derive internal image registry host from the last
unmanaged image or from the last image stream created. In some cases
OpenShift may not contain any of those (for instance in a fresh install
with Removed registry), this makes pruner to fail even with the flag
--prune-registry set to false.

This commit allows the pruner job to move on with the --prune-registry
flag set to false even when we can't derive the internal registry host.