### PR TITLE
AUTOMATION TESTING - PLEASE DISREGARD - Updating builder & base images to be consistent with ART

### DIFF
--- a/images/cli/Dockerfile.rhel
+++ b/images/cli/Dockerfile.rhel
@@ -1,9 +1,9 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-7-golang-openshift-4.6 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-7-golang-openshift-4.7 AS builder
 WORKDIR /go/src/github.com/openshift/oc
 COPY . .
 RUN make build --warn-undefined-variables
 
-FROM registry.svc.ci.openshift.org/ocp/4.6:base
+FROM registry.svc.ci.openshift.org/ocp/4.7:base
 COPY --from=builder /go/src/github.com/openshift/oc/oc /usr/bin/
 RUN for i in kubectl openshift-deploy openshift-docker-build openshift-sti-build openshift-git-clone openshift-manage-dockerfile openshift-extract-image-content openshift-recycle; do ln -sf /usr/bin/oc /usr/bin/$i; done
 LABEL io.k8s.display-name="OpenShift Client" \


### PR DESCRIPTION
AUTOMATION TESTING - PLEASE DISREGARD - Updating openshift-enterprise-cli builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/b109e2315fe65294cb6390ab9883f840130a2cdd/images/openshift-enterprise-cli.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.

Depends on https://github.com/openshift/images/pull/41 . Allow it to merge and then retest.