### PR TITLE
Add json.Valid check before trying to read docker config

### DIFF
--- a/pkg/helpers/image/credentialprovider/config.go
+++ b/pkg/helpers/image/credentialprovider/config.go
@@ -147,7 +147,12 @@ func ReadSpecificDockerConfigJSONFile(filePath string) (cfg DockerConfig, err er
 	if contents, err = ioutil.ReadFile(filePath); err != nil {
 		return nil, err
 	}
-	return readDockerConfigJSONFileFromBytes(contents)
+
+	cfg, err = readDockerConfigJSONFileFromBytes(contents)
+	if err != nil {
+		return nil, fmt.Errorf("invalid config: %q: %w", filePath, err)
+	}
+	return cfg, nil
 }
 
 // ReadDockerConfigFile read a docker config file from default path


### PR DESCRIPTION
Add json.Valid check before trying to read docker config

At the moment, if we fail during unmarshaling JSON, it doesn't
give much of hint where the failure occurred.

For example error message when we provide invalid JSON:

```
    unable to load --registry-config: error occurred while trying to unmarshal json
```

Since we have filePath and json package, before actually unmarshaling
the json, we can verify it's contents.

This patch adds a little bit more friendlier error message, before
even failing on unmarshaling

```
    unable to load --registry-config: json format is invalid: file.json
```
