### PR TITLE
Bug 1878972: pkg/cli/admin/release: Use '-', not '=', for untranslated arches

### DIFF
--- a/pkg/cli/admin/release/mirror.go
+++ b/pkg/cli/admin/release/mirror.go
@@ -484,7 +484,7 @@ func (o *MirrorOptions) Run() error {
 				if val, ok := archMap[config.Architecture]; ok {
 					archExt = "-" + val
 				} else {
-					archExt = "=" + config.Architecture
+					archExt = "-" + config.Architecture
 				}
 			} else {
 				fmt.Fprintf(o.ErrOut, "warning: Unable to retrieve image release architecture\n")


### PR DESCRIPTION
Fixing a bug from e575833cd4 (#646), where untranslated architectures would fail [with][1]:

    error: unable to push manifest to local-registry.apps.pravind.redhat.com:5000/ocp4/openshift4:4.7.0-0.nightly-ppc64le-2020-12-21-131639=ppc64le-prometheus: invalid tag format

because tags are usually restricted to [`[\w][\w.-]{0,127}`][2], and [`\w` is `[0-9A-Za-z_]`][3].  That means `=` is not a valid character.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1878972#c14
[2]: https://github.com/containers/image/blob/a5061e5a5f00333ea3a92e7103effd11c6e2f51d/docker/reference/regexp.go#L36-L37
[3]: https://github.com/google/re2/wiki/Syntax