### PR TITLE
Bug 1880068: Take StatefulSets, Jobs and CronJobs into account during image prune

### DIFF
--- a/pkg/cli/admin/prune/imageprune/prune.go
+++ b/pkg/cli/admin/prune/imageprune/prune.go
@@ -249,8 +249,8 @@ type PrunerOptions struct {
 	DCs *appsv1.DeploymentConfigList
 	// RSs is the entire list of replica sets across all namespaces in the cluster.
 	RSs *kappsv1.ReplicaSetList
-	// SSs is the entire list of statefulsets across all namespaces in the cluster.
-	SSs *kappsv1.StatefulSetList
+	// SSets is the entire list of statefulsets across all namespaces in the cluster.
+	SSets *kappsv1.StatefulSetList
 	// Jobs is the entire list of jobs across all namespaces in the cluster.
 	Jobs *batchv1.JobList
 	// CronJobs is the entire list of cron jobs across all namespaces in the cluster.
@@ -409,7 +409,7 @@ func (p *pruner) analyzeImageStreamsReferences(options PrunerOptions) kerrors.Ag
 	errs = append(errs, p.analyzeReferencesFromDaemonSets(options.DSs)...)
 	errs = append(errs, p.analyzeReferencesFromBuilds(options.Builds)...)
 	errs = append(errs, p.analyzeReferencesFromBuildConfigs(options.BCs)...)
-	errs = append(errs, p.analyzeReferencesFromStatefulSets(options.SSs)...)
+	errs = append(errs, p.analyzeReferencesFromStatefulSets(options.SSets)...)
 	errs = append(errs, p.analyzeReferencesFromJobs(options.Jobs)...)
 	errs = append(errs, p.analyzeReferencesFromCronJobs(options.CronJobs)...)
 	return kerrors.NewAggregate(errs)

--- a/pkg/cli/admin/prune/imageprune/prune_test.go
+++ b/pkg/cli/admin/prune/imageprune/prune_test.go
@@ -2120,6 +2120,9 @@ func TestRegistryPruning(t *testing.T) {
 				Deployments:      &kappsv1.DeploymentList{},
 				DCs:              &appsv1.DeploymentConfigList{},
 				RSs:              &kappsv1.ReplicaSetList{},
+				SSs:              &kappsv1.StatefulSetList{},
+				Jobs:             &batchv1.JobList{},
+				CronJobs:         &batchv1beta1.CronJobList{},
 			}
 			p, err := NewPruner(options)
 			if err != nil {
@@ -2182,6 +2185,9 @@ func TestImageWithStrongAndWeakRefsIsNotPruned(t *testing.T) {
 	deployments := imagetest.DeploymentList()
 	dcs := imagetest.DCList()
 	rss := imagetest.RSList()
+	sss := imagetest.SSList()
+	jobs := imagetest.JobList()
+	cjs := imagetest.CronJobList()
 
 	options := PrunerOptions{
 		Images:      images,
@@ -2194,6 +2200,9 @@ func TestImageWithStrongAndWeakRefsIsNotPruned(t *testing.T) {
 		Deployments: &deployments,
 		DCs:         &dcs,
 		RSs:         &rss,
+		SSs:         &sss,
+		Jobs:        &jobs,
+		CronJobs:    &cjs,
 	}
 	keepYoungerThan := 24 * time.Hour
 	keepTagRevisions := 2

--- a/pkg/cli/admin/prune/imageprune/prune_test.go
+++ b/pkg/cli/admin/prune/imageprune/prune_test.go
@@ -79,7 +79,7 @@ func TestImagePruning(t *testing.T) {
 		deployments                          kappsv1.DeploymentList
 		dcs                                  appsv1.DeploymentConfigList
 		rss                                  kappsv1.ReplicaSetList
-		sss                                  kappsv1.StatefulSetList
+		ssets                                kappsv1.StatefulSetList
 		jobs                                 batchv1.JobList
 		cronjobs                             batchv1beta1.CronJobList
 		limits                               map[string][]*corev1.LimitRange
@@ -1664,7 +1664,7 @@ func TestImagePruning(t *testing.T) {
 					),
 				}),
 			),
-			sss: imagetest.SSList(
+			ssets: imagetest.SSetList(
 				imagetest.StatefulSet("foo", "rc1", registryHost+"/foo/bar@sha256:0000000000000000000000000000000000000000000000000000000000000000"),
 				imagetest.StatefulSet("foo", "rc2", registryHost+"/foo/bar@sha256:0000000000000000000000000000000000000000000000000000000000000002"),
 			),
@@ -1753,7 +1753,7 @@ func TestImagePruning(t *testing.T) {
 				Deployments: &test.deployments,
 				DCs:         &test.dcs,
 				RSs:         &test.rss,
-				SSs:         &test.sss,
+				SSets:       &test.ssets,
 				Jobs:        &test.jobs,
 				CronJobs:    &test.cronjobs,
 				LimitRanges: test.limits,
@@ -2120,7 +2120,7 @@ func TestRegistryPruning(t *testing.T) {
 				Deployments:      &kappsv1.DeploymentList{},
 				DCs:              &appsv1.DeploymentConfigList{},
 				RSs:              &kappsv1.ReplicaSetList{},
-				SSs:              &kappsv1.StatefulSetList{},
+				SSets:            &kappsv1.StatefulSetList{},
 				Jobs:             &batchv1.JobList{},
 				CronJobs:         &batchv1beta1.CronJobList{},
 			}
@@ -2185,7 +2185,7 @@ func TestImageWithStrongAndWeakRefsIsNotPruned(t *testing.T) {
 	deployments := imagetest.DeploymentList()
 	dcs := imagetest.DCList()
 	rss := imagetest.RSList()
-	sss := imagetest.SSList()
+	ssets := imagetest.SSetList()
 	jobs := imagetest.JobList()
 	cjs := imagetest.CronJobList()
 
@@ -2200,7 +2200,7 @@ func TestImageWithStrongAndWeakRefsIsNotPruned(t *testing.T) {
 		Deployments: &deployments,
 		DCs:         &dcs,
 		RSs:         &rss,
-		SSs:         &sss,
+		SSets:       &ssets,
 		Jobs:        &jobs,
 		CronJobs:    &cjs,
 	}

--- a/pkg/cli/admin/prune/images/images.go
+++ b/pkg/cli/admin/prune/images/images.go
@@ -368,6 +368,11 @@ func (o PruneImagesOptions) Run() error {
 		fmt.Fprintf(o.ErrOut, "Failed to list replicasets: %v\n - * Make sure to update clusterRoleBindings.\n", err)
 	}
 
+	allSSs, err := o.KubeClient.AppsV1().StatefulSets(o.Namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
 	limitRangesList, err := o.KubeClient.CoreV1().LimitRanges(o.Namespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return err
@@ -463,6 +468,7 @@ func (o PruneImagesOptions) Run() error {
 		Deployments:        allDeployments,
 		DCs:                allDCs,
 		RSs:                allRSs,
+		SSs:                allSSs,
 		LimitRanges:        limitRangesMap,
 		DryRun:             o.Confirm == false,
 		PruneRegistry:      o.PruneRegistry,

--- a/pkg/cli/admin/prune/images/images.go
+++ b/pkg/cli/admin/prune/images/images.go
@@ -378,6 +378,11 @@ func (o PruneImagesOptions) Run() error {
 		return err
 	}
 
+	allCronJobs, err := o.KubeClient.BatchV1beta1().CronJobs(o.Namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
 	limitRangesList, err := o.KubeClient.CoreV1().LimitRanges(o.Namespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return err
@@ -475,6 +480,7 @@ func (o PruneImagesOptions) Run() error {
 		RSs:                allRSs,
 		SSs:                allSSs,
 		Jobs:               allJobs,
+		CronJobs:           allCronJobs,
 		LimitRanges:        limitRangesMap,
 		DryRun:             o.Confirm == false,
 		PruneRegistry:      o.PruneRegistry,

--- a/pkg/cli/admin/prune/images/images.go
+++ b/pkg/cli/admin/prune/images/images.go
@@ -368,7 +368,7 @@ func (o PruneImagesOptions) Run() error {
 		fmt.Fprintf(o.ErrOut, "Failed to list replicasets: %v\n - * Make sure to update clusterRoleBindings.\n", err)
 	}
 
-	allSSs, err := o.KubeClient.AppsV1().StatefulSets(o.Namespace).List(context.TODO(), metav1.ListOptions{})
+	allSSets, err := o.KubeClient.AppsV1().StatefulSets(o.Namespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -478,7 +478,7 @@ func (o PruneImagesOptions) Run() error {
 		Deployments:        allDeployments,
 		DCs:                allDCs,
 		RSs:                allRSs,
-		SSs:                allSSs,
+		SSets:              allSSets,
 		Jobs:               allJobs,
 		CronJobs:           allCronJobs,
 		LimitRanges:        limitRangesMap,

--- a/pkg/cli/admin/prune/images/images.go
+++ b/pkg/cli/admin/prune/images/images.go
@@ -373,6 +373,11 @@ func (o PruneImagesOptions) Run() error {
 		return err
 	}
 
+	allJobs, err := o.KubeClient.BatchV1().Jobs(o.Namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
 	limitRangesList, err := o.KubeClient.CoreV1().LimitRanges(o.Namespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return err
@@ -469,6 +474,7 @@ func (o PruneImagesOptions) Run() error {
 		DCs:                allDCs,
 		RSs:                allRSs,
 		SSs:                allSSs,
+		Jobs:               allJobs,
 		LimitRanges:        limitRangesMap,
 		DryRun:             o.Confirm == false,
 		PruneRegistry:      o.PruneRegistry,

--- a/pkg/helpers/image/test/util.go
+++ b/pkg/helpers/image/test/util.go
@@ -302,7 +302,7 @@ func CronJob(namespace, name string, containerImages ...string) batchv1beta1.Cro
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
-			SelfLink:  "/apis/apps/v1/deployments/" + name,
+			SelfLink:  "/apis/batch/v1beta1/cronjobs/" + name,
 		},
 		Spec: batchv1beta1.CronJobSpec{
 			JobTemplate: batchv1beta1.JobTemplateSpec{
@@ -329,7 +329,7 @@ func Job(namespace, name string, containerImages ...string) batchv1.Job {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
-			SelfLink:  "/apis/apps/v1/deployments/" + name,
+			SelfLink:  "/apis/batch/v1/jobs/" + name,
 		},
 		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{
@@ -339,8 +339,8 @@ func Job(namespace, name string, containerImages ...string) batchv1.Job {
 	}
 }
 
-// SSList turns the given stateful sets into StatefulSetList.
-func SSList(ss ...kappsv1.StatefulSet) kappsv1.StatefulSetList {
+// SSetList turns the given stateful sets into StatefulSetList.
+func SSetList(ss ...kappsv1.StatefulSet) kappsv1.StatefulSetList {
 	return kappsv1.StatefulSetList{
 		Items: ss,
 	}
@@ -352,7 +352,7 @@ func StatefulSet(namespace, name string, containerImages ...string) kappsv1.Stat
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
-			SelfLink:  "/apis/apps/v1/deployments/" + name,
+			SelfLink:  "/apis/apps/v1/statefulsets/" + name,
 		},
 		Spec: kappsv1.StatefulSetSpec{
 			Template: corev1.PodTemplateSpec{

--- a/pkg/helpers/image/test/util.go
+++ b/pkg/helpers/image/test/util.go
@@ -10,6 +10,7 @@ import (
 
 	kappsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -283,6 +284,33 @@ func DS(namespace, name string, containerImages ...string) kappsv1.DaemonSet {
 		Spec: kappsv1.DaemonSetSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: PodSpecInternal(containerImages...),
+			},
+		},
+	}
+}
+
+// CronJobList turns the given stateful sets into JobList.
+func CronJobList(cjs ...batchv1beta1.CronJob) batchv1beta1.CronJobList {
+	return batchv1beta1.CronJobList{
+		Items: cjs,
+	}
+}
+
+// CronJob creates and returns a CronJob object.
+func CronJob(namespace, name string, containerImages ...string) batchv1beta1.CronJob {
+	return batchv1beta1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			SelfLink:  "/apis/apps/v1/deployments/" + name,
+		},
+		Spec: batchv1beta1.CronJobSpec{
+			JobTemplate: batchv1beta1.JobTemplateSpec{
+				Spec: batchv1.JobSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: PodSpecInternal(containerImages...),
+					},
+				},
 			},
 		},
 	}

--- a/pkg/helpers/image/test/util.go
+++ b/pkg/helpers/image/test/util.go
@@ -287,6 +287,29 @@ func DS(namespace, name string, containerImages ...string) kappsv1.DaemonSet {
 	}
 }
 
+// SSList turns the given stateful sets into StatefulSetList.
+func SSList(ss ...kappsv1.StatefulSet) kappsv1.StatefulSetList {
+	return kappsv1.StatefulSetList{
+		Items: ss,
+	}
+}
+
+// StatefulSet creates and returns a StatefulSet object.
+func StatefulSet(namespace, name string, containerImages ...string) kappsv1.StatefulSet {
+	return kappsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			SelfLink:  "/apis/apps/v1/deployments/" + name,
+		},
+		Spec: kappsv1.StatefulSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: PodSpecInternal(containerImages...),
+			},
+		},
+	}
+}
+
 // DeploymentList turns the given deployments into DeploymentList.
 func DeploymentList(deployments ...kappsv1.Deployment) kappsv1.DeploymentList {
 	return kappsv1.DeploymentList{

--- a/pkg/helpers/image/test/util.go
+++ b/pkg/helpers/image/test/util.go
@@ -9,6 +9,7 @@ import (
 	imagespecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 
 	kappsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -280,6 +281,29 @@ func DS(namespace, name string, containerImages ...string) kappsv1.DaemonSet {
 			SelfLink:  "/apis/apps/v1/daemonsets/" + name,
 		},
 		Spec: kappsv1.DaemonSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: PodSpecInternal(containerImages...),
+			},
+		},
+	}
+}
+
+// JobList turns the given stateful sets into JobList.
+func JobList(jobs ...batchv1.Job) batchv1.JobList {
+	return batchv1.JobList{
+		Items: jobs,
+	}
+}
+
+// Job creates and returns a Job object.
+func Job(namespace, name string, containerImages ...string) batchv1.Job {
+	return batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			SelfLink:  "/apis/apps/v1/deployments/" + name,
+		},
+		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: PodSpecInternal(containerImages...),
 			},


### PR DESCRIPTION
This commit makes image pruner aware of StatefulSets, Jobs and CronJobs existing in the cluster.