### PR TITLE
show proper wildcard for 'oc image mirror --help example'

### DIFF
--- a/pkg/cli/image/mirror/mirror.go
+++ b/pkg/cli/image/mirror/mirror.go
@@ -101,7 +101,7 @@ var (
 		# Copy all os/arch manifests of a multi-architecture image
 		# Run 'oc image info myregistry.com/myimage:latest' to see list of os/arch manifests that will be mirrored.
 		oc image mirror myregistry.com/myimage:latest=myregistry.com/other:test \
-			--filter-by-os=/*
+			--filter-by-os=.*
 	`)
 )
 


### PR DESCRIPTION
Somebody (me) wrote this `--filter-by-os=/*` as example of how to list/mirror all digests of a multi-arch image with the wildcard filter-by-os.  This PR fixes the help to show `--filter-by-os=.*` instead. 