### PR TITLE
bug 1875551: must-gather: move gather init container under containers

### DIFF
--- a/pkg/cli/admin/mustgather/mustgather.go
+++ b/pkg/cli/admin/mustgather/mustgather.go
@@ -300,7 +300,7 @@ func (o *MustGatherOptions) Run() error {
 
 			// wait for pod to be running (gather has completed)
 			log("waiting for gather to complete")
-			if err := o.waitForPodRunning(pod); err != nil {
+			if err := o.waitForGatherToComplete(pod); err != nil {
 				log("gather never finished: %v", err)
 				errs <- fmt.Errorf("gather never finished for pod %s: %s", pod.Name, err)
 				return
@@ -344,7 +344,7 @@ func (o *MustGatherOptions) log(format string, a ...interface{}) {
 func (o *MustGatherOptions) copyFilesFromPod(pod *corev1.Pod) error {
 	streams := o.IOStreams
 	streams.Out = newPrefixWriter(streams.Out, fmt.Sprintf("[%s] OUT", pod.Name))
-	destDir := path.Join(o.DestDir, regexp.MustCompile("[^A-Za-z0-9]+").ReplaceAllString(pod.Status.InitContainerStatuses[0].ImageID, "-"))
+	destDir := path.Join(o.DestDir, regexp.MustCompile("[^A-Za-z0-9]+").ReplaceAllString(pod.Status.ContainerStatuses[0].ImageID, "-"))
 	if err := os.MkdirAll(destDir, 0775); err != nil {
 		return err
 	}
@@ -355,7 +355,7 @@ func (o *MustGatherOptions) copyFilesFromPod(pod *corev1.Pod) error {
 		Destination:   &rsync.PathSpec{PodName: "", Path: destDir},
 		Client:        o.Client,
 		Config:        o.Config,
-		RshCmd:        fmt.Sprintf("%s --namespace=%s", o.RsyncRshCmd, pod.Namespace),
+		RshCmd:        fmt.Sprintf("%s --namespace=%s -c copy", o.RsyncRshCmd, pod.Namespace),
 		IOStreams:     streams,
 	}
 	rsyncOptions.Strategy = rsync.NewDefaultCopyStrategy(rsyncOptions)
@@ -368,7 +368,7 @@ func (o *MustGatherOptions) getGatherContainerLogs(pod *corev1.Pod) error {
 		ResourceArg: pod.Name,
 		Options: &corev1.PodLogOptions{
 			Follow:    true,
-			Container: pod.Spec.InitContainers[0].Name,
+			Container: pod.Spec.Containers[0].Name,
 		},
 		RESTClientGetter: o.RESTClientGetter,
 		Object:           pod,
@@ -389,8 +389,7 @@ func newPrefixWriter(out io.Writer, prefix string) io.Writer {
 	return writer
 }
 
-func (o *MustGatherOptions) waitForPodRunning(pod *corev1.Pod) error {
-	phase := pod.Status.Phase
+func (o *MustGatherOptions) waitForGatherToComplete(pod *corev1.Pod) error {
 	err := wait.PollImmediate(time.Duration(o.Timeout)*time.Second, time.Minute, func() (bool, error) {
 		var err error
 		if pod, err = o.Client.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{}); err != nil {
@@ -400,15 +399,26 @@ func (o *MustGatherOptions) waitForPodRunning(pod *corev1.Pod) error {
 			}
 			return false, nil
 		}
-		phase = pod.Status.Phase
-		switch phase {
-		case corev1.PodRunning:
-			return true, nil
-		case corev1.PodFailed, corev1.PodSucceeded:
-			return true, fmt.Errorf("%s/%s unexpected pod phase: %s", pod.Namespace, pod.Name, phase)
-		default:
+		var state *corev1.ContainerState
+		for _, cstate := range pod.Status.ContainerStatuses {
+			if cstate.Name == "gather" {
+				state = &cstate.State
+				break
+			}
+		}
+
+		// missing status for gather container => timeout in the worst case
+		if state == nil {
 			return false, nil
 		}
+
+		if state.Terminated != nil {
+			if state.Terminated.ExitCode == 0 {
+				return true, nil
+			}
+			return true, fmt.Errorf("%s/%s unexpectedly terminated: exit code: %v, reason: %s, message: %s", pod.Namespace, pod.Name, state.Terminated.ExitCode, state.Terminated.Reason, state.Terminated.Message)
+		}
+		return false, nil
 	})
 	if err != nil {
 		return err
@@ -420,10 +430,10 @@ func (o *MustGatherOptions) waitForGatherContainerRunning(pod *corev1.Pod) error
 	return wait.PollImmediate(time.Duration(o.Timeout)*time.Second, time.Minute, func() (bool, error) {
 		var err error
 		if pod, err = o.Client.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{}); err == nil {
-			if len(pod.Status.InitContainerStatuses) == 0 {
+			if len(pod.Status.ContainerStatuses) == 0 {
 				return false, nil
 			}
-			state := pod.Status.InitContainerStatuses[0].State
+			state := pod.Status.ContainerStatuses[0].State
 			if state.Waiting != nil && state.Waiting.Reason == "ErrImagePull" {
 				return true, fmt.Errorf("unable to pull image: %v: %v", state.Waiting.Reason, state.Waiting.Message)
 			}
@@ -484,7 +494,7 @@ func (o *MustGatherOptions) newPod(node, image string) *corev1.Pod {
 					},
 				},
 			},
-			InitContainers: []corev1.Container{
+			Containers: []corev1.Container{
 				{
 					Name:    "gather",
 					Image:   image,
@@ -497,8 +507,6 @@ func (o *MustGatherOptions) newPod(node, image string) *corev1.Pod {
 						},
 					},
 				},
-			},
-			Containers: []corev1.Container{
 				{
 					Name:    "copy",
 					Image:   image,
@@ -521,7 +529,7 @@ func (o *MustGatherOptions) newPod(node, image string) *corev1.Pod {
 		},
 	}
 	if len(o.Command) > 0 {
-		ret.Spec.InitContainers[0].Command = o.Command
+		ret.Spec.Containers[0].Command = o.Command
 	}
 	return ret
 }


### PR DESCRIPTION
Move `gather` container from init containers into containers so the pod does not stay in `Pending` state until gather container is finished. Otherwise, `KubePodNotReady` alert gets triggered.

Once the gathering phase is finished, must-gather pod drops to NotReady state since `gather` container terminates:
```
NAME                READY   STATUS     RESTARTS   AGE
must-gather-sr295   1/2     NotReady   0          4m18s
```

Having a pod in `NotReady` status might still be better than having it in `Pending`. The copy phase should take less than the gathering one (depending on the network bandwidth).

Backporting https://github.com/openshift/oc/pull/540