### PR TITLE
pkg/cli/admin/release: Delegate to update-approvers

### DIFF
--- a/pkg/cli/admin/release/OWNERS
+++ b/pkg/cli/admin/release/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - update-approvers


### PR DESCRIPTION
Some subcommands within the release package interact with the
cluster-version operator, which is maintained by the updates (OTA) team.