### PR TITLE
Updating openshift-enterprise-deployer builder & base images to be consistent with ART

### DIFF
--- a/images/deployer/Dockerfile.rhel
+++ b/images/deployer/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/4.6:cli
+FROM registry.svc.ci.openshift.org/ocp/4.7:cli
 
 LABEL io.k8s.display-name="OpenShift Deployer" \
       io.k8s.description="This is a component of OpenShift and executes the user deployment process to roll out new containers. It may be used as a base image for building your own custom deployer image." \


### PR DESCRIPTION
Updating openshift-enterprise-deployer builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/openshift-enterprise-deployer.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.

Depends on https://github.com/openshift/oc/pull/606 . Allow it to merge and then run `/test all` on this PR.