### PR TITLE
pkg/cli/admin/inspect/namespace: Gather PDBs too

### DIFF
--- a/pkg/cli/admin/inspect/namespace.go
+++ b/pkg/cli/admin/inspect/namespace.go
@@ -25,6 +25,7 @@ func namespaceResourcesToCollect() []schema.GroupResource {
 		{Resource: "endpoints"},
 		{Resource: "endpointslices"},
 		{Resource: "persistentvolumeclaims"},
+		{Resource: "poddisruptionbudgets"},
 		{Resource: "secrets"},
 	}
 }


### PR DESCRIPTION
Pod disruption budgets are important enough to be included in Insights tarballs (openshift/insights-operator#185), and they aren't all that big, so we should pick them up as a standard part of interesting namespaces too.  This will help with things like auditing issues where we failed to drain (PDB too strict) or disrupted a core workload (PDB too weak or missing).