### PR TITLE
Bug 1919168: when mirroring to a file destination, mount images under the index location

### DIFF
--- a/pkg/cli/admin/catalog/mirrorer_test.go
+++ b/pkg/cli/admin/catalog/mirrorer_test.go
@@ -453,6 +453,395 @@ func mustParseRef(t *testing.T, ref string) imagesource.TypedImageReference {
 	return parsed
 }
 
+// airgap mirror is two step: first to a file, second from a file
+// this test ensures the assumptions around mapping to/from files are correct
+func TestAirGapMirror(t *testing.T) {
+	type fields struct {
+		ImageMirrorer     ImageMirrorerFunc
+		DatabaseExtractor DatabaseExtractorFunc
+		Source            imagesource.TypedImageReference
+		Dest              imagesource.TypedImageReference
+	}
+	tests := []struct {
+		name         string
+		fields       fields
+		fileSource   imagesource.TypedImageReference
+		fileDest     imagesource.TypedImageReference
+		wantToFile   map[imagesource.TypedImageReference]imagesource.TypedImageReference
+		wantFromFile map[imagesource.TypedImageReference]imagesource.TypedImageReference
+	}{
+		{
+			name:       "maps to and from an intermediate file",
+			fileSource: mustParseRef(t, "file:///local/index/example/image:tag"),
+			fileDest:   mustParseRef(t, "file:///local/index"),
+			fields: fields{
+				ImageMirrorer:     noopMirror,
+				DatabaseExtractor: existingExtractor("testdata/test.db"),
+				Source:            mustParse(t, "quay.io/example/image:tag"),
+				Dest:              mustParse(t, "localhost:5000"),
+			},
+			wantToFile: map[imagesource.TypedImageReference]imagesource.TypedImageReference{
+				mustParseRef(t, "quay.io/example/image:tag"):             mustParseRef(t, "file://local/index/example/image:tag"),
+				mustParseRef(t, "quay.io/test/prometheus.0.14.0:latest"): mustParseRef(t, "file://local/index/example/image/test/prometheus.0.14.0:latest"),
+				mustParseRef(t, "quay.io/coreos/etcd-operator@sha256:db563baa8194fcfe39d1df744ed70024b0f1f9e9b55b5923c2f3a413c44dc6b8"): {
+					Type: imagesource.DestinationFile,
+					Ref: reference.DockerImageReference{
+						Registry:  "",
+						Namespace: "local",
+						Name:      "index/example/image/coreos/etcd-operator",
+						Tag:       "b56e2636",
+						ID:        "sha256:db563baa8194fcfe39d1df744ed70024b0f1f9e9b55b5923c2f3a413c44dc6b8",
+					},
+				},
+				mustParseRef(t, "quay.io/test/etcd.0.9.0:latest"): {
+					Type: imagesource.DestinationFile,
+					Ref: reference.DockerImageReference{
+						Registry:  "",
+						Namespace: "local",
+						Name:      "index/example/image/test/etcd.0.9.0",
+						Tag:       "latest",
+						ID:        "",
+					},
+				},
+				mustParseRef(t, "quay.io/coreos/prometheus-operator@sha256:0e92dd9b5789c4b13d53e1319d0a6375bcca4caaf0d698af61198061222a576d"): {
+					Type: imagesource.DestinationFile,
+					Ref: reference.DockerImageReference{
+						Registry:  "",
+						Namespace: "local",
+						Name:      "index/example/image/coreos/prometheus-operator",
+						Tag:       "7f39d12d",
+						ID:        "sha256:0e92dd9b5789c4b13d53e1319d0a6375bcca4caaf0d698af61198061222a576d",
+					},
+				},
+				mustParseRef(t, "quay.io/coreos/prometheus-operator@sha256:3daa69a8c6c2f1d35dcf1fe48a7cd8b230e55f5229a1ded438f687debade5bcf"): {
+					Type: imagesource.DestinationFile,
+					Ref: reference.DockerImageReference{
+						Registry:  "",
+						Namespace: "local",
+						Name:      "index/example/image/coreos/prometheus-operator",
+						Tag:       "1ebe036a",
+						ID:        "sha256:3daa69a8c6c2f1d35dcf1fe48a7cd8b230e55f5229a1ded438f687debade5bcf",
+					},
+				},
+				mustParseRef(t, "quay.io/test/prometheus.0.22.2:latest"): {
+					Type: imagesource.DestinationFile,
+					Ref: reference.DockerImageReference{
+						Registry:  "",
+						Namespace: "local",
+						Name:      "index/example/image/test/prometheus.0.22.2",
+						Tag:       "latest",
+						ID:        "",
+					},
+				},
+				mustParseRef(t, "quay.io/coreos/etcd-operator@sha256:c0301e4686c3ed4206e370b42de5a3bd2229b9fb4906cf85f3f30650424abec2"): {
+					Type: imagesource.DestinationFile,
+					Ref: reference.DockerImageReference{
+						Registry:  "",
+						Namespace: "local",
+						Name:      "index/example/image/coreos/etcd-operator",
+						Tag:       "2f1eb95",
+						ID:        "sha256:c0301e4686c3ed4206e370b42de5a3bd2229b9fb4906cf85f3f30650424abec2",
+					},
+				},
+				mustParseRef(t, "quay.io/coreos/prometheus-operator@sha256:5037b4e90dbb03ebdefaa547ddf6a1f748c8eeebeedf6b9d9f0913ad662b5731"): {
+					Type: imagesource.DestinationFile,
+					Ref: reference.DockerImageReference{
+						Registry:  "",
+						Namespace: "local",
+						Name:      "index/example/image/coreos/prometheus-operator",
+						Tag:       "76771fef",
+						ID:        "sha256:5037b4e90dbb03ebdefaa547ddf6a1f748c8eeebeedf6b9d9f0913ad662b5731",
+					},
+				},
+				mustParseRef(t, "quay.io/test/etcd.0.9.2:latest"): {
+					Type: imagesource.DestinationFile,
+					Ref: reference.DockerImageReference{
+						Registry:  "",
+						Namespace: "local",
+						Name:      "index/example/image/test/etcd.0.9.2",
+						Tag:       "latest",
+						ID:        "",
+					},
+				},
+				mustParseRef(t, "quay.io/test/prometheus.0.15.0:latest"): {
+					Type: imagesource.DestinationFile,
+					Ref: reference.DockerImageReference{
+						Registry:  "",
+						Namespace: "local",
+						Name:      "index/example/image/test/prometheus.0.15.0",
+						Tag:       "latest",
+						ID:        "",
+					},
+				},
+			},
+			wantFromFile: map[imagesource.TypedImageReference]imagesource.TypedImageReference{
+				mustParseRef(t, "file://local/index/example/image:tag"): {
+					Type: imagesource.DestinationRegistry,
+					Ref: reference.DockerImageReference{
+						Registry:  "localhost:5000",
+						Namespace: "local",
+						Name:      "index-example-image",
+						Tag:       "tag",
+						ID:        "",
+					},
+				},
+				mustParseRef(t, "file://local/index/example/image/test/prometheus.0.14.0:latest"): {
+					Type: imagesource.DestinationRegistry,
+					Ref: reference.DockerImageReference{
+						Registry:  "localhost:5000",
+						Namespace: "test",
+						Name:      "prometheus.0.14.0",
+						Tag:       "latest",
+						ID:        "",
+					},
+				},
+				{
+					Type: imagesource.DestinationFile,
+					Ref: reference.DockerImageReference{
+						Registry:  "",
+						Namespace: "local",
+						Name:      "index/example/image/coreos/etcd-operator",
+						Tag:       "",
+						ID:        "sha256:db563baa8194fcfe39d1df744ed70024b0f1f9e9b55b5923c2f3a413c44dc6b8",
+					},
+				}: {
+					Type: imagesource.DestinationRegistry,
+					Ref: reference.DockerImageReference{
+						Registry:  "localhost:5000",
+						Namespace: "coreos",
+						Name:      "etcd-operator",
+						Tag:       "b56e2636",
+						ID:        "sha256:db563baa8194fcfe39d1df744ed70024b0f1f9e9b55b5923c2f3a413c44dc6b8",
+					},
+				},
+				{
+					Type: imagesource.DestinationFile,
+					Ref: reference.DockerImageReference{
+						Registry:  "",
+						Namespace: "local",
+						Name:      "index/example/image/test/etcd.0.9.0",
+						Tag:       "latest",
+						ID:        "",
+					},
+				}: {
+					Type: imagesource.DestinationRegistry,
+					Ref: reference.DockerImageReference{
+						Registry:  "localhost:5000",
+						Namespace: "test",
+						Name:      "etcd.0.9.0",
+						Tag:       "latest",
+						ID:        "",
+					},
+				},
+				{
+					Type: imagesource.DestinationFile,
+					Ref: reference.DockerImageReference{
+						Registry:  "",
+						Namespace: "local",
+						Name:      "index/example/image/coreos/prometheus-operator",
+						Tag:       "",
+						ID:        "sha256:0e92dd9b5789c4b13d53e1319d0a6375bcca4caaf0d698af61198061222a576d",
+					},
+				}: {
+					Type: imagesource.DestinationRegistry,
+					Ref: reference.DockerImageReference{
+						Registry:  "localhost:5000",
+						Namespace: "coreos",
+						Name:      "prometheus-operator",
+						Tag:       "7f39d12d",
+						ID:        "sha256:0e92dd9b5789c4b13d53e1319d0a6375bcca4caaf0d698af61198061222a576d",
+					},
+				},
+				{
+					Type: imagesource.DestinationFile,
+					Ref: reference.DockerImageReference{
+						Registry:  "",
+						Namespace: "local",
+						Name:      "index/example/image/coreos/prometheus-operator",
+						Tag:       "",
+						ID:        "sha256:3daa69a8c6c2f1d35dcf1fe48a7cd8b230e55f5229a1ded438f687debade5bcf",
+					},
+				}: {
+					Type: imagesource.DestinationRegistry,
+					Ref: reference.DockerImageReference{
+						Registry:  "localhost:5000",
+						Namespace: "coreos",
+						Name:      "prometheus-operator",
+						Tag:       "1ebe036a",
+						ID:        "sha256:3daa69a8c6c2f1d35dcf1fe48a7cd8b230e55f5229a1ded438f687debade5bcf",
+					},
+				},
+				{
+					Type: imagesource.DestinationFile,
+					Ref: reference.DockerImageReference{
+						Registry:  "",
+						Namespace: "local",
+						Name:      "index/example/image/test/prometheus.0.22.2",
+						Tag:       "latest",
+						ID:        "",
+					},
+				}: {
+					Type: imagesource.DestinationRegistry,
+					Ref: reference.DockerImageReference{
+						Registry:  "localhost:5000",
+						Namespace: "test",
+						Name:      "prometheus.0.22.2",
+						Tag:       "latest",
+						ID:        "",
+					},
+				},
+				{
+					Type: imagesource.DestinationFile,
+					Ref: reference.DockerImageReference{
+						Registry:  "",
+						Namespace: "local",
+						Name:      "index/example/image/coreos/etcd-operator",
+						Tag:       "",
+						ID:        "sha256:c0301e4686c3ed4206e370b42de5a3bd2229b9fb4906cf85f3f30650424abec2",
+					},
+				}: {
+					Type: imagesource.DestinationRegistry,
+					Ref: reference.DockerImageReference{
+						Registry:  "localhost:5000",
+						Namespace: "coreos",
+						Name:      "etcd-operator",
+						Tag:       "2f1eb95",
+						ID:        "sha256:c0301e4686c3ed4206e370b42de5a3bd2229b9fb4906cf85f3f30650424abec2",
+					},
+				},
+				{
+					Type: imagesource.DestinationFile,
+					Ref: reference.DockerImageReference{
+						Registry:  "",
+						Namespace: "local",
+						Name:      "index/example/image/coreos/prometheus-operator",
+						Tag:       "",
+						ID:        "sha256:5037b4e90dbb03ebdefaa547ddf6a1f748c8eeebeedf6b9d9f0913ad662b5731",
+					},
+				}: {
+					Type: imagesource.DestinationRegistry,
+					Ref: reference.DockerImageReference{
+						Registry:  "localhost:5000",
+						Namespace: "coreos",
+						Name:      "prometheus-operator",
+						Tag:       "76771fef",
+						ID:        "sha256:5037b4e90dbb03ebdefaa547ddf6a1f748c8eeebeedf6b9d9f0913ad662b5731",
+					},
+				},
+				{
+					Type: imagesource.DestinationFile,
+					Ref: reference.DockerImageReference{
+						Registry:  "",
+						Namespace: "local",
+						Name:      "index/example/image/test/etcd.0.9.2",
+						Tag:       "latest",
+						ID:        "",
+					},
+				}: {
+					Type: imagesource.DestinationRegistry,
+					Ref: reference.DockerImageReference{
+						Registry:  "localhost:5000",
+						Namespace: "test",
+						Name:      "etcd.0.9.2",
+						Tag:       "latest",
+						ID:        "",
+					},
+				},
+				{
+					Type: imagesource.DestinationFile,
+					Ref: reference.DockerImageReference{
+						Registry:  "",
+						Namespace: "local",
+						Name:      "index/example/image/test/prometheus.0.15.0",
+						Tag:       "latest",
+						ID:        "",
+					},
+				}: {
+					Type: imagesource.DestinationRegistry,
+					Ref: reference.DockerImageReference{
+						Registry:  "localhost:5000",
+						Namespace: "test",
+						Name:      "prometheus.0.15.0",
+						Tag:       "latest",
+						ID:        "",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// first mirror to file
+			b := &IndexImageMirrorer{
+				ImageMirrorer:     tt.fields.ImageMirrorer,
+				DatabaseExtractor: tt.fields.DatabaseExtractor,
+				Source:            tt.fields.Source,
+				Dest:              tt.fileDest,
+				MaxPathComponents: 0,
+			}
+			gotToFile, err := b.Mirror()
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			for k, v := range tt.wantToFile {
+				w, ok := gotToFile[k]
+				if !ok {
+					t.Errorf("couldn't find wanted key %#v", k)
+					continue
+				}
+				if w != v {
+					t.Errorf("incorrect mapping for %s - have %#v, want %#v", k, w, v)
+				}
+			}
+			for k, v := range gotToFile {
+				w, ok := tt.wantToFile[k]
+				if !ok {
+					t.Errorf("got unexpected key %#v", k)
+					continue
+				}
+				if w != v {
+					t.Errorf("incorrect mapping for %s - have %s, want %s", k, v, w)
+				}
+			}
+
+			// then mirror from file
+			b = &IndexImageMirrorer{
+				ImageMirrorer:     tt.fields.ImageMirrorer,
+				DatabaseExtractor: tt.fields.DatabaseExtractor,
+				Source:            tt.fileSource,
+				Dest:              tt.fields.Dest,
+				MaxPathComponents: 2,
+			}
+			gotFromFile, err := b.Mirror()
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			for k, v := range tt.wantFromFile {
+				w, ok := gotFromFile[k]
+				if !ok {
+					t.Errorf("couldn't find wanted key %#v", k)
+					continue
+				}
+				if w != v {
+					t.Errorf("incorrect mapping for %s - have %s, want %s", k, w, v)
+				}
+			}
+			for k, v := range gotFromFile {
+				w, ok := tt.wantFromFile[k]
+				if !ok {
+					t.Errorf("got unexpected key %#v", k)
+					continue
+				}
+				if w != v {
+					t.Errorf("incorrect mapping for %s - have %s, want %s", k, v, w)
+				}
+			}
+		})
+	}
+}
+
 func TestMappingForImages(t *testing.T) {
 	type args struct {
 		images        map[string]struct{}
@@ -628,7 +1017,7 @@ func TestMappingForImages(t *testing.T) {
 				maxComponents: 2,
 			},
 			wantMapping: map[imagesource.TypedImageReference]imagesource.TypedImageReference{
-				mustParseRef(t, "file://my-local-index/index/my/image"): {
+				mustParseRef(t, "file://my-local-index/index/my/image:latest"): {
 					Type: imagesource.DestinationRegistry,
 					Ref: reference.DockerImageReference{
 						Registry:  "quay.io",


### PR DESCRIPTION
when mirroring an index image: `quay.io/my/index:a`
that contains a reference to another image: `quay.io/other/bundle:1`
to a local file: `file:///local/index`

the referenced images are now mounted under the location for the index
itself, resulting in (for example):

`file:///local/index/my/index:a`
`file:///local/index/my/index/other/bundle:1`

this fixes a bug where the next step of an airgap mirror can't find the
images to be mirrored.

as a side effect, this keeps all catalog content stored under the same
fs location. Local file storage can be shared with other mirrored
images while keeping it simple to copy the full contents of an index
to another location.