### PR TITLE
Bug 1925534: Add proxy to oc

### DIFF
--- a/pkg/helpers/kubeconfig/smart_merge.go
+++ b/pkg/helpers/kubeconfig/smart_merge.go
@@ -4,6 +4,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"net"
+	"net/http"
 	"net/url"
 	"reflect"
 	"strconv"
@@ -70,6 +71,21 @@ func CreateConfig(namespace, userName string, clientCfg *restclient.Config) (*cl
 
 	cluster := clientcmdapi.NewCluster()
 	cluster.Server = clientCfg.Host
+
+	if clientCfg.Proxy != nil {
+		req, err := http.NewRequest("", clientCfg.Host, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create proxy URL request for execProvider: %w", err)
+		}
+		proxyURL, err := clientCfg.Proxy(req)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get proxy URL for execProvider: %w", err)
+		}
+		if proxyURL != nil {
+			cluster.ProxyURL = proxyURL.String()
+		}
+	}
+
 	cluster.CertificateAuthority = clientCfg.CAFile
 	if len(cluster.CertificateAuthority) == 0 {
 		cluster.CertificateAuthorityData = clientCfg.CAData


### PR DESCRIPTION
We can use existing Proxy field.

Without patch:
```
➜  oc git:(add-proxy-to-oc) ✗ cat ~/.kube/config | grep 8080
    proxy-url: http://127.0.0.1:8080
➜  oc git:(add-proxy-to-oc) ✗ ./oc project default
Already on project "default" on server "https://example.com:6443".
➜  oc git:(add-proxy-to-oc) ✗ cat ~/.kube/config | grep 8080
➜  oc git:(add-proxy-to-oc) ✗
```

With patch:

```
➜  oc git:(add-proxy-to-oc) ✗ cat ~/.kube/config | grep 8080
    proxy-url: http://127.0.0.1:8080
➜  oc git:(add-proxy-to-oc) ✗ ./oc project default
Already on project "default" on server "https://example.com:6443".
➜  oc git:(add-proxy-to-oc) ✗ cat ~/.kube/config | grep 8080
    proxy-url: http://127.0.0.1:8080
```

With Login option `--proxy` added `oc` will use that during login and will save the proxy as proxy-url for any subsequent requests against that cluster.

```
➜  oc git:(add-proxy-to-oc) ✗ rm ~/.kube/config
➜  oc git:(add-proxy-to-oc) ✗ ./oc login --token=sha256~XXX --server=https://example.com6443 --proxy=http://127.0.0.1:8080
The server uses a certificate signed by an unknown authority.
You can bypass the certificate check, but any data you send to the server could be intercepted by others.
Use insecure connections? (y/n): y

Logged into "https://example.com:6443" as "kube:admin" using the token provided.

You have access to 58 projects, the list has been suppressed. You can list all projects with 'oc projects'

Using project "default".
Welcome! See 'oc help' to get started.
➜  oc git:(add-proxy-to-oc) ✗ cat ~/.kube/config | grep 8080
    proxy-url: http://127.0.0.1:8080
```