### PR TITLE
Bug 1890951: Improve output of 'oc image mirror' with multi-arch images

### DIFF
--- a/pkg/cli/image/manifest/manifest.go
+++ b/pkg/cli/image/manifest/manifest.go
@@ -411,7 +411,7 @@ func ProcessManifestList(ctx context.Context, srcDigest digest.Digest, srcManife
 			if err != nil {
 				return nil, nil, "", err
 			}
-			klog.V(5).Infof("Used only one manifest from the list %s", srcDigest)
+			klog.Warningf("Chose %s/%s manifest from the list.\nTo include the manifest list digest: %s, use --keep-manifest-list=true", t.Manifests[0].Platform.OS, t.Manifests[0].Platform.Architecture, srcDigest)
 			return srcManifests, srcManifests[0], manifestDigest, nil
 		default:
 			return append(srcManifests, manifestList), manifestList, manifestDigest, nil


### PR DESCRIPTION
With this PR, the `--keep-manifest-list=true` command will fail if `--filter-by-os` is passed with any value other than `--filter-by-os=.*`. This is because it is not possible to preserve the manifest list digest while also altering the manifest list to only include some of its manifests (you could, but it would be rejected by registries as it will no longer be valid). Before this PR, `--keep-manifest-list=true` did not actually keep the manifest list digest, in cases where the `--filter-by-os=not/wildcard`, a new manifest list with a new digest was created. 

This PR also addresses https://bugzilla.redhat.com/show_bug.cgi?id=1882689
/assign @smarterclayton 