### PR TITLE
indicate how many bytes the hidden secret key was

### DIFF
--- a/pkg/cli/admin/inspect/secret.go
+++ b/pkg/cli/admin/inspect/secret.go
@@ -1,6 +1,7 @@
 package inspect
 
 import (
+	"fmt"
 	"os"
 	"path"
 
@@ -73,12 +74,12 @@ var publicSecretKeys = sets.NewString(
 )
 
 func elideSecret(secret *corev1.Secret) {
-	for k := range secret.Data {
+	for k, v := range secret.Data {
 		// some secrets keys are safe to include because know their content.
 		if publicSecretKeys.Has(k) {
 			continue
 		}
-		secret.Data[k] = []byte{}
+		secret.Data[k] = []byte(fmt.Sprintf("%d bytes long", len(v)))
 	}
 
 	if _, ok := secret.Annotations["openshift.io/token-secret.value"]; ok {


### PR DESCRIPTION
still hides the secret content, but let's you know how many bytes it was.