### PR TITLE
Bug 1891555: Accept OS_GIT_VERSION to set version information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 all: build
 .PHONY: all
 
+ifdef OS_GIT_VERSION
+SOURCE_GIT_TAG := ${OS_GIT_VERSION}
+endif
+
 # Include the library makefile
 include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
 	golang.mk \


### PR DESCRIPTION
When building in OCP, this variable is set with the intended version
information.

For CI versions, annotated tags (releases) need to be created.  This 
used to occur in openshift/origin but hasn't regularly since this was 
split out.
