### PR TITLE
Bug 1903033: deduplicate imageContentSources printed when mirroring release

### DIFF
--- a/pkg/cli/admin/release/mirror_test.go
+++ b/pkg/cli/admin/release/mirror_test.go
@@ -1,0 +1,120 @@
+package release
+
+import (
+	"reflect"
+	"testing"
+
+	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
+
+	"k8s.io/apimachinery/pkg/util/diff"
+)
+
+func Test_dedupeSortSources(t *testing.T) {
+	tests := []struct {
+		name            string
+		sources         []operatorv1alpha1.RepositoryDigestMirrors
+		expectedSources []operatorv1alpha1.RepositoryDigestMirrors
+	}{
+		{
+			name: "single Source single Mirror",
+			sources: []operatorv1alpha1.RepositoryDigestMirrors{
+				{
+					Source:  "quay/ocp/test",
+					Mirrors: []string{"registry/ocp/test"},
+				},
+			},
+			expectedSources: []operatorv1alpha1.RepositoryDigestMirrors{
+				{
+					Source:  "quay/ocp/test",
+					Mirrors: []string{"registry/ocp/test"},
+				},
+			},
+		},
+		{
+			name: "single Source multiple Mirrors",
+			sources: []operatorv1alpha1.RepositoryDigestMirrors{
+				{
+					Source:  "quay/ocp/test",
+					Mirrors: []string{"registry/ocp/test"},
+				},
+				{
+					Source:  "quay/ocp/test",
+					Mirrors: []string{"registry/another/test"},
+				},
+				{
+					Source:  "quay/ocp/test",
+					Mirrors: []string{"registry/ocp/test"},
+				},
+			},
+			expectedSources: []operatorv1alpha1.RepositoryDigestMirrors{
+				{
+					Source:  "quay/ocp/test",
+					Mirrors: []string{"registry/ocp/test", "registry/another/test"},
+				},
+			},
+		},
+		{
+			name: "multiple Source single Mirrors",
+			sources: []operatorv1alpha1.RepositoryDigestMirrors{
+				{
+					Source:  "quay/ocp/test",
+					Mirrors: []string{"registry/ocp/test"},
+				},
+				{
+					Source:  "quay/another/test",
+					Mirrors: []string{"registry/ocp/test"},
+				},
+			},
+			expectedSources: []operatorv1alpha1.RepositoryDigestMirrors{
+				{
+					Source:  "quay/another/test",
+					Mirrors: []string{"registry/ocp/test"},
+				},
+				{
+					Source:  "quay/ocp/test",
+					Mirrors: []string{"registry/ocp/test"},
+				},
+			},
+		},
+		{
+			name: "multiple Source multiple Mirrors",
+			sources: []operatorv1alpha1.RepositoryDigestMirrors{
+				{
+					Source:  "quay/ocp/test",
+					Mirrors: []string{"registry/ocp/test"},
+				},
+				{
+					Source:  "quay/ocp/test",
+					Mirrors: []string{"registry/another/test"},
+				},
+				{
+					Source:  "quay/another/test",
+					Mirrors: []string{"registry/ocp/test"},
+				},
+				{
+					Source:  "quay/another/test",
+					Mirrors: []string{"registry/another/test"},
+				},
+			},
+			expectedSources: []operatorv1alpha1.RepositoryDigestMirrors{
+				{
+					Source:  "quay/another/test",
+					Mirrors: []string{"registry/ocp/test", "registry/another/test"},
+				},
+				{
+					Source:  "quay/ocp/test",
+					Mirrors: []string{"registry/ocp/test", "registry/another/test"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			uniqueSources := dedupeSortSources(tt.sources)
+			if !reflect.DeepEqual(uniqueSources, tt.expectedSources) {
+				t.Errorf("%s", diff.ObjectReflectDiff(uniqueSources, tt.expectedSources))
+			}
+		})
+	}
+}


### PR DESCRIPTION
The recent `oc adm release mirror` fix to add the image sources for --to-release-image along with --to introduced a bug where it is possible to get duplicate image sources when --to and --to-release-image have the same registry/repo/name.  This PR adds de-duplicate code to the printed image sources.

/assign @soltysh 