### PR TITLE
Bug 1867594: Clarify which registry/repository fails with unauthorized

### DIFF
--- a/pkg/cli/admin/release/new.go
+++ b/pkg/cli/admin/release/new.go
@@ -1218,7 +1218,7 @@ func (o *NewOptions) write(r io.Reader, is *imageapi.ImageStream, now time.Time)
 		options.LayerStream = r
 		options.To = toRef.Exact()
 		if err := options.Run(); err != nil {
-			return err
+			return fmt.Errorf("failed to push image %s: %v", toRef.Exact(), err)
 		}
 		if !verifier.Verified() {
 			err := fmt.Errorf("the base image failed content verification and may have been tampered with")


### PR DESCRIPTION
With this cmd and a single auth file that contains the creds to quay.io/openshift-release-dev: 
`$ oc adm release new --from-release registry.svc.ci.openshift.org/ocp/release:4.6.0-0.nightly-2020-08-17-150352 --to-image quay.io/sallyom/origin-release:latest -a ~/installer/pull-secret`  
This fails when trying to push to quay.io/sallyom.  The message isn't clear on which registry/repository is failing auth.
With this PR, the error msg is more clear: 
`error: failed to push image quay.io/sallyom/origin-release:latest: unauthorized: access to the requested resource is not authorized`  

(b4 this PR error is this: `error: unauthorized: access to the requested resource is not authorized` with no indication of which auth failed) 