### PR TITLE
Updating generate docs output for product docs

### DIFF
--- a/hack/clibyexample/template
+++ b/hack/clibyexample/template
@@ -1,18 +1,21 @@
-:toc: macro
-:toc-title:
+// NOTE: The contents of this file are auto-generated
 
-toc::[]
+[id="openshift-cli_{context}"]
+= OpenShift CLI (oc) commands
 
 {{range .items}}
+
+{{if .isAdminCommand}}ifdef::openshift-enterprise,openshift-origin[] {{end}}
+
 == {{.fullName}}
 {{.description}}
 
-====
-
-[options="nowrap"]
+.Example usage
+[source,terminal,options="nowrap"]
 ----
 {{.examples}}
 ----
-====
+
+{{if .isAdminCommand}}endif::openshift-enterprise,openshift-origin[] {{end}}
 
 {{end}}

--- a/tools/gendocs/gen_openshift_docs.go
+++ b/tools/gendocs/gen_openshift_docs.go
@@ -44,7 +44,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	outFile := outDir + "oc_by_example_content.adoc"
+	outFile := outDir + "oc-by-example-content.adoc"
 	out := os.Stdout
 	cmd := cli.NewOcCommand(&bytes.Buffer{}, out, ioutil.Discard)
 

--- a/tools/gendocs/gendocs/gendocs.go
+++ b/tools/gendocs/gendocs/gendocs.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -76,6 +77,11 @@ func extractExamples(cmd *cobra.Command) Examples {
 	if cmd.HasExample() {
 		o := &unstructured.Unstructured{
 			Object: make(map[string]interface{}),
+		}
+		if strings.HasPrefix(cmd.CommandPath(), "oc adm") {
+			o.Object["isAdminCommand"] = true
+		} else {
+			o.Object["isAdminCommand"] = false
 		}
 		o.Object["name"] = cmd.Name()
 		o.Object["fullName"] = cmd.CommandPath()


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1790
https://issues.redhat.com/browse/OSDOCS-2017

Example output: https://gist.github.com/bergerhoffer/82d4afaa49505fef53d9d0d388e7b6d9 (there will be a table of contents once it is imported into the product docs)

Preview of file incorporated into the product docs (internal): http://file.rdu.redhat.com/~ahoffer/2021/OSDOCS-1790/OSDOCS-1790/cli_reference/openshift_cli/cli-command-reference.html