### PR TITLE
CCCMO cluster operator addition to must-gather

### DIFF
--- a/pkg/cli/admin/mustgather/summary.go
+++ b/pkg/cli/admin/mustgather/summary.go
@@ -68,6 +68,7 @@ var longExistingOperators = []string{
 	"network",
 	"openshift-apiserver",
 	"openshift-controller-manager",
+	"cloud-controller-manager",
 	"operator-lifecycle-manager",
 	"service-ca",
 	"storage",


### PR DESCRIPTION
`cloud-controller-manager` cluster operator should report healthy conditions on cluster startup, when collected in must-gather output.