### PR TITLE
oc login: Show tokenURL message if only IDP is basic and user has not provided username

### DIFF
--- a/pkg/cli/login/login.go
+++ b/pkg/cli/login/login.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/openshift/oc/pkg/helpers/flagtypes"
 	kubeconfiglib "github.com/openshift/oc/pkg/helpers/kubeconfig"
+	"github.com/openshift/oc/pkg/helpers/tokencmd"
 )
 
 var (
@@ -59,10 +60,11 @@ func NewCmdLogin(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra
 			kcmdutil.CheckErr(o.Validate(cmd, kcmdutil.GetFlagString(cmd, "server"), args))
 
 			if err := o.Run(); kapierrors.IsUnauthorized(err) {
-				fmt.Fprintln(streams.Out, "Login failed (401 Unauthorized)")
-				fmt.Fprintln(streams.Out, "Verify you have provided correct credentials.")
-
 				if err, isStatusErr := err.(*kapierrors.StatusError); isStatusErr {
+					if err.Status().Message != tokencmd.BasicAuthNoUsernameMessage {
+						fmt.Fprintln(streams.Out, "Login failed (401 Unauthorized)")
+						fmt.Fprintln(streams.Out, "Verify you have provided correct credentials.")
+					}
 					if details := err.Status().Details; details != nil {
 						for _, cause := range details.Causes {
 							fmt.Fprintln(streams.Out, cause.Message)

--- a/pkg/helpers/tokencmd/basicauth_test.go
+++ b/pkg/helpers/tokencmd/basicauth_test.go
@@ -44,7 +44,7 @@ func TestHandleChallenge(t *testing.T) {
 					ExpectedCanHandle: true,
 					ExpectedHeaders:   nil,
 					ExpectedHandled:   false,
-					ExpectedErr:       nil,
+					ExpectedErr:       NewBasicAuthNoUsernameError(),
 					ExpectedPrompt:    "",
 				},
 			},
@@ -94,34 +94,6 @@ func TestHandleChallenge(t *testing.T) {
 					ExpectedPrompt: `Authentication required for myhost (myrealm)
 Username: myuser
 Password: `,
-				},
-			},
-		},
-
-		"interactive challenge": {
-			Handler: &BasicChallengeHandler{
-				Host:     "myhost",
-				Reader:   bytes.NewBufferString("myuser\nmypassword\n"),
-				Username: "",
-				Password: "",
-			},
-			Challenges: []Challenge{
-				{
-					Headers:           basicChallenge,
-					ExpectedCanHandle: true,
-					ExpectedHeaders:   http.Header{AUTHORIZATION: []string{getBasicHeader("myuser", "mypassword")}},
-					ExpectedHandled:   true,
-					ExpectedErr:       nil,
-					ExpectedPrompt: `Authentication required for myhost (myrealm)
-Username: Password: `,
-				},
-				{
-					Headers:           basicChallenge,
-					ExpectedCanHandle: true,
-					ExpectedHeaders:   nil,
-					ExpectedHandled:   false,
-					ExpectedErr:       nil,
-					ExpectedPrompt:    ``,
 				},
 			},
 		},
@@ -185,9 +157,7 @@ Username: Password: `,
 					ExpectedHeaders:   nil,
 					ExpectedHandled:   false,
 					ExpectedErr:       errors.New("username system:admin is invalid for basic auth"),
-					ExpectedPrompt: `Authentication required for myhost (myrealm)
-Username: system:admin
-Password: `,
+					ExpectedPrompt:    "",
 				},
 			},
 		},

--- a/pkg/helpers/tokencmd/request_token_test.go
+++ b/pkg/helpers/tokencmd/request_token_test.go
@@ -149,6 +149,7 @@ func TestRequestToken(t *testing.T) {
 
 	basicChallenge1 := resp{401, "", []string{"Basic realm=foo"}}
 	basicRequest1 := req{"Basic bXl1c2VyOm15cGFzc3dvcmQ=", "", ""} // base64("myuser:mypassword")
+	basicRequestOnlyUsername := req{"Basic bXl1c2VyOg==", "", ""}  // base64("myuser:")
 	basicChallenge2 := resp{401, "", []string{"Basic realm=seriously...foo"}}
 
 	negotiateChallenge1 := resp{401, "", []string{"Negotiate"}}
@@ -213,18 +214,27 @@ func TestRequestToken(t *testing.T) {
 			},
 			ExpectedError: "unhandled challenge",
 		},
-		"failing basic handler, basic challenge, failure": {
+		"no username, basic challenge, failure": {
 			Handler: &BasicChallengeHandler{},
 			Requests: []requestResponse{
 				{initialHead, initialHeadResp},
 				{initialRequest, basicChallenge1},
+			},
+			ExpectedError: BasicAuthNoUsernameMessage,
+		},
+		"failing basic handler, basic challenge, failure": {
+			Handler: &BasicChallengeHandler{Username: "myuser"},
+			Requests: []requestResponse{
+				{initialHead, initialHeadResp},
+				{initialRequest, basicChallenge1},
+				{basicRequestOnlyUsername, basicChallenge1},
 			},
 			ExpectedError: "challenger chose not to retry the request",
 		},
 
 		// Prompting basic handler
 		"prompting basic handler, no challenge, success": {
-			Handler: &BasicChallengeHandler{Reader: bytes.NewBufferString("myuser\nmypassword\n")},
+			Handler: &BasicChallengeHandler{Username: "myuser", Reader: bytes.NewBufferString("mypassword\n")},
 			Requests: []requestResponse{
 				{initialHead, initialHeadResp},
 				{initialRequest, success},
@@ -232,7 +242,7 @@ func TestRequestToken(t *testing.T) {
 			ExpectedToken: successfulToken,
 		},
 		"prompting basic handler, basic challenge, success": {
-			Handler: &BasicChallengeHandler{Reader: bytes.NewBufferString("myuser\nmypassword\n")},
+			Handler: &BasicChallengeHandler{Username: "myuser", Reader: bytes.NewBufferString("mypassword\n")},
 			Requests: []requestResponse{
 				{initialHead, initialHeadResp},
 				{initialRequest, basicChallenge1},
@@ -241,7 +251,7 @@ func TestRequestToken(t *testing.T) {
 			ExpectedToken: successfulToken,
 		},
 		"prompting basic handler, basic+negotiate challenge, success": {
-			Handler: &BasicChallengeHandler{Reader: bytes.NewBufferString("myuser\nmypassword\n")},
+			Handler: &BasicChallengeHandler{Username: "myuser", Reader: bytes.NewBufferString("mypassword\n")},
 			Requests: []requestResponse{
 				{initialHead, initialHeadResp},
 				{initialRequest, doubleChallenge},
@@ -250,11 +260,11 @@ func TestRequestToken(t *testing.T) {
 			ExpectedToken: successfulToken,
 		},
 		"prompting basic handler, basic challenge, failure": {
-			Handler: &BasicChallengeHandler{Reader: bytes.NewBufferString("myuser\nmypassword\n")},
+			Handler: &BasicChallengeHandler{Username: "myuser"},
 			Requests: []requestResponse{
 				{initialHead, initialHeadResp},
 				{initialRequest, basicChallenge1},
-				{basicRequest1, basicChallenge2},
+				{basicRequestOnlyUsername, basicChallenge2},
 			},
 			ExpectedError: "challenger chose not to retry the request",
 		},
@@ -381,7 +391,7 @@ func TestRequestToken(t *testing.T) {
 		"failing negotiate+prompting basic handler, negotiate+basic challenge, success": {
 			Handler: NewMultiHandler(
 				&NegotiateChallengeHandler{negotiator: &failingNegotiator{}},
-				&BasicChallengeHandler{Reader: bytes.NewBufferString("myuser\nmypassword\n")},
+				&BasicChallengeHandler{Username: "myuser", Reader: bytes.NewBufferString("mypassword\n")},
 			),
 			Requests: []requestResponse{
 				{initialHead, initialHeadResp},


### PR DESCRIPTION
* If a user provides `oc login -u anything`, try for basic auth prompt. 
* If only password IDP available, and no username was provided, show the tokenURL message instead of basic auth prompt. 