### PR TITLE
OSDOCS-2033: Adding examples for some CLI commands

### DIFF
--- a/pkg/cli/admin/createbootstrapprojecttemplate/create_bootstrap_project_template.go
+++ b/pkg/cli/admin/createbootstrapprojecttemplate/create_bootstrap_project_template.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/cli-runtime/pkg/printers"
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
+	"k8s.io/kubectl/pkg/util/templates"
 )
 
 type CreateBootstrapProjectTemplateOptions struct {
@@ -22,6 +23,11 @@ type CreateBootstrapProjectTemplateOptions struct {
 	genericclioptions.IOStreams
 }
 
+var createBootstrapProjectTemplateExample = templates.Examples(`
+	# Output a bootstrap project template in YAML format to stdout
+	oc adm create-bootstrap-project-template -o yaml
+`)
+
 func NewCreateBootstrapProjectTemplateOptions(streams genericclioptions.IOStreams) *CreateBootstrapProjectTemplateOptions {
 	return &CreateBootstrapProjectTemplateOptions{
 		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme).WithDefaultOutput("json"),
@@ -33,8 +39,9 @@ func NewCreateBootstrapProjectTemplateOptions(streams genericclioptions.IOStream
 func NewCommandCreateBootstrapProjectTemplate(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
 	o := NewCreateBootstrapProjectTemplateOptions(streams)
 	cmd := &cobra.Command{
-		Use:   "create-bootstrap-project-template",
-		Short: "Create a bootstrap project template",
+		Use:     "create-bootstrap-project-template",
+		Short:   "Create a bootstrap project template",
+		Example: createBootstrapProjectTemplateExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			kcmdutil.CheckErr(o.Complete(args))
 			kcmdutil.CheckErr(o.Validate())

--- a/pkg/cli/admin/createerrortemplate/create_error_template.go
+++ b/pkg/cli/admin/createerrortemplate/create_error_template.go
@@ -26,6 +26,11 @@ var errorLongDescription = templates.LongDesc(`
 		        error: templates/error.html
 		`)
 
+var errorExample = templates.Examples(`
+	# Output a template for the error page to stdout
+	oc adm create-error-template
+`)
+
 type CreateErrorTemplateOptions struct {
 	genericclioptions.IOStreams
 }
@@ -39,9 +44,10 @@ func NewCreateErrorTemplateOptions(streams genericclioptions.IOStreams) *CreateE
 func NewCommandCreateErrorTemplate(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
 	o := NewCreateErrorTemplateOptions(streams)
 	cmd := &cobra.Command{
-		Use:   "create-error-template",
-		Short: "Create an error page template",
-		Long:  errorLongDescription,
+		Use:     "create-error-template",
+		Short:   "Create an error page template",
+		Long:    errorLongDescription,
+		Example: errorExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			kcmdutil.CheckErr(o.Validate(args))
 			kcmdutil.CheckErr(o.Run())

--- a/pkg/cli/admin/createlogintemplate/create_login_template.go
+++ b/pkg/cli/admin/createlogintemplate/create_login_template.go
@@ -27,6 +27,11 @@ var longDescription = templates.LongDesc(`
 	        login: templates/login.html
 	`)
 
+var loginExample = templates.Examples(`
+	# Output a template for the login page to stdout
+	oc adm create-login-template
+`)
+
 type CreateLoginTemplateOptions struct {
 	genericclioptions.IOStreams
 }
@@ -40,9 +45,10 @@ func NewCreateLoginTemplateOptions(streams genericclioptions.IOStreams) *CreateL
 func NewCommandCreateLoginTemplate(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
 	o := NewCreateLoginTemplateOptions(streams)
 	cmd := &cobra.Command{
-		Use:   "create-login-template",
-		Short: "Create a login template",
-		Long:  longDescription,
+		Use:     "create-login-template",
+		Short:   "Create a login template",
+		Long:    longDescription,
+		Example: loginExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			kcmdutil.CheckErr(o.Validate(args))
 			kcmdutil.CheckErr(o.Run())

--- a/pkg/cli/admin/createproviderselectiontemplate/create_provider_selection_template.go
+++ b/pkg/cli/admin/createproviderselectiontemplate/create_provider_selection_template.go
@@ -27,6 +27,11 @@ var providerSelectionLongDescription = templates.LongDesc(`
 	        providerSelection: templates/provider-selection.html
 	`)
 
+var providerSelectionExample = templates.Examples(`
+	# Output a template for the provider selection page to stdout
+	oc adm create-provider-selection-template
+`)
+
 type CreateProviderSelectionTemplateOptions struct {
 	genericclioptions.IOStreams
 }
@@ -40,9 +45,10 @@ func NewCreateProviderSelectionTemplateOptions(streams genericclioptions.IOStrea
 func NewCommandCreateProviderSelectionTemplate(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
 	o := NewCreateProviderSelectionTemplateOptions(streams)
 	cmd := &cobra.Command{
-		Use:   "create-provider-selection-template",
-		Short: "Create a provider selection template",
-		Long:  providerSelectionLongDescription,
+		Use:     "create-provider-selection-template",
+		Short:   "Create a provider selection template",
+		Long:    providerSelectionLongDescription,
+		Example: providerSelectionExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			kcmdutil.CheckErr(o.Validate(args))
 			kcmdutil.CheckErr(o.Run())

--- a/pkg/cli/admin/project/new_project.go
+++ b/pkg/cli/admin/project/new_project.go
@@ -52,6 +52,11 @@ var newProjectLong = templates.LongDesc(`
 	an admin user (and role, if you want to use a non-default admin role), and a node selector
 	to restrict which nodes pods in this project can be scheduled to.`)
 
+var newProjectExample = templates.Examples(`
+	# Create a new project using a node selector
+	oc adm new-project myproject --node-selector='type=user-node,region=east'
+`)
+
 func NewNewProjectOptions(streams genericclioptions.IOStreams) *NewProjectOptions {
 	return &NewProjectOptions{
 		AdminRole: "admin",
@@ -63,9 +68,10 @@ func NewNewProjectOptions(streams genericclioptions.IOStreams) *NewProjectOption
 func NewCmdNewProject(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
 	o := NewNewProjectOptions(streams)
 	cmd := &cobra.Command{
-		Use:   "new-project NAME [--display-name=DISPLAYNAME] [--description=DESCRIPTION]",
-		Short: "Create a new project",
-		Long:  newProjectLong,
+		Use:     "new-project NAME [--display-name=DISPLAYNAME] [--description=DESCRIPTION]",
+		Short:   "Create a new project",
+		Long:    newProjectLong,
+		Example: newProjectExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			kcmdutil.CheckErr(o.Complete(f, cmd, args))
 			kcmdutil.CheckErr(o.Run())

--- a/pkg/cli/projects/projects.go
+++ b/pkg/cli/projects/projects.go
@@ -62,15 +62,21 @@ var (
 
 		For advanced configuration, or to manage the contents of your config file, use the 'config'
 		command.`)
+
+	projectsExample = templates.Examples(`
+		# List all projects
+		oc projects
+	`)
 )
 
 // NewCmdProjects implements the OpenShift cli rollback command
 func NewCmdProjects(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
 	o := NewProjectsOptions(streams)
 	cmd := &cobra.Command{
-		Use:   "projects",
-		Short: "Display existing projects",
-		Long:  projectsLong,
+		Use:     "projects",
+		Short:   "Display existing projects",
+		Long:    projectsLong,
+		Example: projectsExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			kcmdutil.CheckErr(o.Complete(f, cmd, args))
 			kcmdutil.CheckErr(o.Validate())

--- a/pkg/cli/whoami/whoami.go
+++ b/pkg/cli/whoami/whoami.go
@@ -31,6 +31,11 @@ var whoamiLong = templates.LongDesc(`
 	or an empty string.  Other flags support returning the currently used token or the
 	user context.`)
 
+var whoamiExample = templates.Examples(`
+	# Display the currently authenticated user
+	oc whoami
+`)
+
 type WhoAmIOptions struct {
 	UserInterface userv1typedclient.UserV1Interface
 
@@ -56,9 +61,10 @@ func NewCmdWhoAmI(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobr
 	o := NewWhoAmIOptions(streams)
 
 	cmd := &cobra.Command{
-		Use:   "whoami",
-		Short: "Return information about the current session",
-		Long:  whoamiLong,
+		Use:     "whoami",
+		Short:   "Return information about the current session",
+		Long:    whoamiLong,
+		Example: whoamiExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			kcmdutil.CheckErr(o.Complete(f))
 			kcmdutil.CheckErr(o.Validate())


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2033

For now, I've just done the ones that we already had existing examples for in the current CLI docs: 
* https://docs.openshift.com/container-platform/4.7/cli_reference/openshift_cli/developer-cli-commands.html
* https://docs.openshift.com/container-platform/4.7/cli_reference/openshift_cli/administrator-cli-commands.html

/assign @soltysh 