### PR TITLE
IR-112: Pruner should be aware of OCI image configs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/moby/buildkit v0.0.0-20181107081847-c3a857e3fca0
 	github.com/mtrmac/gpgme v0.1.2 // indirect
 	github.com/opencontainers/go-digest v1.0.0-rc1
+	github.com/opencontainers/image-spec v1.0.2-0.20190823105129-775207bd45b6
 	github.com/openshift/api v0.0.0-20201019163320-c6a5ec25f267
 	github.com/openshift/build-machinery-go v0.0.0-20200917070002-f171684f77ab
 	github.com/openshift/client-go v0.0.0-20201020074620-f8fd44879f7c

--- a/pkg/cli/admin/prune/imageprune/prune.go
+++ b/pkg/cli/admin/prune/imageprune/prune.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/docker/distribution/manifest/schema2"
 	"github.com/docker/distribution/registry/api/errcode"
+	imagespecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"k8s.io/klog/v2"
 
 	kappsv1 "k8s.io/api/apps/v1"
@@ -749,7 +750,10 @@ func getImageBlobs(image *imagev1.Image) ([]string, error) {
 		return blobs, fmt.Errorf("failed to read metadata for image %s", image.Name)
 	}
 
-	if image.DockerImageManifestMediaType == schema2.MediaTypeManifest && len(dockerImage.ID) > 0 {
+	mediaTypeHasConfig := image.DockerImageManifestMediaType == schema2.MediaTypeManifest ||
+		image.DockerImageManifestMediaType == imagespecv1.MediaTypeImageManifest
+
+	if mediaTypeHasConfig && len(dockerImage.ID) > 0 {
 		configName := dockerImage.ID
 		blobs = append(blobs, configName)
 	}

--- a/pkg/helpers/image/test/util.go
+++ b/pkg/helpers/image/test/util.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/manifest/schema2"
+	imagespecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 
 	kappsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -69,7 +70,7 @@ func Image(id, ref string) imagev1.Image {
 	return AgedImage(id, ref, 120)
 }
 
-// Image returns a default test image referencing the given layers.
+// ImageWithLayers returns a default test image referencing the given layers.
 func ImageWithLayers(id, ref string, configName *string, layers ...string) imagev1.Image {
 	image := imagev1.Image{
 		ObjectMeta: metav1.ObjectMeta{
@@ -100,6 +101,13 @@ func ImageWithLayers(id, ref string, configName *string, layers ...string) image
 		image.DockerImageLayers = append(image.DockerImageLayers, imagev1.ImageLayer{Name: layer})
 	}
 
+	return image
+}
+
+// OCIImageWithLayers returns an OCI image referencing the given layers.
+func OCIImageWithLayers(id, ref string, configName string, layers ...string) imagev1.Image {
+	image := ImageWithLayers(id, ref, &configName, layers...)
+	image.DockerImageManifestMediaType = imagespecv1.MediaTypeImageManifest
 	return image
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -395,6 +395,7 @@ github.com/onsi/gomega/types
 ## explicit
 github.com/opencontainers/go-digest
 # github.com/opencontainers/image-spec v1.0.2-0.20190823105129-775207bd45b6
+## explicit
 github.com/opencontainers/image-spec/specs-go
 github.com/opencontainers/image-spec/specs-go/v1
 # github.com/opencontainers/runc v1.0.0-rc91.0.20200707015106-819fcc687efb


### PR DESCRIPTION
This PR adds support of OCI images to the pruner. The pruner should

1. keep blobs that are used by OCI images (even if they are no longer used by other schema 1 or schema 2 images)
2. delete config/layers of OCI images if they are no longer used by any image