### PR TITLE
Add help text to 'oc registry login' when using --registry flag

### DIFF
--- a/pkg/cli/registry/login/login.go
+++ b/pkg/cli/registry/login/login.go
@@ -55,6 +55,11 @@ var (
 		permission to view image streams you will have to pass the --registry flag with the
 		desired hostname.
 
+		You may also pass the --registry flag to login to the integrated registry but with a
+		custom DNS name, or to an external registry. Note that in absence of --auth-basic=USER:PASSWORD,
+		the authentication token from the connected kubeconfig file will be recorded as the auth entry
+		in the credentials file (defaults to Docker config.json) for the passed registry value.
+
 		Experimental: This command is under active development and may change without notice.`)
 
 	example = templates.Examples(`
@@ -64,8 +69,8 @@ var (
 		# Log in as the default service account in the current namespace
 		oc registry login -z default
 
-		# Log in to a different registry using BASIC auth credentials
-		oc registry login --registry quay.io --auth-basic=USER:PASS
+		# Log in to different registry using BASIC auth credentials
+		oc registry login --registry quay.io/myregistry --auth-basic=USER:PASS
 	`)
 )
 
@@ -125,8 +130,8 @@ func NewRegistryLoginCmd(f kcmdutil.Factory, streams genericclioptions.IOStreams
 
 	flag := cmd.Flags()
 	flag.StringVar(&o.AuthBasic, "auth-basic", o.AuthBasic, "Provide credentials in the form 'user:password' to authenticate (advanced)")
-	flag.StringVarP(&o.ConfigFile, "registry-config", "a", o.ConfigFile, "The location of the Docker config.json your credentials will be stored in.")
-	flag.StringVar(&o.ConfigFile, "to", o.ConfigFile, "The location of the Docker config.json your credentials will be stored in.")
+	flag.StringVarP(&o.ConfigFile, "registry-config", "a", o.ConfigFile, "The location of the file your credentials will be stored in. Default is Docker config.json")
+	flag.StringVar(&o.ConfigFile, "to", o.ConfigFile, "The location of the file your credentials will be stored in. Default is Docker config.json")
 	flag.StringVarP(&o.ServiceAccount, "service-account", "z", o.ServiceAccount, "Log in as the specified service account name in the specified namespace.")
 	flag.StringVar(&o.HostPort, "registry", o.HostPort, "An alternate domain name and port to use for the registry, defaults to the cluster's configured external hostname.")
 	flag.BoolVar(&o.SkipCheck, "skip-check", o.SkipCheck, "Skip checking the credentials against the registry.")


### PR DESCRIPTION
This added help text is necessary because it's easy to forget you have a connected cluster (especially when kubeconfig is unset but there's the file in the default ~/.kube/config). If you forget you are currently connected, then it's easy to forget that `oc registry login localhost:5000` will write the authentication token from the connected cluster (for current context) as the  
```
    "localhost:5000": {
          "auth": "thiswouldbewrong"
```
when what you _probably_ want is `oc registry login localhost:5000 --auth-basic=user:password` 