### PR TITLE
Bug 1878163: Updating ose-cli-artifacts builder & base images to be consistent with ART

### DIFF
--- a/images/cli-artifacts/Dockerfile.rhel
+++ b/images/cli-artifacts/Dockerfile.rhel
@@ -1,6 +1,6 @@
 # This Dockerfile builds an image containing the Mac and Windows version of oc
 # layered on top of the Linux cli image.
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-7-golang-openshift-4.6 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-7-golang-1.15-openshift-4.6 AS builder
 WORKDIR /go/src/github.com/openshift/oc
 COPY . .
 RUN make cross-build --warn-undefined-variables


### PR DESCRIPTION
Updating ose-cli-artifacts builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/990044f295fb1d5e238823902962dbcfa1c041c9/images/ose-cli-artifacts.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.

Depends on https://github.com/openshift/oc/pull/596 . Allow it to merge and then run `/test all` on this PR.