### PR TITLE
Bug 1874293: pkg/cli/admin/upgrade/: Mention Upgradeable=False

### DIFF
--- a/pkg/cli/admin/upgrade/upgrade.go
+++ b/pkg/cli/admin/upgrade/upgrade.go
@@ -317,6 +317,10 @@ func (o *Options) Run() error {
 		}
 		fmt.Fprintln(o.Out)
 
+		if c := findCondition(cv.Status.Conditions, configv1.OperatorUpgradeable); c != nil && c.Status == configv1.ConditionFalse {
+			fmt.Fprintf(o.Out, "Upgradeable=False\n\n  Reason: %s\n  Message: %s\n\n", c.Reason, c.Message)
+		}
+
 		if len(cv.Status.AvailableUpdates) > 0 {
 			fmt.Fprintf(o.Out, "Updates:\n\n")
 			w := tabwriter.NewWriter(o.Out, 0, 2, 1, ' ', 0)


### PR DESCRIPTION
When `Upgradeable=False`, the cluster-version operator will block (usually) minor version bumps.  [Sometimes][1] it will block all version bumps.  Users running `oc adm upgrade` should be notified about these conditions, so they are not surprised if they choose a target and the CVO subsequently blocks the chosen update.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1822844