### PR TITLE
Bug 1914452: Fix the manifest list warning when choosing an os/arch digest from list

### DIFF
--- a/pkg/cli/image/manifest/manifest.go
+++ b/pkg/cli/image/manifest/manifest.go
@@ -411,7 +411,7 @@ func ProcessManifestList(ctx context.Context, srcDigest digest.Digest, srcManife
 			if err != nil {
 				return nil, nil, "", err
 			}
-			klog.Warningf("Chose %s/%s manifest from the list.\nTo include the manifest list digest: %s, use --keep-manifest-list=true", t.Manifests[0].Platform.OS, t.Manifests[0].Platform.Architecture, srcDigest)
+			klog.Warningf("Chose %s/%s manifest from the manifest list.", t.Manifests[0].Platform.OS, t.Manifests[0].Platform.Architecture)
 			return srcManifests, srcManifests[0], manifestDigest, nil
 		default:
 			return append(srcManifests, manifestList), manifestList, manifestDigest, nil


### PR DESCRIPTION
The warning issued when oc chooses an os/arch digest from a manifest list should not include the suggestion to run --keep-manifest-list=true, since that flag is only exposed during mirroring. the warning is issued with oc imageextract _and_ mirror

warning comes from `ProcessManifestList`, exercised with extract & mirror, however
`oc image extract` --keep-manifest-list is not exposed
`oc image mirror` --keep-manifest-list is exposed