### PR TITLE
TEST UPSTREAM CHANGE: DO NOT MERGE

### DIFF
--- a/vendor/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/vendor/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -552,6 +552,13 @@ func (config *inClusterClientConfig) ClientConfig() (*restclient.Config, error) 
 			icc.BearerToken = config.overrides.AuthInfo.Token
 			icc.BearerTokenFile = config.overrides.AuthInfo.TokenFile
 		}
+		if len(config.overrides.AuthInfo.Impersonate) > 0 || len(config.overrides.AuthInfo.ImpersonateGroups) > 0 {
+			icc.Impersonate = restclient.ImpersonationConfig{
+				UserName: config.overrides.AuthInfo.Impersonate,
+				Groups:   config.overrides.AuthInfo.ImpersonateGroups,
+				Extra:    config.overrides.AuthInfo.ImpersonateUserExtra,
+			}
+		}
 		if certificateAuthorityFile := config.overrides.ClusterInfo.CertificateAuthority; len(certificateAuthorityFile) > 0 {
 			icc.TLSClientConfig.CAFile = certificateAuthorityFile
 		}


### PR DESCRIPTION
* added this change, then built an oc image `quay.io/sallyom/testcli:test` 
* added this to kubernetes/kubernetes then built kubectl image `quay.io/sallyom/testcli:kubectl-new`
then:
* created pod/testpod w/ serviceAccount w/ cluster-admin & this testcli:test:
```console
$ oc rsh testpod
sh-4.2# oc whoami
system:serviceaccount:sotest:testsa
sh-4.2# oc --as system:admin get pods
NAME              READY   STATUS    RESTARTS   AGE
testpod           1/1     Running   0          83m
testpod-kubectl   1/1     Running   0          34m
```
When I run the same test with the kubectl image that has this change:
* created pod/testpod-kubectl w/ serviceAccount w/ cluster-admin & testcli:kubectl-new:
```console
$ oc rsh testpod-kubectl
sh-4.2# oc get pods
NAME              READY   STATUS    RESTARTS   AGE
testpod           1/1     Running   0          96m
testpod-kubectl   1/1     Running   0          48m
sh-4.2# kubectl --as system:admin get pods
The connection to the server localhost:8080 was refused - did you specify the right host or port?

sh-4.2# KUBERNETES_MASTER=https://172.30.0.1:443 kubectl --as system:admin get pods
Please enter Username:

```

/cc @soltysh @tnozicka  is this client-go change all that's needed? It fixes the Impersonate issue from https://bugzilla.redhat.com/show_bug.cgi?id=1873210 for oc, but kubectl behaves differently.  It requires KUBERNETES_MASTER be set in env or it defaults to `localhost:8080` [see carry patch](https://github.com/openshift/kubernetes-client-go/commit/9409de4c95e06ed9815076454d0e33c823bededf).  When I set this in the pod, however, kubectl will then default to the username/password prompt.  
