### PR TITLE
Bug 1890671: use proper username for image verification

### DIFF
--- a/pkg/cli/admin/verifyimagesignature/verify-signature.go
+++ b/pkg/cli/admin/verifyimagesignature/verify-signature.go
@@ -261,7 +261,9 @@ func (o *VerifyImageSignatureOptions) getImageManifest(img *imagev1.Image) ([]by
 			registryURL.Scheme = ""
 		}
 	}
-	return getImageManifestByIDFromRegistry(registryURL, parsed.RepositoryName(), img.Name, o.CurrentUser, o.CurrentUserToken, o.Insecure)
+	// when using in-cluster auth, the username is just user + token, compare
+	// https://github.com/openshift/oc/blob/9f54c1d4f68c8530ac9466c655a4e55eb04a1459/pkg/cli/registry/login/login.go#L208
+	return getImageManifestByIDFromRegistry(registryURL, parsed.RepositoryName(), img.Name, "user", o.CurrentUserToken, o.Insecure)
 }
 
 // verifySignature takes policy, image and the image signature blob and verifies that the


### PR DESCRIPTION
/assign @sallyom 

There are two possible approaches to this problem:
1. the one from this PR
2. allowing injecting `--registry-config` similarly to how we do that in `oc image mirror`

what do you think which one would be better?