### PR TITLE
Bug 1906276: oc image append|extract: clarify help for --filter-by-os

### DIFF
--- a/pkg/cli/image/append/append.go
+++ b/pkg/cli/image/append/append.go
@@ -68,6 +68,11 @@ var (
 
 		# Add a new layer to the image
 		oc image append --from mysql:latest --to myregistry.com/myimage:latest layer.tar.gz
+
+		# Add a new layer to a multi-architecture image for an os/arch that is different from the system's os/arch
+		# Note: Wildcard filter is not supported with append. Pass a single os/arch to append.
+		oc image append --from docker.io/library/busybox:latest --filter-by-os=linux/s390x --to myregistry.com/myimage:latest layer.tar.gz
+
 	`)
 )
 

--- a/pkg/cli/image/extract/extract.go
+++ b/pkg/cli/image/extract/extract.go
@@ -63,6 +63,10 @@ var (
 		# Extract the busybox image into the current directory
 		oc image extract docker.io/library/busybox:latest
 
+		# Extract the busybox image into the current directory for linux/s390x platform
+		# Note: Wildcard filter is not supported with extract. Pass a single os/arch to extract.
+		oc image extract docker.io/library/busybox:latest --filter-by-os=linux/s390x
+
 		# Extract the busybox image to a temp directory (must exist)
 		oc image extract docker.io/library/busybox:latest --path /:/tmp/busybox
 


### PR DESCRIPTION
Clarify in help menu that `--filter-by-os=.*` is not supported with `oc image extract` and `oc image append`. 

/assign @soltysh 