### PR TITLE
Fix usage error print

### DIFF
--- a/pkg/cli/process/process.go
+++ b/pkg/cli/process/process.go
@@ -206,7 +206,7 @@ func (o *ProcessOptions) Complete(f kcmdutil.Factory, cmd *cobra.Command, args [
 	}
 
 	o.usageErrorFn = func(format string, args ...interface{}) error {
-		return kcmdutil.UsageErrorf(cmd, format, args)
+		return kcmdutil.UsageErrorf(cmd, format, args...)
 	}
 
 	o.paramValuesProvided = cmd.Flag("param").Changed


### PR DESCRIPTION
The code paths that use the `usageErrorFn` func were appending an [`%!(EXTRA ..)`](https://golang.org/pkg/fmt/) message in the output due to variadic args that were not passed properly.

Example output:
```
❯ oc process
error: Must pass a filename or name of stored template%!(EXTRA []interface {}=[])
See 'oc process -h' for help and examples
```

And output with the fix:
```
❯ oc process
error: The following parameters were provided more than once:
See 'oc process -h' for help and examples
```

PTAL