### PR TITLE
Bug 1944581: Preserve AuthInfo when switching projects

### DIFF
--- a/pkg/helpers/kubeconfig/smart_merge.go
+++ b/pkg/helpers/kubeconfig/smart_merge.go
@@ -58,6 +58,9 @@ func CreateConfig(namespace, userName string, clientCfg *restclient.Config) (*cl
 
 	credentials := clientcmdapi.NewAuthInfo()
 	credentials.Token = clientCfg.BearerToken
+	credentials.TokenFile = clientCfg.BearerTokenFile
+	credentials.AuthProvider = clientCfg.AuthProvider
+	credentials.Exec = clientCfg.ExecProvider
 	credentials.ClientCertificate = clientCfg.TLSClientConfig.CertFile
 	if len(credentials.ClientCertificate) == 0 {
 		credentials.ClientCertificateData = clientCfg.TLSClientConfig.CertData


### PR DESCRIPTION
This is a possible fix for https://github.com/openshift/oc/issues/647

Before this patch, if the openshift cluster is behind a cluster proxy (eg. kubectl proxy), and the authentication method is not token, `oc project <project-name>` will create a new user in `kubeconfig`, with blank info. This will lead to further `oc` commands return authentication error.

```
- name: system:serviceaccount:openshift-xxxx-xxxx:xxxxx
  user: {}
```

With this patch, when `oc project <project-name>` creating a new `kubeconfig`, it will preserve all the `AuthInfo` from `RESTConfig`, so that it won't break the customized settings.

```
- name: system:serviceaccount:openshift-xxxxx-xxxx/xxx-xxx-xxxx-xxxxx-xxxx-xx-xxxx-com:443
  user:
    exec:
      apiVersion: client.authentication.k8s.io/v1beta1
      args:
      - /home/xxx/.kube/xxx-token
      command: bash
      env:
      - name: OCM_CONFIG
        value: /home/xxx/.xxxx.xxxx.stg
      provideClusterInfo: false
```

`clientcmdapi` will handle the null pointer and null strings, so it won't break the existing `oc login` or `oc project` mechanism.  