### PR TITLE
Bug 1872363: Add EndpointSlices to list of namespace resources to collect

### DIFF
--- a/pkg/cli/admin/inspect/namespace.go
+++ b/pkg/cli/admin/inspect/namespace.go
@@ -23,6 +23,7 @@ func namespaceResourcesToCollect() []schema.GroupResource {
 		{Resource: "configmaps"},
 		{Resource: "events"},
 		{Resource: "endpoints"},
+		{Resource: "endpointslices"},
 		{Resource: "persistentvolumeclaims"},
 		{Resource: "secrets"},
 	}


### PR DESCRIPTION
Adds `endpointslices` to the resource list in the `namespaceResourcesToCollect()` function. This way, `oc adm inspect ns/<namespace>` will collect all EndpointSlices resources and place them in `namespaces/<namespace>/discovery.k8s.io/endpoints.yaml`. 

The [OpenShift Router](github.com/openshift/router) uses `EndpointSlices` by default in 4.6, so this change is needed to add `EndpointSlices` resources to `must-gather` outputs on a per-namespace basis in 4.6.
