### PR TITLE
Bug 1925148: ImageRef Stream name priority increased

### DIFF
--- a/pkg/helpers/newapp/app/imageref.go
+++ b/pkg/helpers/newapp/app/imageref.go
@@ -230,11 +230,13 @@ func (r *ImageRef) SuggestName() (string, bool) {
 	if r == nil {
 		return "", false
 	}
-	if len(r.ObjectName) > 0 {
-		return r.ObjectName, true
-	}
+	// if ImageStream already exists, its name should
+	// have higher preference than object name
 	if r.Stream != nil {
 		return r.Stream.Name, true
+	}
+	if len(r.ObjectName) > 0 {
+		return r.ObjectName, true
 	}
 	if len(r.Reference.Name) > 0 {
 		return r.Reference.Name, true
@@ -244,13 +246,9 @@ func (r *ImageRef) SuggestName() (string, bool) {
 
 // SuggestNamespace suggests a namespace for an image reference
 func (r *ImageRef) SuggestNamespace() string {
-	if r == nil {
-		return ""
-	}
-	if len(r.ObjectName) > 0 {
-		return ""
-	}
-	if r.Stream != nil {
+	// if ImageStream already exists, it's namespace should have
+	// priority over object namespace
+	if r != nil && r.Stream != nil {
 		return r.Stream.Namespace
 	}
 	return ""

--- a/pkg/helpers/newapp/app/imageref_test.go
+++ b/pkg/helpers/newapp/app/imageref_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	appsv1 "github.com/openshift/api/apps/v1"
 	buildv1 "github.com/openshift/api/build/v1"
@@ -85,6 +86,35 @@ func TestBuildConfigOutput(t *testing.T) {
 		if !imageChangeTrigger {
 			t.Errorf("expecting image change trigger in build config")
 		}
+	}
+}
+
+func TestImageStreamRefNaming(t *testing.T) {
+	objectName := "object"
+	streamName := "stream"
+	streamNamespace := "anotherNamespace"
+
+	imageRef := &ImageRef{
+		ObjectName: objectName,
+		Stream: &imagev1.ImageStream{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      streamName,
+				Namespace: streamNamespace,
+			},
+		},
+	}
+
+	suggestedName, ok := imageRef.SuggestName()
+	if !ok {
+		t.Fatalf("failed to procure name for stream")
+	}
+	suggestedNamespace := imageRef.SuggestNamespace()
+
+	if suggestedName != streamName {
+		t.Errorf("suggested name %v is different from expected %v", suggestedName, streamName)
+	}
+	if suggestedNamespace != streamNamespace {
+		t.Errorf("suggested namespace %v is different from expected %v", suggestedNamespace, streamNamespace)
 	}
 }
 


### PR DESCRIPTION
If `ImageRef` has `Stream` value filled, it means, that we are working with `ImageStream` that already exists.
In this case suggested name and suggested namespace for `ImageRef` should be taken from that `ImageStream`, and not from the object.

This fixes the bug in which new `ImageStream` is created when we are working with existing `ImageStream`, which has name and namespace different from our deployment name.