### PR TITLE
Bug 1872709: Copy foreign layers from external sources during mirroring

### DIFF
--- a/pkg/cli/image/mirror/plan.go
+++ b/pkg/cli/image/mirror/plan.go
@@ -192,10 +192,20 @@ func (p *plan) CacheBlob(blob distribution.Descriptor) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
-	if existing, ok := p.blobs[blob.Digest]; ok && existing.Size > 0 {
+	existing, ok := p.blobs[blob.Digest]
+	if !ok {
+		p.blobs[blob.Digest] = blob
 		return
 	}
-	p.blobs[blob.Digest] = blob
+	if existing.Size == 0 {
+		existing.Size = blob.Size
+	}
+	if len(blob.URLs) > 0 {
+		urls := sets.NewString(existing.URLs...)
+		urls.Insert(blob.URLs...)
+		existing.URLs = urls.List()
+	}
+	p.blobs[blob.Digest] = existing
 }
 
 func (p *plan) GetBlob(digest godigest.Digest) distribution.Descriptor {
@@ -328,11 +338,12 @@ type registryPlan struct {
 	}
 }
 
-func (p *registryPlan) AssociateBlob(digest godigest.Digest, repo string) {
+func (p *registryPlan) AssociateBlob(repo string, desc distribution.Descriptor) {
+	p.parent.CacheBlob(desc)
+
 	p.lock.Lock()
 	defer p.lock.Unlock()
-
-	p.blobsByRepo[digest] = repo
+	p.blobsByRepo[desc.Digest] = repo
 }
 
 func (p *registryPlan) SavedManifest(srcDigest, dstDigest godigest.Digest) {
@@ -550,8 +561,7 @@ type repositoryBlobCopy struct {
 }
 
 func (p *repositoryBlobCopy) AlreadyExists(blob distribution.Descriptor) {
-	p.parent.parent.parent.CacheBlob(blob)
-	p.parent.parent.AssociateBlob(blob.Digest, p.parent.name)
+	p.parent.parent.AssociateBlob(p.parent.name, blob)
 	p.parent.ExpectBlob(blob.Digest)
 
 	p.lock.Lock()


### PR DESCRIPTION
A foreign image layer has a URL that points outside the current registry, such that the registry returns not found if the blob
is requested. Since mirror attempts to ensure the destination image can be pulled, even in the presence of disjoint networks,
and given that the Docker daemon will by default attempt the blob lookup first before checking URLs, always copy the blob
by checking the source registry, then trying to pull the layer URLs.

There may be scenarios where this is not desirable, and a future change may allow skipping mirror of those blobs.