### PR TITLE
Bug 1866399: lessen retries in must-gather

### DIFF
--- a/pkg/cli/admin/mustgather/mustgather.go
+++ b/pkg/cli/admin/mustgather/mustgather.go
@@ -398,7 +398,7 @@ func newPrefixWriter(out io.Writer, prefix string) io.Writer {
 }
 
 func (o *MustGatherOptions) waitForGatherToComplete(pod *corev1.Pod) error {
-	err := wait.PollImmediate(3*time.Second, time.Duration(o.Timeout)*time.Second, func() (bool, error) {
+	err := wait.PollImmediate(10*time.Second, time.Duration(o.Timeout)*time.Second, func() (bool, error) {
 		var err error
 		if pod, err = o.Client.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{}); err != nil {
 			// at this stage pod should exist, we've been gathering container logs, so error if not found
@@ -435,7 +435,7 @@ func (o *MustGatherOptions) waitForGatherToComplete(pod *corev1.Pod) error {
 }
 
 func (o *MustGatherOptions) waitForGatherContainerRunning(pod *corev1.Pod) error {
-	return wait.PollImmediate(3*time.Second, time.Duration(o.Timeout)*time.Second, func() (bool, error) {
+	return wait.PollImmediate(10*time.Second, time.Duration(o.Timeout)*time.Second, func() (bool, error) {
 		var err error
 		if pod, err = o.Client.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{}); err == nil {
 			if len(pod.Status.ContainerStatuses) == 0 {


### PR DESCRIPTION
Increase retry intervals in must-gather. 3s proved too short for some,
resulted in too many retries.  10s is a fine compromise.