### PR TITLE
Bug 1838512: Set CGO_ENABLED=1 for cross compile on Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ generate-versioninfo:
 .PHONY: generate-versioninfo
 
 cross-build-darwin-amd64:
-	+@GOOS=darwin GOARCH=amd64 $(MAKE) --no-print-directory build GO_BUILD_PACKAGES:=./cmd/oc GO_BUILD_FLAGS:="$(GO_BUILD_FLAGS_DARWIN)" GO_BUILD_BINDIR:=$(CROSS_BUILD_BINDIR)/darwin_amd64
+	+@GOOS=darwin CGO_ENABLED=1 GOARCH=amd64 $(MAKE) --no-print-directory build GO_BUILD_PACKAGES:=./cmd/oc GO_BUILD_FLAGS:="$(GO_BUILD_FLAGS_DARWIN)" GO_BUILD_BINDIR:=$(CROSS_BUILD_BINDIR)/darwin_amd64
 .PHONY: cross-build-darwin-amd64
 
 cross-build-windows-amd64: generate-versioninfo

--- a/Makefile
+++ b/Makefile
@@ -92,8 +92,8 @@ generate-versioninfo:
 	SOURCE_GIT_TAG=$(SOURCE_GIT_TAG) hack/generate-versioninfo.sh
 .PHONY: generate-versioninfo
 
-cross-build-darwin-amd64:
-	+@GOOS=darwin CGO_ENABLED=1 GOARCH=amd64 $(MAKE) --no-print-directory build GO_BUILD_PACKAGES:=./cmd/oc GO_BUILD_FLAGS:="$(GO_BUILD_FLAGS_DARWIN)" GO_BUILD_BINDIR:=$(CROSS_BUILD_BINDIR)/darwin_amd64
+cross-build-darwin-amd64: GO_LD_FLAGS="$(GO_LD_FLAGS)  -extld=o64-clang"
+	+@GOOS=darwin CC=o64-clang CXX=o64-clang++ CGO_ENABLED=1 GOARCH=amd64 $(MAKE) --no-print-directory build GO_BUILD_PACKAGES:=./cmd/oc GO_BUILD_FLAGS:="$(GO_BUILD_FLAGS_DARWIN)" GO_BUILD_BINDIR:=$(CROSS_BUILD_BINDIR)/darwin_amd64
 .PHONY: cross-build-darwin-amd64
 
 cross-build-windows-amd64: generate-versioninfo


### PR DESCRIPTION
With the changes in https://github.com/openshift/ocp-build-data/pull/627, C cross-compilers should be available in our build images. Enabling this for darwin builds of `oc` would fix the referenced bug, in which cgo is required for proper dns resolution on mac (and was fixed in upstream kubectl long ago: https://github.com/kubernetes/release/issues/469)