### PR TITLE
inspect clusteroperators as a backup to must-gather if it fails

### DIFF
--- a/pkg/cli/admin/inspect/inspect_test.go
+++ b/pkg/cli/admin/inspect/inspect_test.go
@@ -72,7 +72,7 @@ func TestDirectoryViable(t *testing.T) {
 				defer test.teardown(dirName)
 			}
 
-			o := InspectOptions{destDir: dirName, overwrite: test.allowOverride}
+			o := InspectOptions{DestDir: dirName, overwrite: test.allowOverride}
 			err = o.ensureDirectoryViable()
 			if !errorFuzzyEquals(err, test.expectedErr) {
 				t.Fatalf("unexpected error: expecting %v, but got %v", test.expectedErr, err)

--- a/pkg/cli/admin/inspect/resource.go
+++ b/pkg/cli/admin/inspect/resource.go
@@ -42,17 +42,17 @@ func InspectResource(info *resource.Info, context *resourceContext, o *InspectOp
 
 		// first, gather config.openshift.io resource data
 		errs := []error{}
-		if err := o.gatherConfigResourceData(path.Join(o.destDir, "/cluster-scoped-resources/config.openshift.io"), context); err != nil {
+		if err := o.gatherConfigResourceData(path.Join(o.DestDir, "/cluster-scoped-resources/config.openshift.io"), context); err != nil {
 			errs = append(errs, err)
 		}
 
 		// then, gather operator.openshift.io resource data
-		if err := o.gatherOperatorResourceData(path.Join(o.destDir, "/cluster-scoped-resources/operator.openshift.io"), context); err != nil {
+		if err := o.gatherOperatorResourceData(path.Join(o.DestDir, "/cluster-scoped-resources/operator.openshift.io"), context); err != nil {
 			errs = append(errs, err)
 		}
 
 		// save clusteroperator resources to disk
-		if err := gatherClusterOperatorResource(o.destDir, unstr, o.fileWriter); err != nil {
+		if err := gatherClusterOperatorResource(o.DestDir, unstr, o.fileWriter); err != nil {
 			errs = append(errs, err)
 		}
 
@@ -65,7 +65,7 @@ func InspectResource(info *resource.Info, context *resourceContext, o *InspectOp
 
 	case corev1.SchemeGroupVersion.WithResource("namespaces").GroupResource():
 		errs := []error{}
-		if err := o.gatherNamespaceData(o.destDir, info.Name); err != nil {
+		if err := o.gatherNamespaceData(o.DestDir, info.Name); err != nil {
 			errs = append(errs, err)
 		}
 		resourcesToCollect := namespaceResourcesToCollect()
@@ -109,7 +109,7 @@ func InspectResource(info *resource.Info, context *resourceContext, o *InspectOp
 		}
 
 		// save the current object to disk
-		dirPath := dirPathForInfo(o.destDir, info)
+		dirPath := dirPathForInfo(o.DestDir, info)
 		filename := filenameForInfo(info)
 		// ensure destination path exists
 		if err := os.MkdirAll(dirPath, os.ModePerm); err != nil {

--- a/pkg/cli/admin/inspect/route.go
+++ b/pkg/cli/admin/inspect/route.go
@@ -53,7 +53,7 @@ func inspectRouteInfo(info *resource.Info, o *InspectOptions) error {
 	}
 
 	// save the current object to disk
-	dirPath := dirPathForInfo(o.destDir, info)
+	dirPath := dirPathForInfo(o.DestDir, info)
 	filename := filenameForInfo(info)
 	// ensure destination path exists
 	if err := os.MkdirAll(dirPath, os.ModePerm); err != nil {

--- a/pkg/cli/admin/inspect/secret.go
+++ b/pkg/cli/admin/inspect/secret.go
@@ -54,7 +54,7 @@ func inspectSecretInfo(info *resource.Info, o *InspectOptions) error {
 	}
 
 	// save the current object to disk
-	dirPath := dirPathForInfo(o.destDir, info)
+	dirPath := dirPathForInfo(o.DestDir, info)
 	filename := filenameForInfo(info)
 	// ensure destination path exists
 	if err := os.MkdirAll(dirPath, os.ModePerm); err != nil {


### PR DESCRIPTION
A possible example of how to run `oc adm inspect clusteroperators` if must-gather fails.


/hold

this hasn't been tested yet.