### PR TITLE
Bug 1891555: Create Windows version information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,12 +84,17 @@ verify-imports:
 	hack/verify-imports.sh
 .PHONY: verify-imports
 
+generate-versioninfo:
+	SOURCE_GIT_TAG=$(SOURCE_GIT_TAG) hack/generate-versioninfo.sh
+.PHONY: generate-versioninfo
+
 cross-build-darwin-amd64:
 	+@GOOS=darwin GOARCH=amd64 $(MAKE) --no-print-directory build GO_BUILD_PACKAGES:=./cmd/oc GO_BUILD_FLAGS:="$(GO_BUILD_FLAGS_DARWIN)" GO_BUILD_BINDIR:=$(CROSS_BUILD_BINDIR)/darwin_amd64
 .PHONY: cross-build-darwin-amd64
 
-cross-build-windows-amd64:
+cross-build-windows-amd64: generate-versioninfo
 	+@GOOS=windows GOARCH=amd64 $(MAKE) --no-print-directory build GO_BUILD_PACKAGES:=./cmd/oc GO_BUILD_FLAGS:="$(GO_BUILD_FLAGS_WINDOWS)" GO_BUILD_BINDIR:=$(CROSS_BUILD_BINDIR)/windows_amd64
+	$(RM) cmd/oc/oc.syso
 .PHONY: cross-build-windows-amd64
 
 cross-build-linux-amd64:
@@ -113,6 +118,7 @@ cross-build: cross-build-darwin-amd64 cross-build-windows-amd64 cross-build-linu
 
 clean-cross-build:
 	$(RM) -r '$(CROSS_BUILD_BINDIR)'
+	$(RM) cmd/oc/oc.syso
 	if [ -d '$(OUTPUT_DIR)' ]; then rmdir --ignore-fail-on-non-empty '$(OUTPUT_DIR)'; fi
 .PHONY: clean-cross-build
 

--- a/hack/generate-versioninfo.sh
+++ b/hack/generate-versioninfo.sh
@@ -1,0 +1,62 @@
+#! /usr/bin/env bash
+
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
+
+# Generates the .syso file used to add compile-time VERSIONINFO metadata to the
+# Windows binary.
+function os::build::generate_windows_versioninfo() {
+  if [[ "${SOURCE_GIT_TAG}" =~ ^[a-z-]*([0-9]+)\.([0-9]+)\.([0-9]+).* ]] ; then
+    local major=${BASH_REMATCH[1]}
+    local minor=${BASH_REMATCH[2]}
+    local patch=${BASH_REMATCH[3]}
+  fi
+  local windows_versioninfo_file=`mktemp --suffix=".versioninfo.json"`
+  cat <<EOF >"${windows_versioninfo_file}"
+{
+       "FixedFileInfo":
+       {
+               "FileVersion": {
+                       "Major": ${major},
+                       "Minor": ${minor},
+                       "Patch": ${patch}
+               },
+               "ProductVersion": {
+                       "Major": ${major},
+                       "Minor": ${minor},
+                       "Patch": ${patch}
+               },
+               "FileFlagsMask": "3f",
+               "FileFlags ": "00",
+               "FileOS": "040004",
+               "FileType": "01",
+               "FileSubType": "00"
+       },
+       "StringFileInfo":
+       {
+               "Comments": "",
+               "CompanyName": "Red Hat, Inc.",
+               "InternalName": "openshift client",
+               "FileVersion": "${SOURCE_GIT_TAG}",
+               "InternalName": "oc",
+               "LegalCopyright": "© Red Hat, Inc. Licensed under the Apache License, Version 2.0",
+               "LegalTrademarks": "",
+               "OriginalFilename": "oc.exe",
+               "PrivateBuild": "",
+               "ProductName": "OpenShift Client",
+               "ProductVersion": "${SOURCE_GIT_TAG}",
+               "SpecialBuild": ""
+       },
+       "VarFileInfo":
+       {
+               "Translation": {
+                       "LangID": "0409",
+                       "CharsetID": "04B0"
+               }
+       }
+}
+EOF
+  goversioninfo -o ${OS_ROOT}/cmd/oc/oc.syso ${windows_versioninfo_file}
+}
+readonly -f os::build::generate_windows_versioninfo
+
+os::build::generate_windows_versioninfo


### PR DESCRIPTION
This was previously enabled in 4.1 but was lost in 4.2 when oc was split
out from the origin repository.

