### PR TITLE
[release-4.5] bug 1877805: Bump k8s.io/kubectl to pick https://github.com/openshift/kubernetes-kubectl/pull/31

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,12 +61,12 @@ require (
 	golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	gopkg.in/ldap.v2 v2.5.1
-	k8s.io/api v0.18.2
-	k8s.io/apimachinery v0.18.2
+	k8s.io/api v0.18.8
+	k8s.io/apimachinery v0.18.8
 	k8s.io/apiserver v0.18.2
-	k8s.io/cli-runtime v0.18.2
+	k8s.io/cli-runtime v0.18.8
 	k8s.io/client-go v8.0.0+incompatible
-	k8s.io/component-base v0.18.2
+	k8s.io/component-base v0.18.8
 	k8s.io/klog v1.0.0
 	k8s.io/kubectl v0.18.2
 	k8s.io/kubernetes v1.13.0
@@ -101,7 +101,7 @@ replace (
 	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.18.2
 	k8s.io/kube-proxy => k8s.io/kube-proxy v0.18.2
 	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.18.2
-	k8s.io/kubectl => github.com/openshift/kubernetes-kubectl v0.0.0-20200507115706-2f87de22f81a
+	k8s.io/kubectl => github.com/openshift/kubernetes-kubectl v0.0.0-20200910133141-9d89ff16e58d
 	k8s.io/kubelet => k8s.io/kubelet v0.18.2
 	k8s.io/kubernetes => github.com/openshift/kubernetes v1.17.0-alpha.0.0.20200427141011-f0879866c662
 	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.18.2

--- a/go.sum
+++ b/go.sum
@@ -258,6 +258,7 @@ github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/euank/go-kmsg-parser v2.0.0+incompatible/go.mod h1:MhmAMZ8V4CYH4ybgdRwPr2TU5ThnS43puaKEMpja1uw=
+github.com/evanphx/json-patch v0.0.0-20200808040245-162e5629780b/go.mod h1:NAJj0yf/KaRKURN6nyi7A9IZydMivZEm9oQLWNjfKDc=
 github.com/evanphx/json-patch v4.2.0+incompatible h1:fUDGZCv/7iAN7u0puUVhvKCcsR6vRfwrJatElLBEf0I=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d h1:105gxyaGwCFad8crR9dcMQWvV9Hvulu6hwUh4tWPJnM=
@@ -528,6 +529,7 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/jackc/fake v0.0.0-20150926172116-812a484cc733/go.mod h1:WrMFNQdiFJ80sQsxDoMokWK1W5TQtxBFNpzWTD84ibQ=
 github.com/jackc/pgx v3.2.0+incompatible/go.mod h1:0ZGrqGqkRlliWnWB4zKnWtjbSWbGkVEFm4TeybAXq+I=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
+github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a/go.mod h1:wK6yTYYcgjHE1Z1QtXACPDjcFJyBskHEdagmnq3vsP8=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
@@ -718,8 +720,8 @@ github.com/openshift/kubernetes-cli-runtime v0.0.0-20200507115657-2fb95e953778 h
 github.com/openshift/kubernetes-cli-runtime v0.0.0-20200507115657-2fb95e953778/go.mod h1:yfFR2sQQzDsV0VEKGZtrJwEy4hLZ2oj4ZIfodgxAHWQ=
 github.com/openshift/kubernetes-client-go v0.0.0-20200507115529-5e2a2d83bced h1:tFIeR3M66xC/l+tuhlZKfK+OCMNk7ZfqeJQaR1ofoRo=
 github.com/openshift/kubernetes-client-go v0.0.0-20200507115529-5e2a2d83bced/go.mod h1:Xcm5wVGXX9HAA2JJ2sSBUn3tCJ+4SVlCbl2MNNv+CIU=
-github.com/openshift/kubernetes-kubectl v0.0.0-20200507115706-2f87de22f81a h1:BG3HbZLvm1NlUkDoelF+vPG+Lnz6mKu0cPNAD800TDU=
-github.com/openshift/kubernetes-kubectl v0.0.0-20200507115706-2f87de22f81a/go.mod h1:OdgFa3AlsPKRpFFYE7ICTwulXOcMGXHTc+UKhHKvrb4=
+github.com/openshift/kubernetes-kubectl v0.0.0-20200910133141-9d89ff16e58d h1:8hGPmPOz4imclVCcpVVYj29LC0p7d94/5PotxsI/AbU=
+github.com/openshift/kubernetes-kubectl v0.0.0-20200910133141-9d89ff16e58d/go.mod h1:PlEgIAjOMua4hDFTEkVf+W5M0asHUKfE4y7VDZkpLHM=
 github.com/openshift/library-go v0.0.0-20200506083334-710b0bd21d0c h1:mo1sYI/JNNgXhoaSzGQdQceyWDC3Q1VYkFMmu1TQ6nc=
 github.com/openshift/library-go v0.0.0-20200506083334-710b0bd21d0c/go.mod h1:2kWwXTkpoQJUN3jZ3QW88EIY1hdRMqxgRs2hheEW/pg=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
@@ -1247,6 +1249,8 @@ k8s.io/kube-aggregator v0.18.2/go.mod h1:ijq6FnNUoKinA6kKbkN6svdTacSoQVNtKqmQ1+X
 k8s.io/kube-controller-manager v0.18.2/go.mod h1:v45wCqexTrOltgwj92V4ve7hm5f70GQzi4a47/RQ0HQ=
 k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c h1:/KUFqjjqAcY4Us6luF5RDNZ16KJtb49HfR3ZHB9qYXM=
 k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c/go.mod h1:GRQhZsXIAJ1xR0C9bd8UpWHZ5plfAS9fzPjJuQ6JL3E=
+k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6 h1:Oh3Mzx5pJ+yIumsAD0MOECPVeXsVot0UkiaCGVyfGQY=
+k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6/go.mod h1:GRQhZsXIAJ1xR0C9bd8UpWHZ5plfAS9fzPjJuQ6JL3E=
 k8s.io/kube-proxy v0.18.2/go.mod h1:VTgyDMdylYGgHVqLQo/Nt4yDWkh/LRsSnxRiG8GVgDo=
 k8s.io/kube-scheduler v0.18.2/go.mod h1:dL+C0Hp/ahQOQK3BsgmV8btb3BtMZvz6ONUw/v1N8sk=
 k8s.io/kubelet v0.18.2/go.mod h1:7x/nzlIWJLg7vOfmbQ4lgsYazEB0gOhjiYiHK1Gii4M=

--- a/vendor/k8s.io/kube-openapi/pkg/util/proto/validation/types.go
+++ b/vendor/k8s.io/kube-openapi/pkg/util/proto/validation/types.go
@@ -210,7 +210,7 @@ func (item *primitiveItem) VisitPrimitive(schema *proto.Primitive) {
 		}
 	case proto.Number:
 		switch item.Kind {
-		case proto.Number:
+		case proto.Integer, proto.Number:
 			return
 		}
 	case proto.String:

--- a/vendor/k8s.io/kubectl/pkg/cmd/certificates/certificates.go
+++ b/vendor/k8s.io/kubectl/pkg/cmd/certificates/certificates.go
@@ -222,7 +222,7 @@ func (o *CertificateOptions) modifyCertificateCondition(builder *resource.Builde
 		WithScheme(scheme.Scheme, scheme.Scheme.PrioritizedVersionsAllGroups()...).
 		ContinueOnError().
 		FilenameParam(false, &o.FilenameOptions).
-		ResourceNames("certificatesigningrequest", o.csrNames...).
+		ResourceNames("certificatesigningrequests.v1beta1.certificates.k8s.io", o.csrNames...).
 		RequireObject(true).
 		Flatten().
 		Latest().
@@ -232,7 +232,10 @@ func (o *CertificateOptions) modifyCertificateCondition(builder *resource.Builde
 			return err
 		}
 		for i := 0; ; i++ {
-			csr := info.Object.(*certificatesv1beta1.CertificateSigningRequest)
+			csr, ok := info.Object.(*certificatesv1beta1.CertificateSigningRequest)
+			if !ok {
+				return fmt.Errorf("can only handle certificates.k8s.io/v1beta1 certificate signing requests")
+			}
 			csr, hasCondition := modify(csr)
 			if !hasCondition || force {
 				_, err = clientSet.CertificateSigningRequests().UpdateApproval(context.TODO(), csr, metav1.UpdateOptions{})

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -689,7 +689,7 @@ gopkg.in/inf.v0
 gopkg.in/ldap.v2
 # gopkg.in/yaml.v2 v2.2.8
 gopkg.in/yaml.v2
-# k8s.io/api v0.18.2 => k8s.io/api v0.18.2
+# k8s.io/api v0.18.8 => k8s.io/api v0.18.2
 k8s.io/api/admission/v1
 k8s.io/api/admission/v1beta1
 k8s.io/api/admissionregistration/v1
@@ -736,7 +736,7 @@ k8s.io/api/storage/v1beta1
 # k8s.io/apiextensions-apiserver v0.18.2 => k8s.io/apiextensions-apiserver v0.18.2
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1
-# k8s.io/apimachinery v0.18.2 => github.com/openshift/kubernetes-apimachinery v0.0.0-20200427132717-228307e8b83c
+# k8s.io/apimachinery v0.18.8 => github.com/openshift/kubernetes-apimachinery v0.0.0-20200427132717-228307e8b83c
 k8s.io/apimachinery/pkg/api/apitesting
 k8s.io/apimachinery/pkg/api/equality
 k8s.io/apimachinery/pkg/api/errors
@@ -809,7 +809,7 @@ k8s.io/apiserver/pkg/server/healthz
 k8s.io/apiserver/pkg/server/httplog
 k8s.io/apiserver/pkg/storage/names
 k8s.io/apiserver/pkg/util/feature
-# k8s.io/cli-runtime v0.18.2 => github.com/openshift/kubernetes-cli-runtime v0.0.0-20200507115657-2fb95e953778
+# k8s.io/cli-runtime v0.18.8 => github.com/openshift/kubernetes-cli-runtime v0.0.0-20200507115657-2fb95e953778
 k8s.io/cli-runtime/pkg/genericclioptions
 k8s.io/cli-runtime/pkg/genericclioptions/openshiftpatch
 k8s.io/cli-runtime/pkg/kustomize
@@ -962,7 +962,7 @@ k8s.io/client-go/util/jsonpath
 k8s.io/client-go/util/keyutil
 k8s.io/client-go/util/retry
 k8s.io/client-go/util/workqueue
-# k8s.io/component-base v0.18.2 => k8s.io/component-base v0.18.2
+# k8s.io/component-base v0.18.8 => k8s.io/component-base v0.18.2
 k8s.io/component-base/cli/flag
 k8s.io/component-base/featuregate
 k8s.io/component-base/logs
@@ -971,12 +971,12 @@ k8s.io/component-base/metrics/legacyregistry
 k8s.io/component-base/version
 # k8s.io/klog v1.0.0
 k8s.io/klog
-# k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c
+# k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6
 k8s.io/kube-openapi/pkg/common
 k8s.io/kube-openapi/pkg/util/proto
 k8s.io/kube-openapi/pkg/util/proto/testing
 k8s.io/kube-openapi/pkg/util/proto/validation
-# k8s.io/kubectl v0.18.2 => github.com/openshift/kubernetes-kubectl v0.0.0-20200507115706-2f87de22f81a
+# k8s.io/kubectl v0.18.2 => github.com/openshift/kubernetes-kubectl v0.0.0-20200910133141-9d89ff16e58d
 k8s.io/kubectl/pkg/apps
 k8s.io/kubectl/pkg/cmd
 k8s.io/kubectl/pkg/cmd/annotate
@@ -1125,7 +1125,7 @@ k8s.io/kubernetes/pkg/kubectl/cmd/cp
 k8s.io/kubernetes/pkg/registry/rbac/reconciliation
 k8s.io/kubernetes/pkg/registry/rbac/validation
 k8s.io/kubernetes/pkg/util/parsers
-# k8s.io/metrics v0.18.2 => k8s.io/metrics v0.18.2
+# k8s.io/metrics v0.18.8 => k8s.io/metrics v0.18.2
 k8s.io/metrics/pkg/apis/metrics
 k8s.io/metrics/pkg/apis/metrics/v1alpha1
 k8s.io/metrics/pkg/apis/metrics/v1beta1


### PR DESCRIPTION
Picking upstream https://github.com/kubernetes/kubernetes/pull/94475 and https://github.com/kubernetes/kubernetes/pull/94226