### PR TITLE
Bug 1812813: oc adm must-gather: add empty node-selector annotation to namespace

### DIFF
--- a/pkg/cli/admin/mustgather/mustgather.go
+++ b/pkg/cli/admin/mustgather/mustgather.go
@@ -236,7 +236,8 @@ func (o *MustGatherOptions) Run() error {
 				"openshift.io/run-level": "0",
 			},
 			Annotations: map[string]string{
-				"oc.openshift.io/command": "oc adm must-gather",
+				"oc.openshift.io/command":    "oc adm must-gather",
+				"openshift.io/node-selector": "",
 			},
 		},
 	}, metav1.CreateOptions{})


### PR DESCRIPTION
Without this, 'oc adm must-gather' fails when defaultNodeSelector is set and the
must-gather namespace is created on a node without the matching labels.
This PR adds the annotation 'openshift.io/node-selector: ""' to the
must-gather namespace to override a configured defaultNodeSelector.

/assign @soltysh 
/cc @deads2k 