### PR TITLE
Bug 1888738: fall-back must-gather to official RH supported image

### DIFF
--- a/pkg/cli/admin/mustgather/mustgather.go
+++ b/pkg/cli/admin/mustgather/mustgather.go
@@ -155,7 +155,7 @@ func (o *MustGatherOptions) completeImages() error {
 		var err error
 		if image, err = o.resolveImageStreamTag("openshift", "must-gather", "latest"); err != nil {
 			o.log("%v\n", err)
-			image = "quay.io/openshift/origin-must-gather:latest"
+			image = "registry.redhat.io/openshift4/ose-must-gather:latest"
 		}
 		o.Images = append(o.Images, image)
 	}

--- a/pkg/cli/admin/mustgather/mustgather_test.go
+++ b/pkg/cli/admin/mustgather/mustgather_test.go
@@ -32,7 +32,7 @@ func TestImagesAndImageStreams(t *testing.T) {
 		},
 		{
 			name:           "DefaultNoMustGatherImageStream",
-			expectedImages: []string{"quay.io/openshift/origin-must-gather:latest"},
+			expectedImages: []string{"registry.redhat.io/openshift4/ose-must-gather:latest"},
 		},
 		{
 			name:           "MultipleImages",


### PR DESCRIPTION
This is the only reasonable image we can probably fall-back to, although I'm a bit hesitant on using it here. 

/assign @wking 