### PR TITLE
Bug 1890995: oc new-app: provide message for unauthorized error with image lookup

### DIFF
--- a/pkg/helpers/newapp/app/dockerimagelookup.go
+++ b/pkg/helpers/newapp/app/dockerimagelookup.go
@@ -230,16 +230,16 @@ func (s ImageImportSearcher) Search(precise bool, terms ...string) (ComponentMat
 		if image.Status.Status != metav1.StatusSuccess {
 			klog.V(4).Infof("image import failed: %#v", image)
 			switch image.Status.Reason {
-			case metav1.StatusReasonInternalError:
+			case metav1.StatusReasonInternalError, metav1.StatusReasonUnauthorized:
 				// try to find the cause of the internal error
 				if image.Status.Details != nil && len(image.Status.Details.Causes) > 0 {
 					for _, c := range image.Status.Details.Causes {
-						klog.Warningf("container image registry lookup failed: %s", c.Message)
+						klog.Warningf("container image remote registry lookup failed: %s", c.Message)
 					}
 				} else {
-					klog.Warningf("container image registry lookup failed: %s", image.Status.Message)
+					klog.Warningf("container image remote registry lookup failed: %s", image.Status.Message)
 				}
-			case metav1.StatusReasonInvalid, metav1.StatusReasonUnauthorized, metav1.StatusReasonNotFound:
+			case metav1.StatusReasonInvalid, metav1.StatusReasonNotFound:
 			default:
 				errs = append(errs, fmt.Errorf("can't look up container image %q: %s", term, image.Status.Message))
 			}


### PR DESCRIPTION
Provide msg for UnuathorizedError with `oc new-app` 
Example: (private image quay.io/sallyom/podescape-io:test)
Before this PR:
```console
$ oc new-app --docker-image=quay.io/sallyom/podescape-io:test
error: unable to locate any local docker images with name "quay.io/sallyom/podescape-io:test"
```
With this PR:
```console
$ oc new-app --docker-image=quay.io/sallyom/podescape-io:test
W0108 17:39:59.507884 3164436 dockerimagelookup.go:240] container image remote registry lookup failed: you may not have access to the container image "quay.io/sallyom/podescape-io:test"
error: unable to locate any local docker images with name "quay.io/sallyom/podescape-io:test"
```

/assign @soltysh 