### PR TITLE
Bug 1935102: Revert Avoid TLS cert checking when login with --insecure-skip-tls-verify=true

### DIFF
--- a/pkg/cli/login/loginoptions.go
+++ b/pkg/cli/login/loginoptions.go
@@ -133,9 +133,6 @@ func (o *LoginOptions) getClientConfig() (*restclient.Config, error) {
 		clientConfig.CAData = caData
 	}
 
-	// if user has selected option --insecure-skip-tls-verify=true, TLS server certificate verification should not be attempted
-	clientConfig.Insecure = o.InsecureTLS
-
 	// try to TCP connect to the server to make sure it's reachable, and discover
 	// about the need of certificates or insecure TLS
 	if err := dialToServer(*clientConfig); err != nil {
@@ -183,10 +180,6 @@ func (o *LoginOptions) gatherAuthInfo() error {
 	directClientConfig, err := o.getClientConfig()
 	if err != nil {
 		return err
-	}
-
-	if directClientConfig.Insecure && o.InsecureTLS {
-		fmt.Fprintf(o.Out, "WARNING: Using insecure TLS client config. Setting this option is not supported!\n\n")
 	}
 
 	// make a copy and use it to avoid mutating the original


### PR DESCRIPTION
Reverts regression introduced in https://github.com/openshift/oc/pull/746 until we can determine a valid approach to solve that problem