### PR TITLE
Updating oc-specific descriptions

### DIFF
--- a/pkg/cli/admin/buildchain/buildchain.go
+++ b/pkg/cli/admin/buildchain/buildchain.go
@@ -31,7 +31,7 @@ const BuildChainRecommendedCommandName = "build-chain"
 
 var (
 	buildChainLong = templates.LongDesc(`
-		Output the inputs and dependencies of your builds
+		Output the inputs and dependencies of your builds.
 
 		Supported formats for the generated graph are dot and a human-readable output.
 		Tag and namespace are optional and if they are not specified, 'latest' and the
@@ -42,10 +42,10 @@ var (
 		# Build the dependency tree for the 'latest' tag in <image-stream>
 		oc adm build-chain <image-stream>
 
-		# Build the dependency tree for 'v2' tag in dot format and visualize it via the dot utility
+		# Build the dependency tree for the 'v2' tag in dot format and visualize it via the dot utility
 		oc adm build-chain <image-stream>:v2 -o dot | dot -T svg -o deps.svg
 
-		# Build the dependency tree across all namespaces for the specified image stream tag found in 'test' namespace
+		# Build the dependency tree across all namespaces for the specified image stream tag found in the 'test' namespace
 		oc adm build-chain <image-stream> -n test --all
 	`)
 )

--- a/pkg/cli/admin/catalog/build.go
+++ b/pkg/cli/admin/catalog/build.go
@@ -30,7 +30,7 @@ var (
 		Extracts the contents of a collection of operator manifests to disk, and builds them into
 		an operator registry catalog image.
 
-		The base image used for the catalog should match the target version of ocp. This can be set manually with
+		The base image used for the catalog should match the target version of OCP. This can be set manually with
 		the '--from' flag. If '--from' references a release image, the base image will be selected from the release. If
 		omitted, the base image will be inferred from the current cluster.
 
@@ -38,19 +38,19 @@ var (
 		overridden with '--filter-by-os'.
 	`)
 	buildExample = templates.Examples(`
-		# Build an operator catalog from an appregistry repo and store in a file.
+		# Build an operator catalog from an appregistry repo and store in a file
 		oc adm catalog build --appregistry-org=redhat-operators --to=file://offline/redhat-operators:4.3
 
-		# Build an operator catalog from an appregistry repo and mirror to a registry.
+		# Build an operator catalog from an appregistry repo and mirror to a registry
 		oc adm catalog build --appregistry-org=redhat-operators --to=quay.io/my/redhat-operators:4.3
 
-		# Build an operator catalog by inferring a base image from a target ocp release
+		# Build an operator catalog by inferring a base image from a target OCP release
 		oc adm catalog build --appregistry-org=redhat-operators --to=quay.io/my/redhat-operators:4.3 --from=quay.io/openshift-release-dev/ocp-release:4.3.0
 
 		# Build an operator catalog by explicitly providing a base image
 		oc adm catalog build --appregistry-org=redhat-operators --to=quay.io/my/redhat-operators:4.3 --from=quay.io/openshift/origin-operator-registry:4.4
 
-		# Build an operator catalog for a specific target architecture. Assumes you are logged in via 'oc login'.
+		# Build an operator catalog for a specific target architecture. Assumes you are logged in via 'oc login'
 		oc adm catalog build --appregistry-org=redhat-operators --to=file://offline/redhat-operators:4.3 --filter-by-os='linux/s390x'
 	`)
 )
@@ -170,7 +170,7 @@ func NewBuildImage(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cob
 	o := NewBuildImageOptions(streams)
 	cmd := &cobra.Command{
 		Use:     "build",
-		Short:   "build an operator-registry catalog",
+		Short:   "Build an operator-registry catalog",
 		Long:    buildLong,
 		Example: buildExample,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cli/admin/catalog/mirror.go
+++ b/pkg/cli/admin/catalog/mirror.go
@@ -44,7 +44,7 @@ var (
 
 		By default, the database is extracted to a temporary directory, but can be saved locally via flags.
 
-		An ImageContentSourcePolicy is written to a file that can be added to a cluster with access to the target
+		An image content source policy is written to a file that can be added to a cluster with access to the target
 		registry. This will configure the cluster to pull from the mirrors instead of the locations referenced in
 		the operator manifests.
 
@@ -112,7 +112,7 @@ func NewMirrorCatalog(f kcmdutil.Factory, streams genericclioptions.IOStreams) *
 
 	cmd := &cobra.Command{
 		Use:     "mirror SRC DEST",
-		Short:   "mirror an operator-registry catalog",
+		Short:   "Mirror an operator-registry catalog",
 		Long:    mirrorLong,
 		Example: mirrorExample,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cli/admin/groups/sync/prune.go
+++ b/pkg/cli/admin/groups/sync/prune.go
@@ -21,10 +21,10 @@ import (
 
 var (
 	pruneLong = templates.LongDesc(`
-		Prune OpenShift Groups referencing missing records on from an external provider.
+		Prune OpenShift groups referencing missing records from an external provider.
 
-		In order to prune OpenShift Group records using those from an external provider, determine which Groups you wish
-		to prune. For instance, all or some groups may be selected from the current Groups stored in OpenShift that have
+		In order to prune OpenShift group records using those from an external provider, determine which groups you want
+		to prune. For instance, all or some groups may be selected from the current groups stored in OpenShift that have
 		been synced previously. Any combination of a literal whitelist, a whitelist file and a blacklist file is supported.
 		The path to a sync configuration file that was used for syncing the groups in question is required in order to
 		describe how data is requested from the external record store. Default behavior is to indicate all OpenShift groups
@@ -80,7 +80,7 @@ func NewCmdPruneGroups(name, fullName string, f kcmdutil.Factory, streams generi
 	o := NewPruneOptions(streams)
 	cmd := &cobra.Command{
 		Use:     fmt.Sprintf("%s [WHITELIST] [--whitelist=WHITELIST-FILE] [--blacklist=BLACKLIST-FILE] --sync-config=CONFIG-SOURCE", name),
-		Short:   "Remove old OpenShift groups referencing missing records on an external provider",
+		Short:   "Remove old OpenShift groups referencing missing records from an external provider",
 		Long:    pruneLong,
 		Example: fmt.Sprintf(pruneExamples, fullName),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cli/admin/groups/sync/sync.go
+++ b/pkg/cli/admin/groups/sync/sync.go
@@ -35,10 +35,10 @@ const SyncRecommendedName = "sync"
 
 var (
 	syncLong = templates.LongDesc(`
-		Sync OpenShift Groups with records from an external provider.
+		Sync OpenShift groups with records from an external provider.
 
-		In order to sync OpenShift Group records with those from an external provider, determine which Groups you wish
-		to sync and where their records live. For instance, all or some groups may be selected from the current Groups
+		In order to sync OpenShift group records with those from an external provider, determine which groups you want
+		to sync and where their records live. For instance, all or some groups may be selected from the current groups
 		stored in OpenShift that have been synced previously, or similarly all or some groups may be selected from those
 		stored on an LDAP server. The path to a sync configuration file is required in order to describe how data is
 		requested from the external record store and migrated to OpenShift records. Default behavior is to do a dry-run
@@ -47,19 +47,19 @@ var (
 	`)
 
 	syncExamples = templates.Examples(`
-		# Sync all groups from an LDAP server
+		# Sync all groups with an LDAP server
 		oc adm groups sync --sync-config=/path/to/ldap-sync-config.yaml --confirm
 
-		# Sync all groups except the ones from the blacklist file from an LDAP server
+		# Sync all groups except the ones from the blacklist file with an LDAP server
 		oc adm groups sync --blacklist=/path/to/blacklist.txt --sync-config=/path/to/ldap-sync-config.yaml --confirm
 
 		# Sync specific groups specified in a whitelist file with an LDAP server
 		oc adm groups sync --whitelist=/path/to/whitelist.txt --sync-config=/path/to/sync-config.yaml --confirm
 
-		# Sync all OpenShift Groups that have been synced previously with an LDAP server
+		# Sync all OpenShift groups that have been synced previously with an LDAP server
 		oc adm groups sync --type=openshift --sync-config=/path/to/ldap-sync-config.yaml --confirm
 
-		# Sync specific OpenShift Groups if they have been synced previously with an LDAP server
+		# Sync specific OpenShift groups if they have been synced previously with an LDAP server
 		oc adm groups sync groups/group1 groups/group2 groups/group3 --sync-config=/path/to/sync-config.yaml --confirm
 	`)
 )
@@ -119,7 +119,7 @@ func NewCmdSync(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.
 	o := NewSyncOptions(streams)
 	cmd := &cobra.Command{
 		Use:     "sync [--type=TYPE] [WHITELIST] [--whitelist=WHITELIST-FILE] --sync-config=CONFIG-FILE [--confirm]",
-		Short:   "Sync OpenShift groups with records from an external provider.",
+		Short:   "Sync OpenShift groups with records from an external provider",
 		Long:    syncLong,
 		Example: syncExamples,
 		Run: func(c *cobra.Command, args []string) {

--- a/pkg/cli/admin/inspect/inspect.go
+++ b/pkg/cli/admin/inspect/inspect.go
@@ -46,13 +46,13 @@ var (
 		# Collect debugging data for the "openshift-apiserver" clusteroperator
 		oc adm inspect clusteroperator/openshift-apiserver
 
-		# Collect debugging data for the "openshift-apiserver" and "kube-apiserver" clusteroperator
+		# Collect debugging data for the "openshift-apiserver" and "kube-apiserver" clusteroperators
 		oc adm inspect clusteroperator/openshift-apiserver clusteroperator/kube-apiserver
 
 		# Collect debugging data for all clusteroperators
 		oc adm inspect clusteroperator
 
-		# Collect debugging data for all clusteroperator and clusterversions
+		# Collect debugging data for all clusteroperators and clusterversions
 		oc adm inspect clusteroperators,clusterversions
 	`)
 )

--- a/pkg/cli/admin/migrate/templateinstances/templateinstances.go
+++ b/pkg/cli/admin/migrate/templateinstances/templateinstances.go
@@ -41,9 +41,9 @@ var (
 	}
 
 	internalMigrateTemplateInstancesLong = templates.LongDesc(fmt.Sprintf(`
-		Migrate Template Instances to refer to new API groups
+		Migrate template instances to refer to new API groups.
 
-		This command locates and updates every Template Instance which refers to a particular
+		This command locates and updates every template instance which refers to a particular
 		group-version-kind to refer to some other, equivalent group-version-kind.
 
 		The following transformations will occur:
@@ -90,7 +90,7 @@ func NewCmdMigrateTemplateInstances(f kcmdutil.Factory, streams genericclioption
 	o := NewMigrateTemplateInstancesOptions(streams)
 	cmd := &cobra.Command{
 		Use:     "template-instances",
-		Short:   "Update TemplateInstances to point to the latest group-version-kinds",
+		Short:   "Update template instances to point to the latest group-version-kinds",
 		Long:    internalMigrateTemplateInstancesLong,
 		Example: internalMigrateTemplateInstancesExample,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cli/admin/mustgather/mustgather.go
+++ b/pkg/cli/admin/mustgather/mustgather.go
@@ -43,7 +43,7 @@ import (
 
 var (
 	mustGatherLong = templates.LongDesc(`
-		Launch a pod to gather debugging information
+		Launch a pod to gather debugging information.
 
 		This command will launch a pod in a temporary namespace on your cluster that gathers
 		debugging information and then downloads the gathered information.
@@ -52,22 +52,22 @@ var (
 	`)
 
 	mustGatherExample = templates.Examples(`
-		# gather information using the default plug-in image and command, writing into ./must-gather.local.<rand>
+		# Gather information using the default plug-in image and command, writing into ./must-gather.local.<rand>
 		  oc adm must-gather
 
-		# gather information with a specific local folder to copy to
+		# Gather information with a specific local folder to copy to
 		  oc adm must-gather --dest-dir=/local/directory
 
-		# gather audit information
+		# Gather audit information
 		  oc adm must-gather -- /usr/bin/gather_audit_logs
 
-		# gather information using multiple plug-in images
+		# Gather information using multiple plug-in images
 		  oc adm must-gather --image=quay.io/kubevirt/must-gather --image=quay.io/openshift/origin-must-gather
 
-		# gather information using a specific image stream plug-in
+		# Gather information using a specific image stream plug-in
 		  oc adm must-gather --image-stream=openshift/must-gather:latest
 
-		# gather information using a specific image, command, and pod-dir
+		# Gather information using a specific image, command, and pod-dir
 		  oc adm must-gather --image=my/image:tag --source-dir=/pod/directory -- myspecial-command.sh
 	`)
 )

--- a/pkg/cli/admin/network/isolate_projects.go
+++ b/pkg/cli/admin/network/isolate_projects.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	isolateProjectsNetworkLong = templates.LongDesc(`
-		Isolate project network
+		Isolate project network.
 
 		Allows projects to isolate their network from other projects when using the %[1]s network plugin.
 	`)

--- a/pkg/cli/admin/network/join_projects.go
+++ b/pkg/cli/admin/network/join_projects.go
@@ -19,7 +19,7 @@ const JoinProjectsNetworkCommandName = "join-projects"
 
 var (
 	joinProjectsNetworkLong = templates.LongDesc(`
-		Join project network
+		Join project network.
 
 		Allows projects to join existing project network when using the %[1]s network plugin.
 	`)

--- a/pkg/cli/admin/network/make_projects_global.go
+++ b/pkg/cli/admin/network/make_projects_global.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	makeGlobalProjectsNetworkLong = templates.LongDesc(`
-		Make project network global
+		Make project network global.
 
 		Allows projects to access all pods in the cluster and vice versa when using the %[1]s network plugin.
 	`)

--- a/pkg/cli/admin/node/logs.go
+++ b/pkg/cli/admin/node/logs.go
@@ -29,7 +29,7 @@ import (
 
 var (
 	logsLong = templates.LongDesc(`
-		Display and filter node logs
+		Display and filter node logs.
 
 		This command retrieves logs for the node. The default mode is to query the
 		systemd journal on supported operating systems, which allows searching, time

--- a/pkg/cli/admin/policy/modify_roles.go
+++ b/pkg/cli/admin/policy/modify_roles.go
@@ -36,11 +36,11 @@ var (
 	`)
 
 	addRoleToUserLongDesc = templates.LongDesc(`
-		Add a role to users or service accounts for the current project
+		Add a role to users or service accounts for the current project.
 
-		This command allows you to grant a user access to specific resources and actions within the current project, by assigning them to a role. It creates or modifies a RoleBinding referencing the specified role adding the user(s) or serviceaccount(s) to the list of subjects. The command does not require that the matching role or user/serviceaccount resources exist and will create the binding successfully even when the role or user/serviceaccount do not exist or when the user does not have access to view them.
+		This command allows you to grant a user access to specific resources and actions within the current project, by assigning them to a role. It creates or modifies a role binding referencing the specified role adding the user(s) or service account(s) to the list of subjects. The command does not require that the matching role or user/service account resources exist and will create the binding successfully even when the role or user/service account do not exist or when the user does not have access to view them.
 
-		If the --rolebinding-name argument is supplied, it will look for an existing rolebinding with that name. The role on the matching rolebinding MUST match the role name supplied to the command. If no rolebinding name is given, a default name will be used. When --role-namespace argument is specified as a non-empty value, it MUST match the current namespace. When role-namespace is specified, the rolebinding will reference a namespaced Role. Otherwise, the rolebinding will reference a ClusterRole resource.
+		If the --rolebinding-name argument is supplied, it will look for an existing role binding with that name. The role on the matching role binding MUST match the role name supplied to the command. If no role binding name is given, a default name will be used. When --role-namespace argument is specified as a non-empty value, it MUST match the current namespace. When role-namespace is specified, the role binding will reference a namespaced role. Otherwise, the role binding will reference a cluster role resource.
 
 		To learn more, see information about RBAC and policy, or use the 'get' and 'describe' commands on the following resources: 'clusterroles', 'clusterrolebindings', 'roles', 'rolebindings', 'users', 'groups', and 'serviceaccounts'.
 	`)
@@ -48,9 +48,9 @@ var (
 	addRoleToGroupLongDesc = templates.LongDesc(`
 		Add a role to groups for the current project
 
-		This command allows you to grant a group access to specific resources and actions within the current project, by assigning them to a role. It creates or modifies a RoleBinding referencing the specified role adding the group(s) to the list of subjects. The command does not require that the matching role or group resources exist and will create the binding successfully even when the role or group do not exist or when the user does not have access to view them.
+		This command allows you to grant a group access to specific resources and actions within the current project, by assigning them to a role. It creates or modifies a role binding referencing the specified role adding the group(s) to the list of subjects. The command does not require that the matching role or group resources exist and will create the binding successfully even when the role or group do not exist or when the user does not have access to view them.
 
-		If the --rolebinding-name argument is supplied, it will look for an existing rolebinding with that name. The role on the matching rolebinding MUST match the role name supplied to the command. If no rolebinding name is given, a default name will be used. When --role-namespace argument is specified as a non-empty value, it MUST match the current namespace. When role-namespace is specified, the rolebinding will reference a namespaced Role. Otherwise, the rolebinding will reference a ClusterRole resource.
+		If the --rolebinding-name argument is supplied, it will look for an existing role binding with that name. The role on the matching role binding MUST match the role name supplied to the command. If no role binding name is given, a default name will be used. When --role-namespace argument is specified as a non-empty value, it MUST match the current namespace. When role-namespace is specified, the role binding will reference a namespaced role. Otherwise, the role binding will reference a cluster role resource.
 
 		To learn more, see information about RBAC and policy, or use the 'get' and 'describe' commands on the following resources: 'clusterroles', 'clusterrolebindings', 'roles', 'rolebindings', 'users', 'groups', and 'serviceaccounts'.
 	`)
@@ -58,9 +58,9 @@ var (
 	addClusterRoleToUserLongDesc = templates.LongDesc(`
 		Add a role to users or service accounts across all projects
 
-		This command allows you to grant a user access to specific resources and actions within the cluster, by assigning them to a role. It creates or modifies a ClusterRoleBinding referencing the specified ClusterRole, adding the user(s) or serviceaccount(s) to the list of subjects. This command does not require that the matching cluster role or user/serviceaccount resources exist and will create the binding successfully even when the role or user/serviceaccount do not exist or when the user does not have access to view them.
+		This command allows you to grant a user access to specific resources and actions within the cluster, by assigning them to a role. It creates or modifies a cluster role binding referencing the specified cluster role, adding the user(s) or service account(s) to the list of subjects. This command does not require that the matching cluster role or user/service account resources exist and will create the binding successfully even when the role or user/service account do not exist or when the user does not have access to view them.
 
-		If the --rolebinding-name argument is supplied, it will look for an existing clusterrolebinding with that name. The role on the matching clusterrolebinding MUST match the role name supplied to the command. If no rolebinding name is given, a default name will be used.
+		If the --rolebinding-name argument is supplied, it will look for an existing cluster role binding with that name. The role on the matching cluster role binding MUST match the role name supplied to the command. If no role binding name is given, a default name will be used.
 
 		To learn more, see information about RBAC and policy, or use the 'get' and 'describe' commands on the following resources: 'clusterroles', 'clusterrolebindings', 'roles', 'rolebindings', 'users', 'groups', and 'serviceaccounts'.
 	`)
@@ -68,9 +68,9 @@ var (
 	addClusterRoleToGroupLongDesc = templates.LongDesc(`
 		Add a role to groups for the current project
 
-		This command creates or modifies a ClusterRoleBinding with the named cluster role by adding the named group(s) to the list of subjects. The command does not require the matching role or group resources exist and will create the binding successfully even when the role or group do not exist or when the user does not have access to view them.
+		This command creates or modifies a cluster role binding with the named cluster role by adding the named group(s) to the list of subjects. The command does not require the matching role or group resources exist and will create the binding successfully even when the role or group do not exist or when the user does not have access to view them.
 
-		If the --rolebinding-name argument is supplied, it will look for an existing clusterrolebinding with that name. The role on the matching clusterrolebinding MUST match the role name supplied to the command. If no rolebinding name is given, a default name will be used.
+		If the --rolebinding-name argument is supplied, it will look for an existing cluster role binding with that name. The role on the matching cluster role binding MUST match the role name supplied to the command. If no rolebinding name is given, a default name will be used.
 	`)
 )
 
@@ -137,7 +137,7 @@ func NewCmdAddRoleToUser(f kcmdutil.Factory, streams genericclioptions.IOStreams
 	o.SANames = []string{}
 	cmd := &cobra.Command{
 		Use:     "add-role-to-user ROLE (USER | -z SERVICEACCOUNT) [USER ...]",
-		Short:   "Add a role to users or serviceaccounts for the current project",
+		Short:   "Add a role to users or service accounts for the current project",
 		Long:    addRoleToUserLongDesc,
 		Example: addRoleToUserExample,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cli/admin/policy/modify_scc.go
+++ b/pkg/cli/admin/policy/modify_scc.go
@@ -29,7 +29,7 @@ var (
 		# Add the 'restricted' security context constraint to user1 and user2
 		oc adm policy add-scc-to-user restricted user1 user2
 
-		# Add the 'privileged' security context constraint to the service account serviceaccount1 in the current namespace
+		# Add the 'privileged' security context constraint to serviceaccount1 in the current namespace
 		oc adm policy add-scc-to-user privileged -z serviceaccount1
 	`)
 
@@ -70,8 +70,8 @@ func NewCmdAddSCCToGroup(f kcmdutil.Factory, streams genericclioptions.IOStreams
 	o := NewSCCModificationOptions(streams)
 	cmd := &cobra.Command{
 		Use:     "add-scc-to-group SCC GROUP [GROUP ...]",
-		Short:   "Add security context constraint to groups",
-		Long:    `Add security context constraint to groups`,
+		Short:   "Add a security context constraint to groups",
+		Long:    `Add a security context constraint to groups.`,
 		Example: addSCCToGroupExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			kcmdutil.CheckErr(o.CompleteGroups(f, cmd, args))
@@ -89,8 +89,8 @@ func NewCmdAddSCCToUser(f kcmdutil.Factory, streams genericclioptions.IOStreams)
 	o.SANames = []string{}
 	cmd := &cobra.Command{
 		Use:     "add-scc-to-user SCC (USER | -z SERVICEACCOUNT) [USER ...]",
-		Short:   "Add security context constraint to users or a service account",
-		Long:    `Add security context constraint to users or a service account`,
+		Short:   "Add a security context constraint to users or a service account",
+		Long:    `Add a security context constraint to users or a service account.`,
 		Example: addSCCToUserExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			kcmdutil.CheckErr(o.CompleteUsers(f, cmd, args))
@@ -109,8 +109,8 @@ func NewCmdRemoveSCCFromGroup(f kcmdutil.Factory, streams genericclioptions.IOSt
 	o := NewSCCModificationOptions(streams)
 	cmd := &cobra.Command{
 		Use:   "remove-scc-from-group SCC GROUP [GROUP ...]",
-		Short: "Remove group from scc",
-		Long:  `Remove group from scc`,
+		Short: "Remove a group from a security context constraint",
+		Long:  `Remove a group from a security context constraint.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			kcmdutil.CheckErr(o.CompleteGroups(f, cmd, args))
 			kcmdutil.CheckErr(o.RemoveSCC())
@@ -127,8 +127,8 @@ func NewCmdRemoveSCCFromUser(f kcmdutil.Factory, streams genericclioptions.IOStr
 	o.SANames = []string{}
 	cmd := &cobra.Command{
 		Use:   "remove-scc-from-user SCC USER [USER ...]",
-		Short: "Remove user from scc",
-		Long:  `Remove user from scc`,
+		Short: "Remove a user from a security context constraint",
+		Long:  `Remove a user from a security context constraint.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			kcmdutil.CheckErr(o.CompleteUsers(f, cmd, args))
 			kcmdutil.CheckErr(o.RemoveSCC())

--- a/pkg/cli/admin/policy/review.go
+++ b/pkg/cli/admin/policy/review.go
@@ -31,23 +31,23 @@ import (
 )
 
 var (
-	reviewLong = templates.LongDesc(`Checks which Service Account can create a Pod.
-		The Pod is inferred from the PodTemplateSpec in the provided resource.
-		If no Service Account is provided the one specified in podTemplateSpec.spec.serviceAccountName is used,
+	reviewLong = templates.LongDesc(`Check which service account can create a pod.
+		The pod is inferred from the pod template spec in the provided resource.
+		If no service account is provided the one specified in podTemplateSpec.spec.serviceAccountName is used,
 		unless it is empty, in which case "default" is used.
-		If Service Accounts are provided the podTemplateSpec.spec.serviceAccountName is ignored.
+		If service accounts are provided, the podTemplateSpec.spec.serviceAccountName is ignored.
 	`)
-	reviewExamples = templates.Examples(`# Check whether Service Accounts sa1 and sa2 can admit a Pod with TemplatePodSpec specified in my_resource.yaml
+	reviewExamples = templates.Examples(`# Check whether service accounts sa1 and sa2 can admit a pod with a template pod spec specified in my_resource.yaml
 		# Service Account specified in myresource.yaml file is ignored
 		oc adm policy scc-review -z sa1,sa2 -f my_resource.yaml
 
-		# Check whether Service Accounts system:serviceaccount:bob:default can admit a Pod with TemplatePodSpec specified in my_resource.yaml
+		# Check whether service accounts system:serviceaccount:bob:default can admit a pod with a template pod spec specified in my_resource.yaml
 		oc adm policy scc-review -z system:serviceaccount:bob:default -f my_resource.yaml
 
-		# Check whether Service Account specified in my_resource_with_sa.yaml can admit the Pod
+		# Check whether the service account specified in my_resource_with_sa.yaml can admit the pod
 		oc adm policy scc-review -f my_resource_with_sa.yaml
 
-		# Check whether default Service Account can admit the Pod, default is taken since no Service Account is defined in myresource_with_no_sa.yaml
+		# Check whether the default service account can admit the pod; default is taken since no service account is defined in myresource_with_no_sa.yaml
 		oc adm policy scc-review -f myresource_with_no_sa.yaml
 	`)
 )
@@ -89,7 +89,7 @@ func NewCmdSccReview(f kcmdutil.Factory, streams genericclioptions.IOStreams) *c
 	o := NewSCCReviewOptions(streams)
 	cmd := &cobra.Command{
 		Use:     "scc-review",
-		Short:   "Checks which ServiceAccount can create a Pod",
+		Short:   "Check which service account can create a pod",
 		Long:    reviewLong,
 		Example: reviewExamples,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cli/admin/policy/subject_review.go
+++ b/pkg/cli/admin/policy/subject_review.go
@@ -27,10 +27,10 @@ import (
 )
 
 var (
-	subjectReviewLong = templates.LongDesc(`Check whether a User, Service Account or a Group can create a Pod.
-		It returns a list of Security Context Constraints that will admit the resource.
-		If User is specified but not Groups, it is interpreted as "What if User is not a member of any groups".
-		If User and Groups are empty, then the check is performed using the current user
+	subjectReviewLong = templates.LongDesc(`Check whether a user, service account or group can create a pod.
+		It returns a list of security context constraints that will admit the resource.
+		If user is specified but not groups, it is interpreted as "what if the user is not a member of any groups".
+		If user and groups are empty, then the check is performed using the current user.
 	`)
 	subjectReviewExamples = templates.Examples(`# Check whether user bob can create a pod specified in myresource.yaml
 		oc adm policy scc-subject-review -u bob -f myresource.yaml
@@ -38,7 +38,7 @@ var (
 		# Check whether user bob who belongs to projectAdmin group can create a pod specified in myresource.yaml
 		oc adm policy scc-subject-review -u bob -g projectAdmin -f myresource.yaml
 
-		# Check whether ServiceAccount specified in podTemplateSpec in myresourcewithsa.yaml can create the Pod
+		# Check whether a service account specified in the pod template spec in myresourcewithsa.yaml can create the pod
 		oc adm policy scc-subject-review -f myresourcewithsa.yaml
 	`)
 )
@@ -76,7 +76,7 @@ func NewCmdSccSubjectReview(f kcmdutil.Factory, streams genericclioptions.IOStre
 	cmd := &cobra.Command{
 		Use:     "scc-subject-review",
 		Long:    subjectReviewLong,
-		Short:   "Check whether a user or a ServiceAccount can create a Pod.",
+		Short:   "Check whether a user or a service account can create a pod",
 		Example: subjectReviewExamples,
 		Run: func(cmd *cobra.Command, args []string) {
 			kcmdutil.CheckErr(o.Complete(f, args, cmd))

--- a/pkg/cli/admin/prune/auth/prune_command.go
+++ b/pkg/cli/admin/prune/auth/prune_command.go
@@ -44,8 +44,8 @@ func NewCmdPruneAuth(f kcmdutil.Factory, streams genericclioptions.IOStreams) *c
 	o := NewPruneAuthOptions(streams)
 	cmd := &cobra.Command{
 		Use:   "auth",
-		Short: "Removes references to the specified roles, clusterroles, users, and groups.",
-		Long:  "Removes references to the specified roles, clusterroles, users, and groups.  Other types are ignored",
+		Short: "Removes references to the specified roles, clusterroles, users, and groups",
+		Long:  "Removes references to the specified roles, clusterroles, users, and groups.  Other types are ignored.",
 
 		Run: func(cmd *cobra.Command, args []string) {
 			kcmdutil.CheckErr(o.Complete(f, cmd, args))

--- a/pkg/cli/admin/prune/builds/builds.go
+++ b/pkg/cli/admin/prune/builds/builds.go
@@ -21,7 +21,7 @@ import (
 
 var (
 	buildsLongDesc = templates.LongDesc(`
-		Prune old completed and failed builds
+		Prune old completed and failed builds.
 
 		By default, the prune operation performs a dry run making no changes to internal registry. A
 		--confirm flag is needed for changes to be effective.
@@ -29,7 +29,7 @@ var (
 
 	buildsExample = templates.Examples(`
 		# Dry run deleting older completed and failed builds and also including
-		# all builds whose associated BuildConfig no longer exists
+		# all builds whose associated build config no longer exists
 		oc adm prune builds --orphans
 
 		# To actually perform the prune operation, the confirm flag must be appended

--- a/pkg/cli/admin/prune/deployments/deployments.go
+++ b/pkg/cli/admin/prune/deployments/deployments.go
@@ -23,7 +23,7 @@ import (
 
 var (
 	deploymentsLongDesc = templates.LongDesc(`
-		Prune old completed and failed deployment configs
+		Prune old completed and failed deployment configs.
 
 		By default, the prune operation performs a dry run making no changes to the deployment configs.
 		A --confirm flag is needed for changes to be effective.

--- a/pkg/cli/admin/prune/images/images.go
+++ b/pkg/cli/admin/prune/images/images.go
@@ -52,7 +52,7 @@ const registryURLNotReachable = `(?:operation|connection) timed out|no such host
 
 var (
 	imagesLongDesc = templates.LongDesc(`
-		Remove image stream tags, images, and image layers by age or usage
+		Remove image stream tags, images, and image layers by age or usage.
 
 		This command removes historical image stream tags, unused images, and unreferenced image
 		layers from the integrated registry. By default, all images are considered as candidates.
@@ -81,14 +81,14 @@ var (
 			--insecure-skip-tls-verify or allowed for insecure connection)`)
 
 	imagesExample = templates.Examples(`
-	  # See, what the prune command would delete if only images and their referrers were more than an hour old
-	  # and obsoleted by 3 newer revisions under the same tag were considered.
+	  # See what the prune command would delete if only images and their referrers were more than an hour old
+	  # and obsoleted by 3 newer revisions under the same tag were considered
 	  oc adm prune images --keep-tag-revisions=3 --keep-younger-than=60m
 
 	  # To actually perform the prune operation, the confirm flag must be appended
 	  oc adm prune images --keep-tag-revisions=3 --keep-younger-than=60m --confirm
 
-	  # See, what the prune command would delete if we're interested in removing images
+	  # See what the prune command would delete if we are interested in removing images
 	  # exceeding currently set limit ranges ('openshift.io/Image')
 	  oc adm prune images --prune-over-size-limit
 

--- a/pkg/cli/admin/release/extract.go
+++ b/pkg/cli/admin/release/extract.go
@@ -63,7 +63,7 @@ func NewExtract(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.
 		Use:   "extract",
 		Short: "Extract the contents of an update payload to disk",
 		Long: templates.LongDesc(`
-			Extract the contents of a release image to disk
+			Extract the contents of a release image to disk.
 
 			Extracts the contents of an OpenShift release image to disk for inspection or
 			debugging. Update images contain manifests and metadata about the operators that
@@ -75,7 +75,7 @@ func NewExtract(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.
 			--command for either 'oc' or 'openshift-install' will extract the binaries directly.
 			You may pass a PGP private key file with --signing-key which will create an ASCII
 			armored sha256sum.txt.asc file describing the content that was extracted that is
-			signed by the key. For more advanced signing use the generated sha256sum.txt and an
+			signed by the key. For more advanced signing, use the generated sha256sum.txt and an
 			external tool like gpg.
 
 			The --credentials-requests flag filters extracted manifests to only cloud credential

--- a/pkg/cli/admin/release/info.go
+++ b/pkg/cli/admin/release/info.go
@@ -63,7 +63,7 @@ func NewInfo(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Com
 		Use:   "info IMAGE [--changes-from=IMAGE] [--verify|--commits|--pullspecs]",
 		Short: "Display information about a release",
 		Long: templates.LongDesc(`
-			Show information about an OpenShift release
+			Show information about an OpenShift release.
 
 			This command retrieves, verifies, and formats the information describing an OpenShift update.
 			Updates are delivered as container images with metadata describing the component images and

--- a/pkg/cli/admin/release/mirror.go
+++ b/pkg/cli/admin/release/mirror.go
@@ -96,11 +96,11 @@ func NewMirror(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.C
 			that must be applied to a cluster to use the mirror, but you may opt to rewrite the
 			update to point to the new location and lose the cryptographic integrity of the update.
 
-			Creates a release image signature ConfigMap that can be saved to a directory, applied
+			Creates a release image signature config map that can be saved to a directory, applied
 			directly to a connected cluster, or both.
 
 			The common use for this command is to mirror a specific OpenShift release version to
-			a private registry and create a signature ConfigMap for use in a disconnected or
+			a private registry and create a signature config map for use in a disconnected or
 			offline context. The command copies all images that are part of a release into the
 			target repository and then prints the correct information to give to OpenShift to use
 			that content offline. An alternate mode is to specify --to-image-stream, which imports
@@ -111,13 +111,13 @@ func NewMirror(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.C
 			that can be used to upload the release to another registry.
 
 			You may use --apply-release-image-signature, --release-image-signature-to-dir, or both
-			to control the handling of the signature ConfigMap. Option
-			--apply-release-image-signature will apply the ConfigMap directly to a connected
+			to control the handling of the signature config map. Option
+			--apply-release-image-signature will apply the config map directly to a connected
 			cluster while --release-image-signature-to-dir specifies an export target directory. If
 			--release-image-signature-to-dir is not specified but --to-dir is,
 			--release-image-signature-to-dir defaults to a 'config' subdirectory of --to-dir.
 			The --overwrite option only applies when --apply-release-image-signature is specified
-			and indicates to update an exisiting ConfigMap if one is found. A ConfigMap written to a
+			and indicates to update an exisiting config map if one is found. A config map written to a
 			directory will always replace onethat already exists.
 		`),
 		Example: templates.Examples(`

--- a/pkg/cli/admin/release/new.go
+++ b/pkg/cli/admin/release/new.go
@@ -63,7 +63,7 @@ func NewRelease(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.
 		Use:   "new [SRC=DST ...]",
 		Short: "Create a new OpenShift release",
 		Long: templates.LongDesc(`
-			Build a new OpenShift release image that will update a cluster
+			Build a new OpenShift release image that will update a cluster.
 
 			OpenShift uses long-running active management processes called "operators" to
 			keep the cluster running and manage component lifecycle. This command
@@ -77,7 +77,7 @@ func NewRelease(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.
 			cluster version operator when it is time to perform an update. Manifest files are
 			renamed to '0000_70_<image_name>_<filename>' by default, and an operator author that
 			needs to provide a global-ordered file (before or after other operators) should
-			prepend '0000_NN_<component>_' to their filename, which instructs the release builder
+			prepend '0000_NN_<component>_' to their file name, which instructs the release builder
 			to not assign a component prefix. Only images in the input that have the image label
 			'io.openshift.release.operator=true' will have manifests loaded.
 

--- a/pkg/cli/admin/top/images.go
+++ b/pkg/cli/admin/top/images.go
@@ -35,14 +35,14 @@ const (
 
 var (
 	topImagesLong = templates.LongDesc(`
-		Show usage statistics for Images
+		Show usage statistics for images.
 
-		This command analyzes all the Images managed by the platform and presents current
+		This command analyzes all the images managed by the platform and presents current
 		usage statistics.
 	`)
 
 	topImagesExample = templates.Examples(`
-		# Show usage statistics for Images
+		# Show usage statistics for images
 		oc adm top images
 	`)
 )
@@ -67,7 +67,7 @@ func NewCmdTopImages(f kcmdutil.Factory, streams genericclioptions.IOStreams) *c
 	o := NewTopImagesOptions(streams)
 	cmd := &cobra.Command{
 		Use:     "images",
-		Short:   "Show usage statistics for Images",
+		Short:   "Show usage statistics for images",
 		Long:    topImagesLong,
 		Example: topImagesExample,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cli/admin/top/imagestreams.go
+++ b/pkg/cli/admin/top/imagestreams.go
@@ -28,14 +28,14 @@ const TopImageStreamsRecommendedName = "imagestreams"
 
 var (
 	topImageStreamsLong = templates.LongDesc(`
-		Show usage statistics for ImageStreams
+		Show usage statistics for image streams.
 
-		This command analyzes all the ImageStreams managed by the platform and presents current
+		This command analyzes all the image streams managed by the platform and presents current
 		usage statistics.
 	`)
 
 	topImageStreamsExample = templates.Examples(`
-		# Show usage statistics for ImageStreams
+		# Show usage statistics for image streams
 		oc adm top imagestreams
 	`)
 )
@@ -59,7 +59,7 @@ func NewCmdTopImageStreams(f kcmdutil.Factory, streams genericclioptions.IOStrea
 	o := NewTopImageStreamsOptions(streams)
 	cmd := &cobra.Command{
 		Use:     "imagestreams",
-		Short:   "Show usage statistics for ImageStreams",
+		Short:   "Show usage statistics for image streams",
 		Long:    topImageStreamsLong,
 		Example: topImageStreamsExample,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cli/admin/verifyimagesignature/verify-signature.go
+++ b/pkg/cli/admin/verifyimagesignature/verify-signature.go
@@ -37,15 +37,15 @@ var (
 	with the identity (pull spec) of the given image.
 	By default, this command will use the public GPG keyring located in "$GNUPGHOME/.gnupg/pubring.gpg"
 
-	By default, this command will not save the result of the verification back to the image object, to do so
-	user have to specify the "--save" flag. Note that to modify the image signature verification status,
-	user have to have permissions to edit an image object (usually an "image-auditor" role).
+	By default, this command will not save the result of the verification back to the image object; to do so
+	the user must specify the "--save" flag. Note that to modify the image signature verification status,
+	the user must have permissions to edit an image object (usually an "image-auditor" role).
 
 	Note that using the "--save" flag on already verified image together with invalid GPG
 	key or invalid expected identity will cause the saved verification status to be removed
 	and the image will become "unverified".
 
-	If this command is outside the cluster, users have to specify the "--registry-url" parameter
+	If this command is outside the cluster, users must specify the "--registry-url" parameter
 	with the public URL of image registry.
 
 	To remove all verifications, users can use the "--remove-all" flag.

--- a/pkg/cli/cancelbuild/cancelbuild.go
+++ b/pkg/cli/cancelbuild/cancelbuild.go
@@ -35,7 +35,7 @@ const CancelBuildRecommendedCommandName = "cancel-build"
 
 var (
 	cancelBuildLong = templates.LongDesc(`
-		Cancel running, pending, or new builds
+		Cancel running, pending, or new builds.
 
 		This command requests a graceful shutdown of the build. There may be a delay between requesting
 		the build and the time the build is terminated.
@@ -54,7 +54,7 @@ var (
 		# Cancel multiple builds
 		oc cancel-build ruby-build-1 ruby-build-2 ruby-build-3
 
-		# Cancel all builds created from 'ruby-build' build configuration that are in 'new' state
+		# Cancel all builds created from the 'ruby-build' build config that are in the 'new' state
 		oc cancel-build bc/ruby-build --state=new
 	`)
 )

--- a/pkg/cli/create/build.go
+++ b/pkg/cli/create/build.go
@@ -23,7 +23,7 @@ import (
 
 var (
 	buildLong = templates.LongDesc(`
-		Create a new build
+		Create a new build.
 
 		Builds create container images from source code or Dockerfiles. A build can pull source
 		code from Git or accept a Dockerfile that pulls the source content.

--- a/pkg/cli/create/clusterquota.go
+++ b/pkg/cli/create/clusterquota.go
@@ -25,7 +25,7 @@ var (
 	clusterQuotaLong = templates.LongDesc(`
 		Create a cluster resource quota that controls certain resources.
 
-		Cluster resource quota objects defined quota restrictions that span multiple projects based on label selectors.
+		Cluster resource quota objects define quota restrictions that span multiple projects based on label selectors.
 	`)
 
 	clusterQuotaExample = templates.Examples(`
@@ -58,7 +58,7 @@ func NewCmdCreateClusterQuota(f genericclioptions.RESTClientGetter, streams gene
 	o := NewCreateClusterQuotaOptions(streams)
 	cmd := &cobra.Command{
 		Use:     "clusterresourcequota NAME --project-label-selector=key=value [--hard=RESOURCE=QUANTITY]...",
-		Short:   "Create cluster resource quota resource.",
+		Short:   "Create a cluster resource quota",
 		Long:    clusterQuotaLong,
 		Example: clusterQuotaExample,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cli/create/deploymentconfig.go
+++ b/pkg/cli/create/deploymentconfig.go
@@ -21,7 +21,7 @@ var (
 	deploymentConfigLong = templates.LongDesc(`
 		Create a deployment config that uses a given image.
 
-		Deployment configs define the template for a pod and manages deploying new images or configuration changes.
+		Deployment configs define the template for a pod and manage deploying new images or configuration changes.
 	`)
 
 	deploymentConfigExample = templates.Examples(`
@@ -46,7 +46,7 @@ func NewCmdCreateDeploymentConfig(f genericclioptions.RESTClientGetter, streams 
 	}
 	cmd := &cobra.Command{
 		Use:     "deploymentconfig NAME --image=IMAGE -- [COMMAND] [args...]",
-		Short:   "Create deployment config with default options that uses a given image.",
+		Short:   "Create a deployment config with default options that uses a given image",
 		Long:    deploymentConfigLong,
 		Example: deploymentConfigExample,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cli/create/identity.go
+++ b/pkg/cli/create/identity.go
@@ -26,7 +26,7 @@ var (
 		creation is disabled (by using the "lookup" mapping method), identities must
 		be created manually.
 
-		Corresponding user and useridentitymapping objects must also be created
+		Corresponding user and user identity mapping objects must also be created
 		to allow logging in with the created identity.
 	`)
 
@@ -52,7 +52,7 @@ func NewCmdCreateIdentity(f genericclioptions.RESTClientGetter, streams genericc
 	}
 	cmd := &cobra.Command{
 		Use:     "identity <PROVIDER_NAME>:<PROVIDER_USER_NAME>",
-		Short:   "Manually create an identity (only needed if automatic creation is disabled).",
+		Short:   "Manually create an identity (only needed if automatic creation is disabled)",
 		Long:    identityLong,
 		Example: identityExample,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cli/create/imagestream.go
+++ b/pkg/cli/create/imagestream.go
@@ -18,7 +18,7 @@ import (
 
 var (
 	imageStreamLong = templates.LongDesc(`
-		Create a new image stream
+		Create a new image stream.
 
 		Image streams allow you to track, tag, and import images from other registries. They also define an
 		access controlled destination that you can push images to. An image stream can reference images
@@ -51,7 +51,7 @@ func NewCmdCreateImageStream(f genericclioptions.RESTClientGetter, streams gener
 	}
 	cmd := &cobra.Command{
 		Use:     "imagestream NAME",
-		Short:   "Create a new empty image stream.",
+		Short:   "Create a new empty image stream",
 		Long:    imageStreamLong,
 		Example: imageStreamExample,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cli/create/imagestreamtag.go
+++ b/pkg/cli/create/imagestreamtag.go
@@ -23,7 +23,7 @@ import (
 
 var (
 	imageStreamTagLong = templates.LongDesc(`
-		Create a new image stream tag
+		Create a new image stream tag.
 
 		Image streams tags allow you to track, tag, and import images from other registries. They also
 		define an access controlled destination that you can push images to. An image stream tag can
@@ -36,7 +36,7 @@ var (
 	`)
 
 	imageStreamTagExample = templates.Examples(`
-		# Create a new image stream tag based on an image on a remote registry
+		# Create a new image stream tag based on an image in a remote registry
 		oc create imagestreamtag mysql:latest --from-image=myregistry.local/mysql/mysql:5.0
 	`)
 )
@@ -63,7 +63,7 @@ func NewCmdCreateImageStreamTag(f genericclioptions.RESTClientGetter, streams ge
 	}
 	cmd := &cobra.Command{
 		Use:     "imagestreamtag NAME",
-		Short:   "Create a new image stream tag.",
+		Short:   "Create a new image stream tag",
 		Long:    imageStreamTagLong,
 		Example: imageStreamTagExample,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cli/create/route.go
+++ b/pkg/cli/create/route.go
@@ -19,10 +19,10 @@ import (
 
 var (
 	routeLong = templates.LongDesc(`
-		Expose containers externally via secured routes
+		Expose containers externally via secured routes.
 
 		Three types of secured routes are supported: edge, passthrough, and reencrypt.
-		If you wish to create unsecured routes, see "oc expose -h"
+		If you want to create unsecured routes, see "oc expose -h".
 	`)
 )
 

--- a/pkg/cli/create/routeedge.go
+++ b/pkg/cli/create/routeedge.go
@@ -23,18 +23,18 @@ import (
 
 var (
 	edgeRouteLong = templates.LongDesc(`
-		Create a route that uses edge TLS termination
+		Create a route that uses edge TLS termination.
 
 		Specify the service (either just its name or using type/name syntax) that the
 		generated route should expose via the --service flag.
 	`)
 
 	edgeRouteExample = templates.Examples(`
-		# Create an edge route named "my-route" that exposes frontend service.
+		# Create an edge route named "my-route" that exposes the frontend service
 		oc create route edge my-route --service=frontend
 
-		# Create an edge route that exposes the frontend service and specify a path.
-		# If the route name is omitted, the service name will be re-used.
+		# Create an edge route that exposes the frontend service and specify a path
+		# If the route name is omitted, the service name will be used
 		oc create route edge --service=frontend --path /assets
 	`)
 )

--- a/pkg/cli/create/routepassthrough.go
+++ b/pkg/cli/create/routepassthrough.go
@@ -18,18 +18,18 @@ import (
 
 var (
 	passthroughRouteLong = templates.LongDesc(`
-		Create a route that uses passthrough TLS termination
+		Create a route that uses passthrough TLS termination.
 
 		Specify the service (either just its name or using type/name syntax) that the
 		generated route should expose via the --service flag.
 	`)
 
 	passthroughRouteExample = templates.Examples(`
-		# Create a passthrough route named "my-route" that exposes the frontend service.
+		# Create a passthrough route named "my-route" that exposes the frontend service
 		oc create route passthrough my-route --service=frontend
 
 		# Create a passthrough route that exposes the frontend service and specify
-		# a hostname. If the route name is omitted, the service name will be re-used.
+		# a host name. If the route name is omitted, the service name will be used
 		oc create route passthrough --service=frontend --hostname=www.example.com
 	`)
 )

--- a/pkg/cli/create/routereenecrypt.go
+++ b/pkg/cli/create/routereenecrypt.go
@@ -19,7 +19,7 @@ import (
 
 var (
 	reencryptRouteLong = templates.LongDesc(`
-		Create a route that uses reencrypt TLS termination
+		Create a route that uses reencrypt TLS termination.
 
 		Specify the service (either just its name or using type/name syntax) that the
 		generated route should expose using the --service flag. You may also specify
@@ -29,12 +29,12 @@ var (
 	`)
 
 	reencryptRouteExample = templates.Examples(`
-		# Create a route named "my-route" that exposes the frontend service:
+		# Create a route named "my-route" that exposes the frontend service
 		oc create route reencrypt my-route --service=frontend --dest-ca-cert cert.cert
 
 		# Create a reencrypt route that exposes the frontend service, letting the
 		# route name default to the service name and the destination CA certificate
-		# default to the service CA:
+		# default to the service CA
 		oc create route reencrypt --service=frontend
 	`)
 )

--- a/pkg/cli/create/user.go
+++ b/pkg/cli/create/user.go
@@ -24,7 +24,7 @@ var (
 		creation is disabled (by using the "lookup" mapping method), users must
 		be created manually.
 
-		Corresponding identity and useridentitymapping objects must also be created
+		Corresponding identity and user identity mapping objects must also be created
 		to allow logging in as the created user.
 	`)
 
@@ -49,7 +49,7 @@ func NewCmdCreateUser(f genericclioptions.RESTClientGetter, streams genericcliop
 	}
 	cmd := &cobra.Command{
 		Use:     "user NAME",
-		Short:   "Manually create a user (only needed if automatic creation is disabled).",
+		Short:   "Manually create a user (only needed if automatic creation is disabled)",
 		Long:    userLong,
 		Example: userExample,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cli/create/user_identity_mapping.go
+++ b/pkg/cli/create/user_identity_mapping.go
@@ -23,7 +23,7 @@ var (
 		Typically, identities are automatically mapped to users during login. If automatic
 		mapping is disabled (by using the "lookup" mapping method), or a mapping needs to
 		be manually established between an identity and a user, this command can be used
-		to create a useridentitymapping object.
+		to create a user identity mapping object.
 	`)
 
 	userIdentityMappingExample = templates.Examples(`
@@ -52,7 +52,7 @@ func NewCmdCreateUserIdentityMapping(f genericclioptions.RESTClientGetter, strea
 	o := NewCreateUserIdentityMappingOptions(streams)
 	cmd := &cobra.Command{
 		Use:     "useridentitymapping <IDENTITY_NAME> <USER_NAME>",
-		Short:   "Manually map an identity to a user.",
+		Short:   "Manually map an identity to a user",
 		Long:    userIdentityMappingLong,
 		Example: userIdentityMappingExample,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cli/debug/debug.go
+++ b/pkg/cli/debug/debug.go
@@ -62,7 +62,7 @@ const (
 
 var (
 	debugLong = templates.LongDesc(`
-		Launch a command shell to debug a running application
+		Launch a command shell to debug a running application.
 
 		When debugging images and setup problems, it's useful to get an exact copy of a running
 		pod configuration and troubleshoot with a shell. Since a pod that is failing may not be
@@ -110,10 +110,10 @@ var (
 		# See the pod that would be created to debug
 		oc debug mypod-9xbc -o yaml
 
-		# Debug a resource but launch the debug pod in another namespace.
+		# Debug a resource but launch the debug pod in another namespace
 		# Note: Not all resources can be debugged using --to-namespace without modification. For example,
-		# volumes and serviceaccounts are namespace-dependent. Add '-o yaml' to output the debug pod definition
-		# to disk.  If necessary, edit the definition then run 'oc debug -f -' or run without --to-namespace.
+		# volumes and service accounts are namespace-dependent. Add '-o yaml' to output the debug pod definition
+		# to disk.  If necessary, edit the definition then run 'oc debug -f -' or run without --to-namespace
 		oc debug mypod-9xbc --to-namespace testns
 	`)
 )

--- a/pkg/cli/experimental/dockergc/dockergc.go
+++ b/pkg/cli/experimental/dockergc/dockergc.go
@@ -50,7 +50,7 @@ type dockerGCConfigCmdOptions struct {
 
 var (
 	dockerGCLong = templates.LongDesc(`
-		Perform garbage collection to free space in docker storage
+		Perform garbage collection to free space in docker storage.
 
 		If the OpenShift node is configured to use a container runtime other than docker,
 		docker will still be used to do builds.  However OpenShift itself may not

--- a/pkg/cli/expose/expose.go
+++ b/pkg/cli/expose/expose.go
@@ -19,26 +19,26 @@ import (
 
 var (
 	exposeLong = templates.LongDesc(`
-		Expose containers internally as services or externally via routes
+		Expose containers internally as services or externally via routes.
 
-		There is also the ability to expose a deployment configuration, replication controller, service, or pod
-		as a new service on a specified port. If no labels are specified, the new object will re-use the
+		There is also the ability to expose a deployment config, replication controller, service, or pod
+		as a new service on a specified port. If no labels are specified, the new object will reuse the
 		labels from the object it exposes.
 	`)
 
 	exposeExample = templates.Examples(`
-		# Create a route based on service nginx. The new route will re-use nginx's labels
+		# Create a route based on service nginx. The new route will reuse nginx's labels
 		oc expose service nginx
 
 		# Create a route and specify your own label and route name
 		oc expose service nginx -l name=myroute --name=fromdowntown
 
-		# Create a route and specify a hostname
+		# Create a route and specify a host name
 		oc expose service nginx --hostname=www.example.com
 
-		# Create a route with wildcard
+		# Create a route with a wildcard
 		oc expose service nginx --hostname=x.example.com --wildcard-policy=Subdomain
-		This would be equivalent to *.example.com. NOTE: only hosts are matched by the wildcard, subdomains would not be included.
+		# This would be equivalent to *.example.com. NOTE: only hosts are matched by the wildcard; subdomains would not be included
 
 		# Expose a deployment configuration as a service and use the specified port
 		oc expose dc ruby-hello-world --port=8080
@@ -50,8 +50,8 @@ var (
 		oc expose service nginx --name=exposed-svc --port=12201 --protocol="TCP" --generator="service/v2"
 		oc expose service nginx --name=my-route --port=12201 --generator="route/v1"
 
-		Exposing a service using the "route/v1" generator (default) will create a new exposed route with the "--name" provided
-		(or the name of the service otherwise). You may not specify a "--protocol" or "--target-port" option when using this generator.
+		# Exposing a service using the "route/v1" generator (default) will create a new exposed route with the "--name" provided
+		# (or the name of the service otherwise). You may not specify a "--protocol" or "--target-port" option when using this generator
 	`)
 )
 

--- a/pkg/cli/extract/extract.go
+++ b/pkg/cli/extract/extract.go
@@ -23,30 +23,30 @@ import (
 
 var (
 	extractLong = templates.LongDesc(`
-		Extract files out of secrets and config maps
+		Extract files out of secrets and config maps.
 
 		The extract command makes it easy to download the contents of a config map or secret into a directory.
 		Each key in the config map or secret is created as a separate file with the name of the key, as it
 		is when you mount a secret or config map into a container.
 
-		You may extract the contents of a secret or config map to standard out by passing '-' to --to. The
-		names of each key will be written to stdandard error.
+		You may extract the contents of a secret or config map to standard out by passing '-' to the --to option. The
+		names of each key will be written to standard error.
 
 		You can limit which keys are extracted with the --keys=NAME flag, or set the directory to extract to
 		with --to=DIRECTORY.
 	`)
 
 	extractExample = templates.Examples(`
-		# extract the secret "test" to the current directory
+		# Extract the secret "test" to the current directory
 		oc extract secret/test
 
-		# extract the config map "nginx" to the /tmp directory
+		# Extract the config map "nginx" to the /tmp directory
 		oc extract configmap/nginx --to=/tmp
 
-		# extract the config map "nginx" to STDOUT
+		# Extract the config map "nginx" to STDOUT
 		oc extract configmap/nginx --to=-
 
-		# extract only the key "nginx.conf" from config map "nginx" to the /tmp directory
+		# Extract only the key "nginx.conf" from config map "nginx" to the /tmp directory
 		oc extract configmap/nginx --to=/tmp --keys=nginx.conf
 	`)
 )

--- a/pkg/cli/idle/idle.go
+++ b/pkg/cli/idle/idle.go
@@ -39,7 +39,7 @@ import (
 
 var (
 	idleLong = templates.LongDesc(`
-		Idle scalable resources
+		Idle scalable resources.
 
 		Idling discovers the scalable resources (such as deployment configs and replication controllers)
 		associated with a series of services by examining the endpoints of the service.

--- a/pkg/cli/image/append/append.go
+++ b/pkg/cli/image/append/append.go
@@ -38,7 +38,7 @@ import (
 
 var (
 	desc = templates.LongDesc(`
-		Add layers to container images
+		Add layers to container images.
 
 		Modifies an existing image by adding layers or changing configuration and then pushes that
 		image to a remote registry. Any inherited layers are streamed from registry to registry
@@ -84,7 +84,7 @@ var (
 		oc image append --from-dir v2 --to myregistry.com/myimage:latest layer.tar.gz
 
 		# Add a new layer to a multi-architecture image for an os/arch that is different from the system's os/arch
-		# Note: Wildcard filter is not supported with append. Pass a single os/arch to append.
+		# Note: Wildcard filter is not supported with append. Pass a single os/arch to append
 		oc image append --from docker.io/library/busybox:latest --filter-by-os=linux/s390x --to myregistry.com/myimage:latest layer.tar.gz
 
 	`)

--- a/pkg/cli/image/extract/extract.go
+++ b/pkg/cli/image/extract/extract.go
@@ -34,9 +34,9 @@ import (
 
 var (
 	desc = templates.LongDesc(`
-		Extract the contents of an image to disk
+		Extract the contents of an image to disk.
 
-		Download an image or parts of an image to the filesystem. Allows users to access the
+		Download an image or parts of an image to the file system. Allows users to access the
 		contents of images without requiring a container runtime engine running.
 
 		Unless the --path flag is passed, image contents will be extracted into the current directory.
@@ -69,7 +69,7 @@ var (
 		oc image extract docker.io/library/busybox:latest --path /:/tmp/busybox
 
 		# Extract the busybox image into the current directory for linux/s390x platform
-		# Note: Wildcard filter is not supported with extract. Pass a single os/arch to extract.
+		# Note: Wildcard filter is not supported with extract. Pass a single os/arch to extract
 		oc image extract docker.io/library/busybox:latest --filter-by-os=linux/s390x
 
 		# Extract a single file from the image into the current directory
@@ -79,15 +79,15 @@ var (
 		oc image extract docker.io/library/centos:7 --path /etc/yum.repos.d/*.repo:.
 
 		# Extract all .repo files from the image's /etc/yum.repos.d/ folder into a designated directory (must exist)
-		# this results in /tmp/yum.repos.d/*.repo on local system
+		# This results in /tmp/yum.repos.d/*.repo on local system
 		oc image extract docker.io/library/centos:7 --path /etc/yum.repos.d/*.repo:/tmp/yum.repos.d
 
 		# Extract an image stored on disk into the current directory ($(pwd)/v2/busybox/blobs,manifests exists)
-		# --confirm is required because current directory is not empty
+		# --confirm is required because the current directory is not empty
 		oc image extract file://busybox:local --confirm
 
 		# Extract an image stored on disk in a directory other than $(pwd)/v2 into the current directory
-		# --confirm is required because current directory is not empty ($(pwd)/busybox-mirror-dir/v2/busybox exists)
+		# --confirm is required because the current directory is not empty ($(pwd)/busybox-mirror-dir/v2/busybox exists)
 		oc image extract file://busybox:local --dir busybox-mirror-dir --confirm
 
 		# Extract an image stored on disk in a directory other than $(pwd)/v2 into a designated directory (must exist)
@@ -161,7 +161,7 @@ func NewExtract(streams genericclioptions.IOStreams) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "extract",
-		Short:   "Copy files from an image to the filesystem",
+		Short:   "Copy files from an image to the file system",
 		Long:    desc,
 		Example: example,
 		Run: func(c *cobra.Command, args []string) {

--- a/pkg/cli/image/info/info.go
+++ b/pkg/cli/image/info/info.go
@@ -44,7 +44,7 @@ func NewInfo(streams genericclioptions.IOStreams) *cobra.Command {
 		Use:   "info IMAGE [...]",
 		Short: "Display information about an image",
 		Long: templates.LongDesc(`
-			Show information about an image in a remote image registry
+			Show information about an image in a remote image registry.
 
 			This command will retrieve metadata about container images in a remote image
 			registry. You may specify images by tag or digest and specify multiple at a

--- a/pkg/cli/image/mirror/mirror.go
+++ b/pkg/cli/image/mirror/mirror.go
@@ -92,19 +92,19 @@ var (
 		oc image mirror myregistry.com/myimage:latest=myregistry.com/other:test \
 			myregistry.com/myimage:new=myregistry.com/other:target
 
-		# Copy manifest list of a multi-architecture image, even if only a single image is found.
+		# Copy manifest list of a multi-architecture image, even if only a single image is found
 		oc image mirror myregistry.com/myimage:latest=myregistry.com/other:test \
 			--keep-manifest-list=true
 
 		# Copy specific os/arch manifest of a multi-architecture image
 		# Run 'oc image info myregistry.com/myimage:latest' to see available os/arch for multi-arch images
 		# Note that with multi-arch images, this results in a new manifest list digest that includes only
-		# the filtered manifests.
+		# the filtered manifests
 		oc image mirror myregistry.com/myimage:latest=myregistry.com/other:test \
 			--filter-by-os=os/arch
 
 		# Copy all os/arch manifests of a multi-architecture image
-		# Run 'oc image info myregistry.com/myimage:latest' to see list of os/arch manifests that will be mirrored.
+		# Run 'oc image info myregistry.com/myimage:latest' to see list of os/arch manifests that will be mirrored
 		oc image mirror myregistry.com/myimage:latest=myregistry.com/other:test \
 			--keep-manifest-list=true
 

--- a/pkg/cli/image/serve/serve.go
+++ b/pkg/cli/image/serve/serve.go
@@ -30,14 +30,14 @@ func NewServe(streams genericclioptions.IOStreams) *cobra.Command {
 		Use:   "serve IMAGE",
 		Short: "Serve a container registry from images mirrored to disk",
 		Long: templates.LongDesc(`
-			Serve a container registry
+			Serve a container registry.
 
 			This command will start an HTTP or HTTPS server that hosts a local directory of mirrored
 			images. Use the 'oc image mirror --dir=DIR SRC=DST' command to populate that directory.
 			The directory must have a 'v2' folder that contains repository sub directories.
 
 			No authentication or authorization checks are performed and the source directory should
-			only include content you wish network users to see.
+			only include content you want network users to see.
 
 			Experimental: This command is under active development and may change without notice.
 		`),

--- a/pkg/cli/importimage/importimage.go
+++ b/pkg/cli/importimage/importimage.go
@@ -26,7 +26,7 @@ import (
 
 var (
 	importImageLong = templates.LongDesc(`
-		Import the latest image information from a tag in a container image registry
+		Import the latest image information from a tag in a container image registry.
 
 		Image streams allow you to control which images are rolled out to your builds
 		and applications. This command fetches the latest version of an image from a
@@ -35,26 +35,26 @@ var (
 		entries. When importing an image, only the image metadata is copied, not the
 		image contents.
 
-		If you wish to change the image stream tag or provide more advanced options,
+		If you want to change the image stream tag or provide more advanced options,
 		see the 'tag' command.`)
 
 	importImageExample = templates.Examples(`
-		# Import tag latest into a new image stream.
+		# Import tag latest into a new image stream
 		oc import-image mystream --from=registry.io/repo/image:latest --confirm
 
-		# Update imported data for tag latest in an already existing image stream.
+		# Update imported data for tag latest in an already existing image stream
 		oc import-image mystream
 
-		# Update imported data for tag stable in an already existing image stream.
+		# Update imported data for tag stable in an already existing image stream
 		oc import-image mystream:stable
 
-		# Update imported data for all tags in an existing image stream.
+		# Update imported data for all tags in an existing image stream
 		oc import-image mystream --all
 
-		# Import all tags into a new image stream.
+		# Import all tags into a new image stream
 		oc import-image mystream --from=registry.io/repo/image --all --confirm
 
-		# Import all tags into a new image stream using a custom timeout.
+		# Import all tags into a new image stream using a custom timeout
 		oc --request-timeout=5m import-image mystream --from=registry.io/repo/image --all --confirm
 	`)
 )
@@ -103,7 +103,7 @@ func NewCmdImportImage(f kcmdutil.Factory, streams genericclioptions.IOStreams) 
 
 	cmd := &cobra.Command{
 		Use:     "import-image IMAGESTREAM[:TAG]",
-		Short:   "Imports images from a container image registry",
+		Short:   "Import images from a container image registry",
 		Long:    importImageLong,
 		Example: importImageExample,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cli/login/login.go
+++ b/pkg/cli/login/login.go
@@ -22,7 +22,7 @@ import (
 
 var (
 	loginLong = templates.LongDesc(`
-		Log in to your server and save login for subsequent use
+		Log in to your server and save login for subsequent use.
 
 		First-time users of the client should run this command to connect to a server,
 		establish an authenticated session, and save connection to the configuration file. The

--- a/pkg/cli/logout/logout.go
+++ b/pkg/cli/logout/logout.go
@@ -36,7 +36,7 @@ type LogoutOptions struct {
 
 var (
 	logoutLong = templates.LongDesc(`
-		Log out of the active session out by clearing saved tokens
+		Log out of the active session out by clearing saved tokens.
 
 		An authentication token is stored in the config file after login - this command will delete
 		that token on the server, and then remove the token from the configuration file.
@@ -50,7 +50,7 @@ var (
 	`)
 
 	logoutExample = templates.Examples(`
-		# Logout
+		# Log out
 		oc logout
 	`)
 )

--- a/pkg/cli/logs/logs.go
+++ b/pkg/cli/logs/logs.go
@@ -22,7 +22,7 @@ import (
 
 var (
 	logsLong = templates.LongDesc(`
-		Print the logs for a resource
+		Print the logs for a resource.
 
 		Supported resources are builds, build configs (bc), deployment configs (dc), and pods.
 		When a pod is specified and has more than one container, the container name should be
@@ -34,21 +34,21 @@ var (
 	`)
 
 	logsExample = templates.Examples(`
-		# Start streaming the logs of the most recent build of the openldap build config.
+		# Start streaming the logs of the most recent build of the openldap build config
 		oc logs -f bc/openldap
 
-		# Start streaming the logs of the latest deployment of the mysql deployment config.
+		# Start streaming the logs of the latest deployment of the mysql deployment config
 		oc logs -f dc/mysql
 
 		# Get the logs of the first deployment for the mysql deployment config. Note that logs
 		# from older deployments may not exist either because the deployment was successful
-		# or due to deployment pruning or manual deletion of the deployment.
+		# or due to deployment pruning or manual deletion of the deployment
 		oc logs --version=1 dc/mysql
 
-		# Return a snapshot of ruby-container logs from pod backend.
+		# Return a snapshot of ruby-container logs from pod backend
 		oc logs backend -c ruby-container
 
-		# Start streaming of ruby-container logs from pod backend.
+		# Start streaming of ruby-container logs from pod backend
 		oc logs -f pod/backend -c ruby-container
 	`)
 )

--- a/pkg/cli/newapp/newapp.go
+++ b/pkg/cli/newapp/newapp.go
@@ -64,10 +64,10 @@ const RoutePollTimeout = 5 * time.Second
 
 var (
 	newAppLong = templates.LongDesc(`
-		Create a new application by specifying source code, templates, and/or images
+		Create a new application by specifying source code, templates, and/or images.
 
 		This command will try to build up the components of an application using images, templates,
-		or code that has a public repository. It will lookup the images on the local Docker installation
+		or code that has a public repository. It will look up the images on the local Docker installation
 		(if available), a container image registry, an integrated image stream, or stored templates.
 
 		If you specify a source code URL, it will set up a build that takes your source code and converts
@@ -121,7 +121,7 @@ var (
 		# can be used to filter search results)
 		oc new-app --search --template=ruby
 
-		# Search for "ruby" in stored templates and print the output as an YAML
+		# Search for "ruby" in stored templates and print the output as YAML
 		oc new-app --search --template=ruby --output=yaml
 	`)
 

--- a/pkg/cli/newbuild/newbuild.go
+++ b/pkg/cli/newbuild/newbuild.go
@@ -26,10 +26,10 @@ const NewBuildRecommendedCommandName = "new-build"
 
 var (
 	newBuildLong = templates.LongDesc(`
-		Create a new build by specifying source code
+		Create a new build by specifying source code.
 
 		This command will try to create a build configuration for your application using images and
-		code that has a public repository. It will lookup the images on the local Docker installation
+		code that has a public repository. It will look up the images on the local Docker installation
 		(if available), a container image registry, or an image stream.
 
 		If you specify a source code URL, it will set up a build that takes your source code and converts

--- a/pkg/cli/observe/observe.go
+++ b/pkg/cli/observe/observe.go
@@ -40,7 +40,7 @@ import (
 
 var (
 	observeLong = templates.LongDesc(`
-		Observe changes to resources and take action on them
+		Observe changes to resources and take action on them.
 
 		This command assists in building scripted reactions to changes that occur in
 		Kubernetes or OpenShift resources. This is frequently referred to as a
@@ -57,7 +57,7 @@ var (
 		* Send an email alert whenever a node reports 'NotReady'
 		* Watch for the 'FailedScheduling' event and write an IRC message
 		* Dynamically provision persistent volumes when a new PVC is created
-		* Delete pods that have reached successful completion after a period of time.
+		* Delete pods that have reached successful completion after a period of time
 
 		The simplest pattern is maintaining an invariant on an object - for instance,
 		"every namespace should have an annotation that indicates its owner". If the
@@ -86,7 +86,7 @@ var (
 		server - any resources returned by --names that are not found on the server
 		will be passed to your --delete command.
 
-		For example, you may wish to ensure that every node that is added to Kubernetes
+		For example, you may want to ensure that every node that is added to Kubernetes
 		is added to your cluster inventory along with its IP:
 
 		    $ cat add_to_inventory.sh

--- a/pkg/cli/process/process.go
+++ b/pkg/cli/process/process.go
@@ -40,7 +40,7 @@ import (
 
 var (
 	processLong = templates.LongDesc(`
-		Process template into a list of resources specified in filename or stdin
+		Process template into a list of resources specified in a file name or stdin.
 
 		Templates allow parameterization of resources prior to being sent to the server for creation or
 		update. Templates have "parameters", which may either be generated on creation or set by the user,
@@ -55,7 +55,7 @@ var (
 	`)
 
 	processExample = templates.Examples(`
-		# Convert template.json file into resource list and pass to create
+		# Convert the template.json file into a resource list and pass to create
 		oc process -f template.json | oc create -f -
 
 		# Process a file locally instead of contacting the server
@@ -64,16 +64,16 @@ var (
 		# Process template while passing a user-defined label
 		oc process -f template.json -l name=mytemplate
 
-		# Convert stored template into resource list
+		# Convert a stored template into a resource list
 		oc process foo
 
-		# Convert stored template into resource list by setting/overriding parameter values
+		# Convert a stored template into a resource list by setting/overriding parameter values
 		oc process foo PARM1=VALUE1 PARM2=VALUE2
 
-		# Convert template stored in different namespace into a resource list
+		# Convert a template stored in different namespace into a resource list
 		oc process openshift//foo
 
-		# Convert template.json into resource list
+		# Convert template.json into a resource list
 		cat template.json | oc process -f -
 	`)
 )

--- a/pkg/cli/project/project.go
+++ b/pkg/cli/project/project.go
@@ -46,7 +46,7 @@ type ProjectOptions struct {
 
 var (
 	projectLong = templates.LongDesc(`
-		Switch to another project and make it the default in your configuration
+		Switch to another project and make it the default in your configuration.
 
 		If no project was specified on the command line, display information about the current active
 		project. Since you can use this command to connect to projects on different servers, you will
@@ -60,7 +60,7 @@ var (
 	`)
 
 	projectExample = templates.Examples(`
-		# Switch to 'myapp' project
+		# Switch to the 'myapp' project
 		oc project myapp
 
 		# Display the project currently in use

--- a/pkg/cli/registry/info/info.go
+++ b/pkg/cli/registry/info/info.go
@@ -21,11 +21,11 @@ import (
 
 var (
 	desc = templates.LongDesc(`
-		Display information about the integrated registry
+		Display information about the integrated registry.
 
 		This command exposes information about the integrated registry, if configured.
 		Use --check to verify your local client can access the registry. If the adminstrator
-		has not configured a public hostname for the registry then this command may fail when
+		has not configured a public host name for the registry then this command may fail when
 		run outside of the server.
 
 		Experimental: This command is under active development and may change without notice.
@@ -61,7 +61,7 @@ func NewRegistryInfoCmd(f kcmdutil.Factory, streams genericclioptions.IOStreams)
 
 	cmd := &cobra.Command{
 		Use:     "info ",
-		Short:   "Print info about the integrated registry",
+		Short:   "Print information about the integrated registry",
 		Long:    desc,
 		Example: example,
 		Run: func(c *cobra.Command, args []string) {

--- a/pkg/cli/registry/login/login.go
+++ b/pkg/cli/registry/login/login.go
@@ -34,7 +34,7 @@ import (
 
 var (
 	desc = templates.LongDesc(`
-		Login to the OpenShift integrated registry.
+		Log in to the OpenShift integrated registry.
 
 		This logs your local Docker client into the OpenShift integrated registry using the
 		external registry name (if configured by your administrator). You may also log in
@@ -53,7 +53,7 @@ var (
 		the current namespace or the openshift namespace and use the status fields that
 		indicate the registry hostnames. If no image stream is found or if you do not have
 		permission to view image streams you will have to pass the --registry flag with the
-		desired hostname.
+		desired host name.
 
 		You may also pass the --registry flag to login to the integrated registry but with a
 		custom DNS name, or to an external registry. Note that in absence of --auth-basic=USER:PASSWORD,
@@ -118,7 +118,7 @@ func NewRegistryLoginCmd(f kcmdutil.Factory, streams genericclioptions.IOStreams
 
 	cmd := &cobra.Command{
 		Use:     "login ",
-		Short:   "Login to the integrated registry",
+		Short:   "Log in to the integrated registry",
 		Long:    desc,
 		Example: example,
 		Run: func(c *cobra.Command, args []string) {

--- a/pkg/cli/requestproject/request_project.go
+++ b/pkg/cli/requestproject/request_project.go
@@ -36,7 +36,7 @@ type RequestProjectOptions struct {
 // RequestProject command description.
 var (
 	requestProjectLong = templates.LongDesc(`
-		Create a new project for yourself
+		Create a new project for yourself.
 
 		If your administrator allows self-service, this command will create a new project for you and assign you
 		as the project admin.

--- a/pkg/cli/rollback/rollback.go
+++ b/pkg/cli/rollback/rollback.go
@@ -27,9 +27,9 @@ import (
 
 var (
 	rollbackLong = templates.LongDesc(`
-		Revert an application back to a previous deployment
+		Revert an application back to a previous deployment.
 
-		When you run this command your deployment configuration will be updated to
+		When you run this command, your deployment configuration will be updated to
 		match a previous deployment. By default only the pod and container
 		configuration will be changed and scaling or trigger settings will be left as-
 		is. Note that environment variables and volumes are included in rollbacks, so
@@ -41,16 +41,16 @@ var (
 		replaced by a triggered deployment soon after your rollback. To re-enable the
 		triggers, use the 'set triggers' command.
 
-		If you would like to review the outcome of the rollback, pass '--dry-run' to print
+		If you want to review the outcome of the rollback, pass '--dry-run' to print
 		a human-readable representation of the updated deployment configuration instead of
-		executing the rollback. This is useful if you're not quite sure what the outcome
+		executing the rollback. This is useful if you're not sure what the outcome
 		will be.`)
 
 	rollbackExample = templates.Examples(`
-		# Perform a rollback to the last successfully completed deployment for a deploymentconfig
+		# Perform a rollback to the last successfully completed deployment for a deployment config
 		oc rollback frontend
 
-		# See what a rollback to version 3 will look like, but don't perform the rollback
+		# See what a rollback to version 3 will look like, but do not perform the rollback
 		oc rollback frontend --to-version=3 --dry-run
 
 		# Perform a rollback to a specific deployment

--- a/pkg/cli/rollout/cancel.go
+++ b/pkg/cli/rollout/cancel.go
@@ -46,7 +46,7 @@ type CancelOptions struct {
 
 var (
 	rolloutCancelLong = templates.LongDesc(`
-		Cancel the in-progress deployment
+		Cancel the in-progress deployment.
 
 		Running this command will cause the current in-progress deployment to be
 		cancelled, but keep in mind that this is a best-effort operation and may take
@@ -73,7 +73,7 @@ func NewCmdRolloutCancel(f kcmdutil.Factory, streams genericclioptions.IOStreams
 		Use:     "cancel (TYPE NAME | TYPE/NAME) [flags]",
 		Long:    rolloutCancelLong,
 		Example: rolloutCancelExample,
-		Short:   "cancel the in-progress deployment",
+		Short:   "Cancel the in-progress deployment",
 		Run: func(cmd *cobra.Command, args []string) {
 			kcmdutil.CheckErr(o.Complete(f, cmd, args))
 			kcmdutil.CheckErr(o.Run())

--- a/pkg/cli/rollout/latest.go
+++ b/pkg/cli/rollout/latest.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	rolloutLatestLong = templates.LongDesc(`
-		Start a new rollout for a deployment config with the latest state from its triggers
+		Start a new rollout for a deployment config with the latest state from its triggers.
 
 		This command is appropriate for running manual rollouts. If you want full control over
 		running new rollouts, use "oc set triggers --manual" to disable all triggers in your
@@ -36,7 +36,7 @@ var (
 		your image change triggers.`)
 
 	rolloutLatestExample = templates.Examples(`
-		# Start a new rollout based on the latest images defined in the image change triggers.
+		# Start a new rollout based on the latest images defined in the image change triggers
 		oc rollout latest dc/nginx
 
 		# Print the rolled out deployment config

--- a/pkg/cli/rollout/rollout.go
+++ b/pkg/cli/rollout/rollout.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	rolloutLong = templates.LongDesc(`
-		Start a new rollout, view its status or history, rollback to a previous revision of your app
+		Start a new rollout, view its status or history, rollback to a previous revision of your app.
 
 		This command allows you to control a deployment config. Each individual rollout is exposed
 		as a replication controller, and the deployment process manages scaling down old replication
@@ -79,7 +79,7 @@ func NewCmdRolloutHistory(f kcmdutil.Factory, streams genericclioptions.IOStream
 
 var (
 	rolloutPauseLong = templates.LongDesc(`
-    Mark the provided resource as paused
+    Mark the provided resource as paused.
 
     Paused resources will not be reconciled by a controller.
     Use \"oc rollout resume\" to resume a paused resource.`)
@@ -87,7 +87,7 @@ var (
 	rolloutPauseExample = templates.Examples(`
     # Mark the nginx deployment as paused. Any current state of
     # the deployment will continue its function, new updates to the deployment will not
-    # have an effect as long as the deployment is paused.
+    # have an effect as long as the deployment is paused
     oc rollout pause dc/nginx`)
 )
 
@@ -102,7 +102,7 @@ func NewCmdRolloutPause(f kcmdutil.Factory, streams genericclioptions.IOStreams)
 
 var (
 	rolloutResumeLong = templates.LongDesc(`
-    Resume a paused resource
+    Resume a paused resource.
 
     Paused resources will not be reconciled by a controller. By resuming a
     resource, we allow it to be reconciled again.`)
@@ -123,7 +123,7 @@ func NewCmdRolloutResume(f kcmdutil.Factory, streams genericclioptions.IOStreams
 
 var (
 	rolloutUndoLong = templates.LongDesc(`
-    Revert an application back to a previous deployment
+    Revert an application back to a previous deployment.
 
     When you run this command your deployment configuration will be updated to
     match a previous deployment. By default only the pod and container
@@ -143,10 +143,10 @@ var (
     will be.`)
 
 	rolloutUndoExample = templates.Examples(`
-    # Rollback to the previous deployment
+    # Roll back to the previous deployment
     oc rollout undo dc/nginx
 
-    # Rollback to deployment revision 3. The replication controller for that version must exist.
+    # Roll back to deployment revision 3. The replication controller for that version must exist
     oc rollout undo dc/nginx --to-revision=3`)
 )
 

--- a/pkg/cli/rsh/rsh.go
+++ b/pkg/cli/rsh/rsh.go
@@ -24,7 +24,7 @@ var (
 	rshUsageErrStr = fmt.Sprintf("expected '%s'.\nPOD or TYPE/NAME is a required argument for the rsh command", rshUsageStr)
 
 	rshLong = templates.LongDesc(`
-		Open a remote shell session to a container
+		Open a remote shell session to a container.
 
 		This command will attempt to start a shell session in a pod for the specified resource.
 		It works with pods, deployment configs, deployments, jobs, daemon sets, replication controllers
@@ -91,7 +91,7 @@ func NewCmdRsh(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.C
 	cmd := &cobra.Command{
 		Use:                   rshUsageStr,
 		DisableFlagsInUseLine: true,
-		Short:                 "Start a shell session in a container.",
+		Short:                 "Start a shell session in a container",
 		Long:                  rshLong,
 		Example:               rshExample,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cli/rsync/rsync.go
+++ b/pkg/cli/rsync/rsync.go
@@ -30,7 +30,7 @@ const (
 
 var (
 	rsyncLong = templates.LongDesc(`
-		Copy local files to or from a pod container
+		Copy local files to or from a pod container.
 
 		This command will copy local files to or from a remote container.
 		It only copies the changed files using the rsync command from your OS.
@@ -115,7 +115,7 @@ func NewCmdRsync(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra
 
 	cmd := &cobra.Command{
 		Use:     "rsync SOURCE DESTINATION",
-		Short:   "Copy files between local filesystem and a pod",
+		Short:   "Copy files between a local file system and a pod",
 		Long:    rsyncLong,
 		Example: rsyncExample,
 		Run: func(c *cobra.Command, args []string) {

--- a/pkg/cli/secrets/link.go
+++ b/pkg/cli/secrets/link.go
@@ -17,19 +17,19 @@ import (
 
 var (
 	linkSecretLong = templates.LongDesc(`
-		Link secrets to a service account
+		Link secrets to a service account.
 
 		Linking a secret enables a service account to automatically use that secret for some forms of authentication.
 	`)
 
 	linkSecretExample = templates.Examples(`
-		# Add an image pull secret to a service account to automatically use it for pulling pod images:
+		# Add an image pull secret to a service account to automatically use it for pulling pod images
 		oc secrets link serviceaccount-name pull-secret --for=pull
 
-		# Add an image pull secret to a service account to automatically use it for both pulling and pushing build images:
+		# Add an image pull secret to a service account to automatically use it for both pulling and pushing build images
 		oc secrets link builder builder-image-secret --for=pull,mount
 
-		# If the cluster's serviceAccountConfig is operating with limitSecretReferences: True, secrets must be added to the pod's service account whitelist in order to be available to the pod:
+		# If the cluster's serviceAccountConfig is operating with limitSecretReferences: True, secrets must be added to the pod's service account whitelist in order to be available to the pod
 		oc secrets link pod-sa pod-secret
 	`)
 )
@@ -55,7 +55,7 @@ func NewCmdLinkSecret(f kcmdutil.Factory, streams genericclioptions.IOStreams) *
 
 	cmd := &cobra.Command{
 		Use:     "link serviceaccounts-name secret-name [another-secret-name]...",
-		Short:   "Link secrets to a ServiceAccount",
+		Short:   "Link secrets to a service account",
 		Long:    linkSecretLong,
 		Example: linkSecretExample,
 		Run: func(c *cobra.Command, args []string) {

--- a/pkg/cli/secrets/unlink.go
+++ b/pkg/cli/secrets/unlink.go
@@ -18,13 +18,13 @@ import (
 
 var (
 	unlinkSecretLong = templates.LongDesc(`
-		Unlink (detach) secrets from a service account
+		Unlink (detach) secrets from a service account.
 
 		If a secret is no longer valid for a pod, build or image pull, you may unlink it from a service account.
 	`)
 
 	unlinkSecretExample = templates.Examples(`
-		# Unlink a secret currently associated with a service account:
+		# Unlink a secret currently associated with a service account
 		oc secrets unlink serviceaccount-name secret-name another-secret-name ...
 	`)
 )
@@ -52,7 +52,7 @@ func NewCmdUnlinkSecret(f kcmdutil.Factory, streams genericclioptions.IOStreams)
 
 	cmd := &cobra.Command{
 		Use:     "unlink serviceaccount-name secret-name [another-secret-name] ...",
-		Short:   "Detach secrets from a ServiceAccount",
+		Short:   "Detach secrets from a service account",
 		Long:    unlinkSecretLong,
 		Example: unlinkSecretExample,
 		Run: func(c *cobra.Command, args []string) {

--- a/pkg/cli/serviceaccounts/gettoken.go
+++ b/pkg/cli/serviceaccounts/gettoken.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	getServiceAccountTokenShort = `Get a token assigned to a service account.`
+	getServiceAccountTokenShort = `Get a token assigned to a service account`
 )
 
 var (

--- a/pkg/cli/serviceaccounts/newtoken.go
+++ b/pkg/cli/serviceaccounts/newtoken.go
@@ -26,7 +26,7 @@ import (
 const (
 	NewServiceAccountTokenRecommendedName = "new-token"
 
-	newServiceAccountTokenShort = `Generate a new token for a service account.`
+	newServiceAccountTokenShort = `Generate a new token for a service account`
 
 	newServiceAccountTokenUsage = `%s SA-NAME`
 )

--- a/pkg/cli/set/buildhook.go
+++ b/pkg/cli/set/buildhook.go
@@ -24,7 +24,7 @@ import (
 
 var (
 	buildHookLong = templates.LongDesc(`
-		Set or remove a build hook on a build config
+		Set or remove a build hook on a build config.
 
 		Build hooks allow behavior to be injected into the build process.
 

--- a/pkg/cli/set/buildsecret.go
+++ b/pkg/cli/set/buildsecret.go
@@ -26,7 +26,7 @@ import (
 
 var (
 	buildSecretLong = templates.LongDesc(`
-		Set or remove a build secret on a build config
+		Set or remove a build secret on a build config.
 
 		A build config can reference a secret to push or pull images from private registries or
 		to access private source repositories.
@@ -39,7 +39,7 @@ var (
 		be selected with the --all flag.`)
 
 	buildSecretExample = templates.Examples(`
-		# Clear push secret on a build config
+		# Clear the push secret on a build config
 		oc set build-secret --push --remove bc/mybuild
 
 		# Set the pull secret on a build config

--- a/pkg/cli/set/data.go
+++ b/pkg/cli/set/data.go
@@ -29,7 +29,7 @@ import (
 
 var (
 	dataLong = templates.LongDesc(`
-		Add, update, or remove data keys from secrets and config maps
+		Add, update, or remove data keys from secrets and config maps.
 
 		Secrets and config maps allow users to store keys and values that can be passed into
 		pods or loaded by other Kubernetes resources. This command lets you set or remove keys

--- a/pkg/cli/set/deploymenthook.go
+++ b/pkg/cli/set/deploymenthook.go
@@ -26,7 +26,7 @@ import (
 
 var (
 	deploymentHookLong = templates.LongDesc(`
-		Set or remove a deployment hook on a deployment config
+		Set or remove a deployment hook on a deployment config.
 
 		Deployment configs allow hooks to execute at different points in the lifecycle of the
 		deployment, depending on the deployment strategy.

--- a/pkg/cli/set/env.go
+++ b/pkg/cli/set/env.go
@@ -36,7 +36,7 @@ import (
 
 var (
 	envLong = templates.LongDesc(`
-		Update environment variables on a pod template or a build config
+		Update environment variables on a pod template or a build config.
 
 		List environment variable definitions in one or more pods, pod templates or build
 		configuration.

--- a/pkg/cli/set/imagelookup.go
+++ b/pkg/cli/set/imagelookup.go
@@ -26,7 +26,7 @@ import (
 
 var (
 	imageLookupLong = templates.LongDesc(`
-		Use an image stream from pods and other objects
+		Use an image stream from pods and other objects.
 
 		Image streams make it easy to tag images, track changes from other registries, and centralize
 		access control to images. Local name lookup allows an image stream to be the source of

--- a/pkg/cli/set/probe.go
+++ b/pkg/cli/set/probe.go
@@ -30,7 +30,7 @@ import (
 
 var (
 	probeLong = templates.LongDesc(`
-		Set or remove a liveness, readiness or startup probe from a pod or pod template
+		Set or remove a liveness, readiness or startup probe from a pod or pod template.
 
 		Each container in a pod may define one or more probes that are used for general health
 		checking. A liveness probe is checked periodically to ensure the container is still healthy:

--- a/pkg/cli/set/routebackends.go
+++ b/pkg/cli/set/routebackends.go
@@ -29,7 +29,7 @@ import (
 
 var (
 	backendsLong = templates.LongDesc(`
-		Set and adjust route backends
+		Set and adjust route backends.
 
 		Routes may have one or more optional backend services with weights controlling how much
 		traffic flows to each service. Traffic is assigned proportional to the combined weights

--- a/pkg/cli/set/set.go
+++ b/pkg/cli/set/set.go
@@ -107,7 +107,7 @@ func NewCmdImage(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra
 
 var (
 	setResourcesLong = ktemplates.LongDesc(`
-Specify compute resource requirements (cpu, memory) for any resource that defines a pod template. If a pod is successfully schedualed it is guaranteed the amount of resource requested, but may burst up to its specified limits.
+Specify compute resource requirements (cpu, memory) for any resource that defines a pod template. If a pod is successfully scheduled, it is guaranteed the amount of resource requested, but may burst up to its specified limits.
 
 For each compute resource, if a limit is specified and a request is omitted, the request will default to the limit.
 
@@ -115,21 +115,16 @@ Possible resources include (case insensitive):
 "ReplicationController", "Deployment", "DaemonSet", "Job", "ReplicaSet", "DeploymentConfigs"`)
 
 	setResourcesExample = ktemplates.Examples(`
-# Set a deployments nginx container cpu limits to "200m and memory to 512Mi"
-
+# Set a deployments nginx container CPU limits to "200m and memory to 512Mi"
 oc set resources deployment nginx -c=nginx --limits=cpu=200m,memory=512Mi
 
-
 # Set the resource request and limits for all containers in nginx
-
 oc set resources deployment nginx --limits=cpu=200m,memory=512Mi --requests=cpu=100m,memory=256Mi
 
 # Remove the resource requests for resources on containers in nginx
-
 oc set resources deployment nginx --limits=cpu=0,memory=0 --requests=cpu=0,memory=0
 
-# Print the result (in yaml format) of updating nginx container limits from a local, without hitting the server
-
+# Print the result (in YAML format) of updating nginx container limits locally, without hitting the server
 oc set resources -f path/to/file.yaml --limits=cpu=200m,memory=512Mi --local -o yaml`)
 )
 
@@ -149,10 +144,10 @@ of 'set selector'.
 
 A selector must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores, up to oc characters.
 If --resource-version is specified, then updates will use this resource version, otherwise the existing resource-version will be used.
-Note: currently selectors can only be set on Service objects.`)
+Note: currently selectors can only be set on service objects.`)
 
 	setSelectorExample = ktemplates.Examples(`
-# set the labels and selector before creating a deployment/service pair.
+# Set the labels and selector before creating a deployment/service pair.
 oc create service clusterip my-svc --clusterip="None" -o yaml --dry-run | oc set selector --local -f - 'environment=qa' -o yaml | oc create -f -
 oc create deployment my-dep -o yaml --dry-run | oc label --local -f - environment=qa -o yaml | oc create -f -`)
 )
@@ -172,10 +167,10 @@ Update ServiceAccount of pod template resources.
 `)
 
 	setServiceaccountExample = ktemplates.Examples(`
-# Set Deployment nginx-deployment's ServiceAccount to serviceaccount1
+# Set deployment nginx-deployment's service account to serviceaccount1
 oc set serviceaccount deployment nginx-deployment serviceaccount1
 
-# Print the result (in yaml format) of updated nginx deployment with serviceaccount from local file, without hitting apiserver
+# Print the result (in YAML format) of updated nginx deployment with service account from a local file, without hitting the API server
 oc set sa -f nginx-deployment.yaml serviceaccount1 --local --dry-run -o yaml
 `)
 )
@@ -191,16 +186,16 @@ func NewCmdServiceAccount(f kcmdutil.Factory, streams genericclioptions.IOStream
 
 var (
 	setSubjectLong = ktemplates.LongDesc(`
-Update User, Group or ServiceAccount in a RoleBinding/ClusterRoleBinding.`)
+Update user, group or service account in a role binding or cluster role binding.`)
 
 	setSubjectExample = ktemplates.Examples(`
-# Update a ClusterRoleBinding for serviceaccount1
+# Update a cluster role binding for serviceaccount1
 oc set subject clusterrolebinding admin --serviceaccount=namespace:serviceaccount1
 
-# Update a RoleBinding for user1, user2, and group1
+# Update a role binding for user1, user2, and group1
 oc set subject rolebinding admin --user=user1 --user=user2 --group=group1
 
-# Print the result (in yaml format) of updating rolebinding subjects from a local, without hitting the server
+# Print the result (in YAML format) of updating role binding subjects locally, without hitting the server
 oc create rolebinding admin --role=admin --user=admin -o yaml --dry-run | oc set subject --local -f - --user=foo -o yaml`)
 )
 

--- a/pkg/cli/set/triggers.go
+++ b/pkg/cli/set/triggers.go
@@ -42,7 +42,7 @@ import (
 
 var (
 	triggersLong = templates.LongDesc(`
-		Set or remove triggers
+		Set or remove triggers.
 
 		Build configs, deployment configs, and most Kubernetes workload objects may have a set of triggers
 		that result in a new deployment or build being created when an image changes. This command enables

--- a/pkg/cli/set/volume.go
+++ b/pkg/cli/set/volume.go
@@ -40,7 +40,7 @@ const (
 
 var (
 	volumeLong = templates.LongDesc(`
-		Update volumes on a pod template
+		Update volumes on a pod template.
 
 		This command can add, update or remove volumes from containers for any object
 		that has a pod template (deployment configs, replication controllers, or pods).

--- a/pkg/cli/startbuild/startbuild.go
+++ b/pkg/cli/startbuild/startbuild.go
@@ -51,7 +51,7 @@ import (
 
 var (
 	startBuildLong = templates.LongDesc(`
-		Start a build
+		Start a build.
 
 		This command starts a new build for the provided build config or copies an existing build using
 		--from-build=<name>. Pass the --follow flag to see output from the build.
@@ -81,11 +81,11 @@ var (
 		oc start-build hello-world --from-repo=../hello-world --commit=v2
 
 		# Start a new build for build config "hello-world" and watch the logs until the build
-		# completes or fails.
+		# completes or fails
 		oc start-build hello-world --follow
 
 		# Start a new build for build config "hello-world" and wait until the build completes. It
-		# exits with a non-zero return code if the build fails.
+		# exits with a non-zero return code if the build fails
 		oc start-build hello-world --wait
 	`)
 )

--- a/pkg/cli/status/status.go
+++ b/pkg/cli/status/status.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	statusLong = templates.LongDesc(`
-		Show a high level overview of the current project
+		Show a high level overview of the current project.
 
 		This command will show services, deployment configs, build configurations, and active deployments.
 		If you have any misconfigured components information about them will be shown. For more information
@@ -38,13 +38,13 @@ var (
 		graph in DOT format that is suitable for use by the "dot" command.`)
 
 	statusExample = templates.Examples(`
-		# See an overview of the current project.
+		# See an overview of the current project
 		oc status
 
-		# Export the overview of the current project in an svg file.
+		# Export the overview of the current project in an svg file
 		oc status -o dot | dot -T svg -o project.svg
 
-		# See an overview of the current project including details for any identified issues.
+		# See an overview of the current project including details for any identified issues
 		oc status --suggest`)
 )
 

--- a/pkg/cli/tag/tag.go
+++ b/pkg/cli/tag/tag.go
@@ -48,7 +48,7 @@ type TagOptions struct {
 
 var (
 	tagLong = templates.LongDesc(`
-		Tag existing images into image streams
+		Tag existing images into image streams.
 
 		The tag command allows you to take an existing tag or image from an image
 		stream, or a container image pull spec, and set it as the most recent image for a
@@ -62,19 +62,19 @@ var (
 		container images.`)
 
 	tagExample = templates.Examples(`
-		# Tag the current image for the image stream 'openshift/ruby' and tag '2.0' into the image stream 'yourproject/ruby with tag 'tip'.
+		# Tag the current image for the image stream 'openshift/ruby' and tag '2.0' into the image stream 'yourproject/ruby with tag 'tip'
 		oc tag openshift/ruby:2.0 yourproject/ruby:tip
 
-		# Tag a specific image.
+		# Tag a specific image
 		oc tag openshift/ruby@sha256:6b646fa6bf5e5e4c7fa41056c27910e679c03ebe7f93e361e6515a9da7e258cc yourproject/ruby:tip
 
-		# Tag an external container image.
+		# Tag an external container image
 		oc tag --source=docker openshift/origin-control-plane:latest yourproject/ruby:tip
 
-		# Tag an external container image and request pullthrough for it.
+		# Tag an external container image and request pullthrough for it
 		oc tag --source=docker openshift/origin-control-plane:latest yourproject/ruby:tip --reference-policy=local
 
-		# Remove the specified spec tag from an image stream.
+		# Remove the specified spec tag from an image stream
 		oc tag openshift/origin-control-plane:latest -d`)
 )
 

--- a/pkg/cli/version/version.go
+++ b/pkg/cli/version/version.go
@@ -37,11 +37,13 @@ var (
 		Pass --client to print only the OpenShift client version.
 	`)
 	versionExample = templates.Examples(`
-		# Print the OpenShift client, kube-apiserver, and openshift-apiserver version information for the current context.
+		# Print the OpenShift client, kube-apiserver, and openshift-apiserver version information for the current context
 		oc version
-		# Print the OpenShift client, kube-apiserver, and openshift-apiserver version numbers for the current context.
+
+		# Print the OpenShift client, kube-apiserver, and openshift-apiserver version numbers for the current context
 		oc version --short
-		# Print the OpenShift client version information for the current context.
+
+		# Print the OpenShift client version information for the current context
 		oc version --client
 	`)
 )


### PR DESCRIPTION
Minor grammatical and punctuation consistency updates to oc-specific CLI commands. Short descriptions and comments in examples do not use ending punctuation; long descriptions do use ending punctuation.

https://issues.redhat.com/browse/OSDOCS-2018
https://issues.redhat.com/browse/OSDOCS-1790