### PR TITLE
Bug 1879081: Build cli images with RHEL 7

### DIFF
--- a/images/cli-artifacts/Dockerfile.rhel
+++ b/images/cli-artifacts/Dockerfile.rhel
@@ -1,6 +1,6 @@
 # This Dockerfile builds an image containing the Mac and Windows version of oc
 # layered on top of the Linux cli image.
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-openshift-4.6 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-7-golang-openshift-4.6 AS builder
 WORKDIR /go/src/github.com/openshift/oc
 COPY . .
 RUN make cross-build --warn-undefined-variables

--- a/images/cli-artifacts/Dockerfile.rhel
+++ b/images/cli-artifacts/Dockerfile.rhel
@@ -3,7 +3,6 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-openshift-4.6 AS builder
 WORKDIR /go/src/github.com/openshift/oc
 COPY . .
-RUN yum install -y --setopt=skip_missing_names_on_install=False gpgme-devel libassuan-devel
 RUN make cross-build --warn-undefined-variables
 
 FROM registry.svc.ci.openshift.org/ocp/4.6:cli

--- a/images/cli/Dockerfile.rhel
+++ b/images/cli/Dockerfile.rhel
@@ -1,7 +1,6 @@
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.14 AS builder
 WORKDIR /go/src/github.com/openshift/oc
 COPY . .
-RUN yum install -y --setopt=skip_missing_names_on_install=False gpgme-devel libassuan-devel
 RUN make build --warn-undefined-variables
 
 FROM registry.svc.ci.openshift.org/ocp/4.2:base

--- a/images/cli/Dockerfile.rhel
+++ b/images/cli/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.14 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-7-golang-openshift-4.6 AS builder
 WORKDIR /go/src/github.com/openshift/oc
 COPY . .
 RUN make build --warn-undefined-variables


### PR DESCRIPTION
oc is currently dynamically linked, which is needed for gssapi support.
Dynamically linked RHEL 8 binaries will not run on RHEL 7 because of
dependencies on GLIBC_2.28 symbols.