### PR TITLE
Bug 1914894: warn users about using non-groupified resources

### DIFF
--- a/pkg/cli/shim_kubectl.go
+++ b/pkg/cli/shim_kubectl.go
@@ -1,6 +1,10 @@
 package cli
 
 import (
+	"k8s.io/klog/v2"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericclioptions/openshiftpatch"
 	kclientcmd "k8s.io/client-go/tools/clientcmd"
@@ -19,8 +23,8 @@ func shimKubectlForOc() {
 	// if we call this factory construction method, we want the openshift style config loading
 	kclientcmd.ErrEmptyConfig = genericclioptions.ErrEmptyConfig
 	kcmdset.ParseDockerImageReferenceToStringFunc = clientcmd.ParseDockerImageReferenceToStringFunc
-	openshiftpatch.OAPIToGroupified = legacygroupification.OAPIToGroupified
-	openshiftpatch.OAPIToGroupifiedGVK = legacygroupification.OAPIToGroupifiedGVK
+	openshiftpatch.OAPIToGroupified = oAPIToGroupified
+	openshiftpatch.OAPIToGroupifiedGVK = oAPIToGroupifiedGVK
 	openshiftpatch.IsOAPIFn = legacygroupification.IsOAPI
 	openshiftpatch.IsOC = true
 	kclientcmd.UseModifyConfigLock = false
@@ -42,4 +46,20 @@ func shimKubectlForOc() {
 	// update some functions we inject
 	versioned.GeneratorFn = originpolymorphichelpers.NewGeneratorsFn(versioned.GeneratorFn)
 	describeversioned.DescriberFn = originpolymorphichelpers.NewDescriberFn(describeversioned.DescriberFn)
+}
+
+func oAPIToGroupified(uncast runtime.Object, gvk *schema.GroupVersionKind) {
+	before := gvk.Group
+	legacygroupification.OAPIToGroupified(uncast, gvk)
+	if before != gvk.Group {
+		klog.Warningf("Using non-groupfied API resources is deprecated and will be removed in a future release, update apiVersion to %q for your resource", gvk.GroupVersion())
+	}
+}
+
+func oAPIToGroupifiedGVK(gvk *schema.GroupVersionKind) {
+	before := gvk.Group
+	legacygroupification.OAPIToGroupifiedGVK(gvk)
+	if before != gvk.Group {
+		klog.Warningf("Using non-groupfied API resources is deprecated and will be removed in a future release, update apiVersion to %q for your resource", gvk.GroupVersion())
+	}
 }


### PR DESCRIPTION
/assign @deads2k 

Example invocation with this PR:
```
$ ./oc annotate --local -f ../origin/test/extended/testdata/deployments/deployment-simple.yaml x=y
W0111 14:15:50.202062   44273 shim_kubectl.go:55] Using non-groupfied API resources is deprecated, update apiVersion to "apps.openshift.io/v1" for your resource
deploymentconfig.apps.openshift.io/deployment-simple annotated
```