### PR TITLE
Bug 1936904: Insert apiVersion and Kind into `oc adm groups sync` list output

### DIFF
--- a/pkg/helpers/groupsync/groupsyncer.go
+++ b/pkg/helpers/groupsync/groupsyncer.go
@@ -179,6 +179,8 @@ func (s *LDAPGroupSyncer) makeOpenShiftGroup(ldapGroupUID string, usernames []st
 	// overwrite Group Users data
 	group.Users = usernames
 	group.Annotations[LDAPSyncTimeAnnotation] = ISO8601(time.Now())
+	group.APIVersion = userv1.GroupVersion.String()
+	group.Kind = "Group"
 
 	return group, nil
 }

--- a/pkg/helpers/groupsync/groupsyncer_test.go
+++ b/pkg/helpers/groupsync/groupsyncer_test.go
@@ -46,7 +46,9 @@ func TestMakeOpenShiftGroup(t *testing.T) {
 		"good": {
 			ldapGroupUID: "alfa",
 			usernames:    []string{"valerie"},
-			expectedGroup: &userv1.Group{ObjectMeta: metav1.ObjectMeta{Name: "zulu",
+			expectedGroup: &userv1.Group{
+				TypeMeta: metav1.TypeMeta{Kind: "Group", APIVersion: userv1.GroupVersion.String()},
+				ObjectMeta: metav1.ObjectMeta{Name: "zulu",
 				Annotations: map[string]string{LDAPURLAnnotation: "test-host:port", LDAPUIDAnnotation: "alfa"},
 				Labels:      map[string]string{LDAPHostLabel: "test-host"}},
 				Users: []string{"valerie"}},
@@ -54,7 +56,9 @@ func TestMakeOpenShiftGroup(t *testing.T) {
 		"replaced good": {
 			ldapGroupUID: "alfa",
 			usernames:    []string{"valerie"},
-			expectedGroup: &userv1.Group{ObjectMeta: metav1.ObjectMeta{Name: "zulu",
+			expectedGroup: &userv1.Group{
+				TypeMeta: metav1.TypeMeta{Kind: "Group", APIVersion: userv1.GroupVersion.String()},
+				ObjectMeta: metav1.ObjectMeta{Name: "zulu",
 				Annotations: map[string]string{LDAPURLAnnotation: "test-host:port", LDAPUIDAnnotation: "alfa"},
 				Labels:      map[string]string{LDAPHostLabel: "test-host"}},
 				Users: []string{"valerie"}},
@@ -271,6 +275,7 @@ func extractActualGroups(tc *fakeuserv1client.FakeUserV1) []*userv1.Group {
 func newDefaultOpenShiftGroups(host string) []*userv1.Group {
 	return []*userv1.Group{
 		{
+			TypeMeta: metav1.TypeMeta{Kind: "Group", APIVersion: userv1.GroupVersion.String()},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "os" + Group1UID,
 				Annotations: map[string]string{
@@ -284,6 +289,7 @@ func newDefaultOpenShiftGroups(host string) []*userv1.Group {
 			Users: []string{Member1UID, Member2UID},
 		},
 		{
+			TypeMeta: metav1.TypeMeta{Kind: "Group", APIVersion: userv1.GroupVersion.String()},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "os" + Group2UID,
 				Annotations: map[string]string{
@@ -297,6 +303,7 @@ func newDefaultOpenShiftGroups(host string) []*userv1.Group {
 			Users: []string{Member2UID, Member3UID},
 		},
 		{
+			TypeMeta: metav1.TypeMeta{Kind: "Group", APIVersion: userv1.GroupVersion.String()},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "os" + Group3UID,
 				Annotations: map[string]string{

--- a/pkg/helpers/groupsync/groupsyncer_test.go
+++ b/pkg/helpers/groupsync/groupsyncer_test.go
@@ -49,8 +49,8 @@ func TestMakeOpenShiftGroup(t *testing.T) {
 			expectedGroup: &userv1.Group{
 				TypeMeta: metav1.TypeMeta{Kind: "Group", APIVersion: userv1.GroupVersion.String()},
 				ObjectMeta: metav1.ObjectMeta{Name: "zulu",
-				Annotations: map[string]string{LDAPURLAnnotation: "test-host:port", LDAPUIDAnnotation: "alfa"},
-				Labels:      map[string]string{LDAPHostLabel: "test-host"}},
+					Annotations: map[string]string{LDAPURLAnnotation: "test-host:port", LDAPUIDAnnotation: "alfa"},
+					Labels:      map[string]string{LDAPHostLabel: "test-host"}},
 				Users: []string{"valerie"}},
 		},
 		"replaced good": {
@@ -59,8 +59,8 @@ func TestMakeOpenShiftGroup(t *testing.T) {
 			expectedGroup: &userv1.Group{
 				TypeMeta: metav1.TypeMeta{Kind: "Group", APIVersion: userv1.GroupVersion.String()},
 				ObjectMeta: metav1.ObjectMeta{Name: "zulu",
-				Annotations: map[string]string{LDAPURLAnnotation: "test-host:port", LDAPUIDAnnotation: "alfa"},
-				Labels:      map[string]string{LDAPHostLabel: "test-host"}},
+					Annotations: map[string]string{LDAPURLAnnotation: "test-host:port", LDAPUIDAnnotation: "alfa"},
+					Labels:      map[string]string{LDAPHostLabel: "test-host"}},
 				Users: []string{"valerie"}},
 			startingGroups: []runtime.Object{
 				&userv1.Group{ObjectMeta: metav1.ObjectMeta{Name: "zulu",


### PR DESCRIPTION
This attempts to get group `kind`/`apiVersion` to print in the list when using `oc adm groups sync`

Output with these changes (using sample LDAP at https://www.forumsys.com/tutorials/integration-how-to/ldap/online-ldap-test-server/):
```
$ ./oc adm groups sync --sync-config=ldap-config.yaml -o yaml
apiVersion: v1
items:
- apiVersion: user.openshift.io/v1
  kind: group
  metadata:
    annotations:
      openshift.io/ldap.sync-time: 2021-03-09T11:34:59-0500
      openshift.io/ldap.uid: ou=mathematicians,dc=example,dc=com
      openshift.io/ldap.url: ldap.forumsys.com:389
    creationTimestamp: null
    labels:
      openshift.io/ldap.host: ldap.forumsys.com
    name: Mathematicians
  users: null
kind: List
metadata: {}
```