### PR TITLE
explicit-upgrade doc usage

### DIFF
--- a/pkg/cli/admin/upgrade/upgrade.go
+++ b/pkg/cli/admin/upgrade/upgrade.go
@@ -81,7 +81,7 @@ func New(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command
 	flags.BoolVar(&o.ToLatestAvailable, "to-latest", o.ToLatestAvailable, "Use the next available version")
 	flags.BoolVar(&o.Clear, "clear", o.Clear, "If an upgrade has been requested but not yet downloaded, cancel the update. This has no effect once the update has started.")
 	flags.BoolVar(&o.Force, "force", o.Force, "Forcefully upgrade the cluster even when upgrade release image validation fails and the cluster is reporting errors.")
-	flags.BoolVar(&o.AllowExplicitUpgrade, "allow-explicit-upgrade", o.AllowExplicitUpgrade, "Upgrade even if the upgrade target is not listed in the available versions list.")
+	flags.BoolVar(&o.AllowExplicitUpgrade, "allow-explicit-upgrade", o.AllowExplicitUpgrade, "Upgrade even if the upgrade target is not listed in the available versions list. Requires --to-image.")
 	flags.BoolVar(&o.AllowUpgradeWithWarnings, "allow-upgrade-with-warnings", o.AllowUpgradeWithWarnings, "Upgrade even if an upgrade is in process or a cluster error is blocking the update.")
 	return cmd
 }


### PR DESCRIPTION
```
oc adm upgrade --to-image quay.io/openshift-release-dev/ocp-release@sha256:3ad6bab0bfb5642ef18ebbfc9f011da6cdcd950f5f8ccbf5b34c6c5cc0b4c289 --allow-explicit-upgrade 
warning: The requested upgrade image is not one of the available updates.  You have used --allow-explicit-upgrade to the update to preceed anyway
Updating to release image quay.io/openshift-release-dev/ocp-release@sha256:3ad6bab0bfb5642ef18ebbfc9f011da6cdcd950f5f8ccbf5b34c6c5cc0b4c289
```

```
oc adm upgrade --allow-explicit-upgrade --to 4.5.0-0.hotfix-2020-08-24-185832 
error: The update 4.5.0-0.hotfix-2020-08-24-185832 is not one of the available updates: 4.4.17, 4.4.18
```