### PR TITLE
must-gather: use exponential backoff for polling

### DIFF
--- a/pkg/cli/admin/mustgather/mustgather.go
+++ b/pkg/cli/admin/mustgather/mustgather.go
@@ -397,9 +397,18 @@ func newPrefixWriter(out io.Writer, prefix string) io.Writer {
 	return writer
 }
 
+func (o *MustGatherOptions) getBackoff() wait.Backoff {
+	return wait.Backoff{
+		Duration: time.Second,
+		Factor:   2,
+		Steps:    10,
+		Cap:      time.Duration(o.Timeout) * time.Second,
+	}
+}
+
 func (o *MustGatherOptions) waitForPodRunning(pod *corev1.Pod) error {
 	phase := pod.Status.Phase
-	err := wait.PollImmediate(time.Minute, time.Duration(o.Timeout)*time.Second, func() (bool, error) {
+	err := wait.ExponentialBackoff(o.getBackoff(), func() (bool, error) {
 		var err error
 		if pod, err = o.Client.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{}); err != nil {
 			// at this stage pod should exist, we've been gathering container logs, so error if not found
@@ -425,7 +434,7 @@ func (o *MustGatherOptions) waitForPodRunning(pod *corev1.Pod) error {
 }
 
 func (o *MustGatherOptions) waitForGatherContainerRunning(pod *corev1.Pod) error {
-	return wait.PollImmediate(time.Minute, time.Duration(o.Timeout)*time.Second, func() (bool, error) {
+	return wait.ExponentialBackoff(o.getBackoff(), func() (bool, error) {
 		var err error
 		if pod, err = o.Client.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{}); err == nil {
 			if len(pod.Status.InitContainerStatuses) == 0 {


### PR DESCRIPTION
When running must-gather on a bare metal cluster, the command will fail
to find the pod after a 1 minute duration, and exit with an error
message in the form of `Get: $pod-url: unexpected EOF`.

This patch replaces the normal way of polling (every 1 minute), with an
exponential backoff starting with 1 second, and a factor of 2.  The
timeout value is unchanged.

Bug 1859972

Signed-off-by: Yuval Turgeman <yturgema@redhat.com>