### PR TITLE
Bug 1868324: oc logout should make the token invalid

### DIFF
--- a/pkg/cli/logout/logout.go
+++ b/pkg/cli/logout/logout.go
@@ -2,8 +2,11 @@ package logout
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
@@ -20,6 +23,8 @@ import (
 	kubeconfiglib "github.com/openshift/oc/pkg/helpers/kubeconfig"
 	"github.com/openshift/oc/pkg/helpers/project"
 )
+
+const sha256Prefix = "sha256~"
 
 type LogoutOptions struct {
 	StartingKubeConfig *kclientcmdapi.Config
@@ -112,6 +117,7 @@ func (o LogoutOptions) Validate(args []string) error {
 
 func (o LogoutOptions) RunLogout() error {
 	token := o.Config.BearerToken
+	tokenName := o.Config.BearerToken
 
 	client, err := oauthv1client.NewForConfig(o.Config)
 	if err != nil {
@@ -123,7 +129,11 @@ func (o LogoutOptions) RunLogout() error {
 		return err
 	}
 
-	if err := client.OAuthAccessTokens().Delete(context.TODO(), token, metav1.DeleteOptions{}); err != nil {
+	if strings.HasPrefix(tokenName, sha256Prefix) {
+		tokenName = tokenToObjectName(tokenName)
+	}
+
+	if err := client.OAuthAccessTokens().Delete(context.TODO(), tokenName, metav1.DeleteOptions{}); err != nil {
 		klog.V(1).Infof("%v", err)
 	}
 
@@ -148,4 +158,26 @@ func deleteTokenFromConfig(config kclientcmdapi.Config, pathOptions *kclientcmd.
 		}
 	}
 	return kclientcmd.ModifyConfig(pathOptions, config, true)
+}
+
+// tokenToObjectName returns the oauthaccesstokens object name for the given raw token,
+// i.e. the sha256 hash prefixed with "sha256~".
+func tokenToObjectName(code string) string {
+	name, prefixed := trimSHA256Prefix(code)
+	if prefixed {
+		return sha256Token(name)
+	}
+	return name
+}
+
+func trimSHA256Prefix(code string) (string, bool) {
+	if !strings.HasPrefix(code, sha256Prefix) {
+		return code, false
+	}
+	return strings.TrimPrefix(code, sha256Prefix), true
+}
+
+func sha256Token(token string) string {
+	h := sha256.Sum256([]byte(token))
+	return sha256Prefix + base64.RawURLEncoding.EncodeToString(h[0:])
 }


### PR DESCRIPTION
Since openshift/enhancements#323, oc logout should delete the object name of oauthaccesstoken instead of token value.

And I didnt **import** [openshift/oauth-server](https://github.com/openshift/oauth-server),because this fix  just needs few funcs from that repo.  