### PR TITLE
Bug 1904006: update and clarify --dir --from-dir flags with 'oc image'

### DIFF
--- a/pkg/cli/image/append/append.go
+++ b/pkg/cli/image/append/append.go
@@ -69,6 +69,20 @@ var (
 		# Add a new layer to the image
 		oc image append --from mysql:latest --to myregistry.com/myimage:latest layer.tar.gz
 
+		# Add a new layer to the image and store the result on disk
+		# This results in $(pwd)/v2/mysql/blobs,manifests
+		oc image append --from mysql:latest --to file://mysql:local layer.tar.gz
+
+		# Add a new layer to the image and store the result on disk in a designated directory
+		# This will result in $(pwd)/mysql-local/v2/mysql/blobs,manifests
+		oc image append --from mysql:latest --to file://mysql:local --dir mysql-local layer.tar.gz
+
+		# Add a new layer to an image that is stored on disk (~/mysql-local/v2/image exists)
+		oc image append --from-dir ~/mysql-local --to myregistry.com/myimage:latest layer.tar.gz
+
+		# Add a new layer to an image that was mirrored to the current directory on disk ($(pwd)/v2/image exists)
+		oc image append --from-dir v2 --to myregistry.com/myimage:latest layer.tar.gz
+
 		# Add a new layer to a multi-architecture image for an os/arch that is different from the system's os/arch
 		# Note: Wildcard filter is not supported with append. Pass a single os/arch to append.
 		oc image append --from docker.io/library/busybox:latest --filter-by-os=linux/s390x --to myregistry.com/myimage:latest layer.tar.gz
@@ -224,6 +238,7 @@ func (o *AppendImageOptions) Run() error {
 		Insecure:        o.SecurityOptions.Insecure,
 		RegistryContext: fromContext,
 	}
+
 	if len(o.FromFileDir) > 0 {
 		fromOptions.FileDir = o.FromFileDir
 	}


### PR DESCRIPTION
/assign @smarterclayton 

This flag `--dir` ~does not make sense~ wrt `oc image extract` and is confusing because it lends to the misconception that with it one can choose where to extract contents of an image into. ~It also is not wired properly~  This PR exposes the flag `--to-dir` to add the ability for users to designate where to extract image contents to on disk. 

`--dir` is used elsewhere and in most cases is misleading. 
This PR clarifies and updates the flags `--dir, --to-dir, --from-dir`.

For example with `oc image mirror`:
`'--dir='': The directory on disk that file:// images will be copied under'`
`oc image info`:
`--dir='': The directory on disk that file:// images will be read from.`  

And here is an example of `--dir`  with both meanings of the flag:
```console
$ oc image mirror docker.io/library/busybox:latest=file://busybox:latest --dir $(pwd)/busybox
$ oc image info file://busybox:latest --dir $(pwd)/busybox
```
Since `--dir` can mean "directory that file://image is read from" and also "directory where file://image contents will be copied under" we need to add help examples and make it more clear

This PR also resolves https://bugzilla.redhat.com/show_bug.cgi?id=1906277 by adding help examples for append