### PR TITLE
Bug 1878022: Increasing timeout for image import

### DIFF
--- a/pkg/cli/importimage/importimage.go
+++ b/pkg/cli/importimage/importimage.go
@@ -193,7 +193,7 @@ func (o *ImportImageOptions) Run() error {
 		Namespace(isi.Namespace).
 		Resource(imagev1.Resource("imagestreamimports").Resource).
 		Body(isi).
-		Timeout(time.Minute).
+		Timeout(time.Hour).
 		Do(context.TODO()).
 		Into(result)
 	if err != nil {

--- a/pkg/cli/importimage/importimage.go
+++ b/pkg/cli/importimage/importimage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -187,7 +188,14 @@ func (o *ImportImageOptions) Run() error {
 		return err
 	}
 
-	result, err := o.imageClient.ImageStreamImports(isi.Namespace).Create(context.TODO(), isi, metav1.CreateOptions{})
+	result := &imagev1.ImageStreamImport{}
+	err = o.imageClient.RESTClient().Post().
+		Namespace(isi.Namespace).
+		Resource(imagev1.Resource("imagestreamimports").Resource).
+		Body(isi).
+		Timeout(time.Minute).
+		Do(context.TODO()).
+		Into(result)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR increases the timeout for an image import up to one minute,
similar to what is done by openshift-controller-manager.