### PR TITLE
Bug 1888192: add rsync & log re-tries

### DIFF
--- a/pkg/cli/admin/mustgather/mustgather.go
+++ b/pkg/cli/admin/mustgather/mustgather.go
@@ -431,8 +431,9 @@ func (o *MustGatherOptions) getGatherContainerLogs(pod *corev1.Pod) error {
 		Namespace:   pod.Namespace,
 		ResourceArg: pod.Name,
 		Options: &corev1.PodLogOptions{
-			Follow:    true,
-			Container: pod.Spec.Containers[0].Name,
+			Follow:     true,
+			Container:  pod.Spec.Containers[0].Name,
+			Timestamps: true,
 		},
 		RESTClientGetter: o.RESTClientGetter,
 		Object:           pod,

--- a/pkg/cli/admin/mustgather/mustgather.go
+++ b/pkg/cli/admin/mustgather/mustgather.go
@@ -13,9 +13,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/openshift/oc/pkg/cli/admin/inspect"
-
 	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -33,12 +32,12 @@ import (
 	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util/templates"
 
-	imagereference "github.com/openshift/library-go/pkg/image/reference"
-
 	imagev1client "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
 	"github.com/openshift/library-go/pkg/image/imageutil"
+	imagereference "github.com/openshift/library-go/pkg/image/reference"
 	"github.com/openshift/library-go/pkg/operator/resource/retry"
 
+	"github.com/openshift/oc/pkg/cli/admin/inspect"
 	"github.com/openshift/oc/pkg/cli/rsync"
 )
 
@@ -394,15 +393,23 @@ func (o *MustGatherOptions) copyFilesFromPod(pod *corev1.Pod) error {
 		Destination:   &rsync.PathSpec{PodName: "", Path: destDir},
 		Client:        o.Client,
 		Config:        o.Config,
+		Compress:      true,
 		RshCmd:        fmt.Sprintf("%s --namespace=%s -c copy", o.RsyncRshCmd, pod.Namespace),
 		IOStreams:     streams,
 	}
 	rsyncOptions.Strategy = rsync.NewDefaultCopyStrategy(rsyncOptions)
-	return rsyncOptions.RunRsync()
+	err := rsyncOptions.RunRsync()
+	if err != nil {
+		klog.V(4).Infof("re-trying rsync after initial failure %v", err)
+		// re-try copying data before letting it go
+		err = rsyncOptions.RunRsync()
+	}
+	return err
 }
 
 func (o *MustGatherOptions) getGatherContainerLogs(pod *corev1.Pod) error {
-	return (&logs.LogsOptions{
+	since2s := int64(2)
+	opts := &logs.LogsOptions{
 		Namespace:   pod.Namespace,
 		ResourceArg: pod.Name,
 		Options: &corev1.PodLogOptions{
@@ -414,7 +421,23 @@ func (o *MustGatherOptions) getGatherContainerLogs(pod *corev1.Pod) error {
 		ConsumeRequestFn: logs.DefaultConsumeRequest,
 		LogsForObject:    polymorphichelpers.LogsForObjectFn,
 		IOStreams:        genericclioptions.IOStreams{Out: newPrefixWriter(o.Out, fmt.Sprintf("[%s] POD", pod.Name))},
-	}).RunLogs()
+	}
+
+	for {
+		// gather script might take longer than the default API server time,
+		// so we should check if the gather script still runs and re-run logs
+		// thus we run this in a loop
+		if err := opts.RunLogs(); err != nil {
+			return err
+		}
+
+		// to ensure we don't print all of history set since to past 2 seconds
+		opts.Options.(*corev1.PodLogOptions).SinceSeconds = &since2s
+		if done, _ := o.isGatherDone(pod); done {
+			return nil
+		}
+		klog.V(4).Infof("lost logs, re-trying...")
+	}
 }
 
 func newPrefixWriter(out io.Writer, prefix string) io.Writer {
@@ -429,40 +452,40 @@ func newPrefixWriter(out io.Writer, prefix string) io.Writer {
 }
 
 func (o *MustGatherOptions) waitForGatherToComplete(pod *corev1.Pod) error {
-	err := wait.PollImmediate(10*time.Second, time.Duration(o.Timeout)*time.Second, func() (bool, error) {
-		var err error
-		if pod, err = o.Client.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{}); err != nil {
-			// at this stage pod should exist, we've been gathering container logs, so error if not found
-			if kerrors.IsNotFound(err) {
-				return true, err
-			}
-			return false, nil
-		}
-		var state *corev1.ContainerState
-		for _, cstate := range pod.Status.ContainerStatuses {
-			if cstate.Name == "gather" {
-				state = &cstate.State
-				break
-			}
-		}
+	return wait.PollImmediate(10*time.Second, time.Duration(o.Timeout)*time.Second, func() (bool, error) {
+		return o.isGatherDone(pod)
+	})
+}
 
-		// missing status for gather container => timeout in the worst case
-		if state == nil {
-			return false, nil
-		}
-
-		if state.Terminated != nil {
-			if state.Terminated.ExitCode == 0 {
-				return true, nil
-			}
-			return true, fmt.Errorf("%s/%s unexpectedly terminated: exit code: %v, reason: %s, message: %s", pod.Namespace, pod.Name, state.Terminated.ExitCode, state.Terminated.Reason, state.Terminated.Message)
+func (o *MustGatherOptions) isGatherDone(pod *corev1.Pod) (bool, error) {
+	var err error
+	if pod, err = o.Client.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{}); err != nil {
+		// at this stage pod should exist, we've been gathering container logs, so error if not found
+		if kerrors.IsNotFound(err) {
+			return true, err
 		}
 		return false, nil
-	})
-	if err != nil {
-		return err
 	}
-	return nil
+	var state *corev1.ContainerState
+	for _, cstate := range pod.Status.ContainerStatuses {
+		if cstate.Name == "gather" {
+			state = &cstate.State
+			break
+		}
+	}
+
+	// missing status for gather container => timeout in the worst case
+	if state == nil {
+		return false, nil
+	}
+
+	if state.Terminated != nil {
+		if state.Terminated.ExitCode == 0 {
+			return true, nil
+		}
+		return true, fmt.Errorf("%s/%s unexpectedly terminated: exit code: %v, reason: %s, message: %s", pod.Namespace, pod.Name, state.Terminated.ExitCode, state.Terminated.Reason, state.Terminated.Message)
+	}
+	return false, nil
 }
 
 func (o *MustGatherOptions) waitForGatherContainerRunning(pod *corev1.Pod) error {

--- a/pkg/cli/rsh/rsh.go
+++ b/pkg/cli/rsh/rsh.go
@@ -65,7 +65,6 @@ type RshOptions struct {
 	ForceTTY   bool
 	DisableTTY bool
 	Executable string
-	Timeout    int
 	*exec.ExecOptions
 }
 
@@ -73,7 +72,6 @@ func NewRshOptions(streams genericclioptions.IOStreams) *RshOptions {
 	return &RshOptions{
 		ForceTTY:   false,
 		DisableTTY: false,
-		Timeout:    10,
 		Executable: DefaultShell,
 		ExecOptions: &exec.ExecOptions{
 			StreamOptions: exec.StreamOptions{
@@ -108,8 +106,6 @@ func NewCmdRsh(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.C
 	cmd.Flags().BoolVarP(&o.ForceTTY, "tty", "t", o.ForceTTY, "Force a pseudo-terminal to be allocated")
 	cmd.Flags().BoolVarP(&o.DisableTTY, "no-tty", "T", o.DisableTTY, "Disable pseudo-terminal allocation")
 	cmd.Flags().StringVar(&o.Executable, "shell", o.Executable, "Path to the shell command")
-	cmd.Flags().IntVar(&o.Timeout, "timeout", o.Timeout, "Request timeout for obtaining a pod from the server; defaults to 10 seconds")
-	cmd.Flags().MarkDeprecated("timeout", "use --request-timeout, instead.")
 	cmd.Flags().StringVarP(&o.ContainerName, "container", "c", o.ContainerName, "Container name; defaults to first container")
 	// For consistencty with rsh API (https://linux.die.net/man/1/rsh) we don't
 	// allow '--' and we need this flag enabled explicitly, otherwise two things

--- a/pkg/cli/rsync/copy_rsync.go
+++ b/pkg/cli/rsync/copy_rsync.go
@@ -40,7 +40,7 @@ func DefaultRsyncRemoteShellToUse(cmd *cobra.Command) string {
 	})
 	// flag.Name represents what was present on the CLI, so the excluded list needs
 	// to have both short and long versions of flags
-	excludeFlags := localFlags.Difference(sets.NewString("container", "c", "no-tty", "T", "shell", "timeout", "tty", "t"))
+	excludeFlags := localFlags.Difference(sets.NewString("container", "c", "no-tty", "T", "shell", "tty", "t"))
 	cmd.Flags().Visit(func(flag *pflag.Flag) {
 		if excludeFlags.Has(flag.Name) {
 			return


### PR DESCRIPTION
There are 2 main issues with `oc adm must-gather` that this PR addresses:
1. On the env, the logs streaming from gather pod ends after ~10min, when the gather runs longer and on that cluster I was given access it was taking ~30mins, you'll only get info about the initial 10mins. The time-out is coming from server, so we just need to ensure we re-try streaming logs after that time-out if the pod is still running.
2. Current copy logic is missing compression.
3. Current sync logic is copying the artifacts only once, if it fails it doesn't re-try. 

/assign @sallyom 