### PR TITLE
pkg/cli/admin/release/info: Add caveat for baked-in update sources

### DIFF
--- a/pkg/cli/admin/release/info.go
+++ b/pkg/cli/admin/release/info.go
@@ -1200,6 +1200,7 @@ func describeReleaseInfo(out io.Writer, release *ReleaseInfo, showCommit, showCo
 		fmt.Fprintf(w, "  Version:\t%s\n", m.Version)
 		if len(m.Previous) > 0 {
 			fmt.Fprintf(w, "  Upgrades:\t%s\n", strings.Join(sortSemanticVersions(m.Previous), ", "))
+			fmt.Fprint(w, "    Upgrades from these versions were expected when the release image was built, but may not be currently recommended for a cluster by its configured update service.\n")
 		} else {
 			fmt.Fprintf(w, "  Upgrades:\t<none>\n")
 		}


### PR DESCRIPTION
We've occasionally had folks look at this previous-version set and then wonder why their cluster, whose version was included in the set, was not being recommended an update to the new release.  The new wording will remind folks that update services may not recommending those updates.  In most cases, I expect that to be "Red Hat's central update service has decided to [block the edge][1]", but folks could also be pointing at update services that completely ignore the baked-in update metadata.  I'm aiming to say something that's generic and true, but which is hopefully still concrete enough to keep folks from taking the data as a commited set of current recommendations.

[1]: https://github.com/openshift/cincinnati-graph-data/tree/ce8236f69bf66ac1e5442508e715e3bc636e8fc9#block-edges