### PR TITLE
update discovery burst to reflect lots of CRDs on openshift clusters

### DIFF
--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
@@ -225,7 +225,7 @@ func (f *ConfigFlags) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, e
 	// The more groups you have, the more discovery requests you need to make.
 	// given 25 groups (our groups + a few custom resources) with one-ish version each, discovery needs to make 50 requests
 	// double it just so we don't end up here again for a while.  This config is only used for discovery.
-	config.Burst = 100
+	config.Burst = 200
 
 	cacheDir := defaultCacheDir
 


### PR DESCRIPTION
@soltysh see if this is the source of the throttling messages.  Turns out we have lots and lots of groups and versions for CRDs, especially when people start installing operators.