### PR TITLE
AUTOMATION TESTING - PLEASE DISREGARD - Updating ose-tools builder & base images to be consistent with ART

### DIFF
--- a/images/tools/Dockerfile
+++ b/images/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/4.6:cli
+FROM registry.svc.ci.openshift.org/ocp/4.7:cli
 RUN INSTALL_PKGS="\
   bash-completion \
   bc \


### PR DESCRIPTION
AUTOMATION TESTING - PLEASE DISREGARD - Updating ose-tools builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/b109e2315fe65294cb6390ab9883f840130a2cdd/images/ose-tools.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.

Depends on https://github.com/openshift/oc/pull/584 . Allow it to merge and then retest.