### PR TITLE
Add missing docs generation tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,10 @@ verify-generated-completions: build
 	hack/verify-generated-completions.sh
 .PHONY: verify-generated-completions
 
+generate-docs:
+	go run ./tools/gendocs
+.PHONY: generate-docs
+
 generate-versioninfo:
 	SOURCE_GIT_TAG=$(SOURCE_GIT_TAG) hack/generate-versioninfo.sh
 .PHONY: generate-versioninfo

--- a/docs/generated/.gitignore
+++ b/docs/generated/.gitignore
@@ -1,0 +1,2 @@
+!/.gitignore
+*

--- a/hack/clibyexample/OWNERS
+++ b/hack/clibyexample/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - soltysh
+approvers:
+  - soltysh

--- a/hack/clibyexample/template
+++ b/hack/clibyexample/template
@@ -1,0 +1,18 @@
+:toc: macro
+:toc-title:
+
+toc::[]
+
+{{range .items}}
+== {{.fullName}}
+{{.description}}
+
+====
+
+[options="nowrap"]
+----
+{{.examples}}
+----
+====
+
+{{end}}


### PR DESCRIPTION
Looks like we missed those when moving from origin repo.

Sample output after running `make generate-docs`: https://gist.github.com/soltysh/526b047401dad67e1558068f535ef558

/assign @sallyom 