### PR TITLE
Bug 1878022: Improving import-image help messages

### DIFF
--- a/pkg/cli/importimage/importimage.go
+++ b/pkg/cli/importimage/importimage.go
@@ -39,7 +39,23 @@ var (
 		see the 'tag' command.`)
 
 	importImageExample = templates.Examples(`
+		# Import tag latest into a new image stream.
+		oc import-image mystream --from=registry.io/repo/image:latest --confirm
+
+		# Update imported data for tag latest in an already existing image stream.
 		oc import-image mystream
+
+		# Update imported data for tag stable in an already existing image stream.
+		oc import-image mystream:stable
+
+		# Update imported data for all tags in an existing image stream.
+		oc import-image mystream --all
+
+		# Import all tags into a new image stream.
+		oc import-image mystream --from=registry.io/repo/image --all --confirm
+
+		# Import all tags into a new image stream using a custom timeout.
+		oc --request-timeout=5m import-image mystream --from=registry.io/repo/image --all --confirm
 	`)
 )
 


### PR DESCRIPTION
Following our discussions on https://github.com/openshift/oc/pull/679 this PR makes `oc help image-import` to contain an example of `--request-timeout` flag usage.