### PR TITLE
Bug 1878925: pkg/cli/admin/upgrade: Remove help text around history lookups

### DIFF
--- a/pkg/cli/admin/upgrade/upgrade.go
+++ b/pkg/cli/admin/upgrade/upgrade.go
@@ -78,7 +78,7 @@ func New(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command
 		},
 	}
 	flags := cmd.Flags()
-	flags.StringVar(&o.To, "to", o.To, "Specify the version to upgrade to. The version must be on the list of previous or available updates.")
+	flags.StringVar(&o.To, "to", o.To, "Specify the version to upgrade to. The version must be on the list of available updates.")
 	flags.StringVar(&o.ToImage, "to-image", o.ToImage, "Provide a release image to upgrade to. WARNING: This option does not check for upgrade compatibility and may break your cluster.")
 	flags.BoolVar(&o.ToLatestAvailable, "to-latest", o.ToLatestAvailable, "Use the next available version")
 	flags.BoolVar(&o.Clear, "clear", o.Clear, "If an upgrade has been requested but not yet downloaded, cancel the update. This has no effect once the update has started.")


### PR DESCRIPTION
Copying from [the CVO][1], and adjusting to return a pointer instead of a (non-pointer,found) tuple.  Future work can shift this function into library-go.  This avoids:

```console
$ oc adm upgrade --to 4.6.0-fc.5
error: Can't look up image for version 4.6.0-fc.5. The update channel has not been configured.
```

When that lookup would succeed when investigating ClusterVersion's `status.history`:

```console
$ oc patch clusterversion version --type json -p '[{"op": "add", "path": "/spec/desiredUpdate", "value": {"version": "4.6.0-fc.5"}}]'
$ oc adm upgrade
info: An upgrade is in progress. Working towards 4.6.0-fc.5: downloading update

warning: Cannot display available updates:
  Reason: NoChannel
  Message: The update channel has not been configured.
```

[1]: https://github.com/openshift/cluster-version-operator/blob/6d56c655ea16f6faee4b65ffef43dcd912657bc6/pkg/cvo/updatepayload.go#L305-L325