### PR TITLE
Bug 1879980: Fix swallowed error message in GroupDetector

### DIFF
--- a/pkg/helpers/groupsync/groupdetector/groupdetector.go
+++ b/pkg/helpers/groupsync/groupdetector/groupdetector.go
@@ -20,7 +20,7 @@ type GroupBasedDetector struct {
 func (l *GroupBasedDetector) Exists(ldapGroupUID string) (bool, error) {
 	group, err := l.groupGetter.GroupEntryFor(ldapGroupUID)
 	if ldapquery.IsQueryOutOfBoundsError(err) || ldapquery.IsEntryNotFoundError(err) || ldapquery.IsNoSuchObjectError(err) {
-		return false, nil
+		return false, err
 	}
 	if err != nil {
 		return false, err


### PR DESCRIPTION
 ldapquery.IsQueryOutOfBoundsError(err) ||
 ldapquery.IsEntryNotFoundError(err) ||
 ldapquery.IsNoSuchObjectError(err)

Would return false but error was swallowed