### PR TITLE
Bug 1891555: BuildRequires goversioninfo

### DIFF
--- a/oc.spec
+++ b/oc.spec
@@ -46,6 +46,7 @@ ExclusiveArch:  x86_64 aarch64 ppc64le s390x
 %endif
 
 BuildRequires:  golang >= %{golang_version}
+BuildRequires:  goversioninfo
 BuildRequires:  krb5-devel
 BuildRequires:  rsync
 


### PR DESCRIPTION
This is needed after https://github.com/openshift/oc/pull/623
