### PR TITLE
Bug 1952230: pkg/cli/admin/upgrade: Always run all client-side checks

### DIFF
--- a/pkg/cli/admin/upgrade/upgrade_test.go
+++ b/pkg/cli/admin/upgrade/upgrade_test.go
@@ -1,6 +1,7 @@
 package upgrade
 
 import (
+	"errors"
 	"math/rand"
 	"reflect"
 	"testing"
@@ -27,5 +28,51 @@ func TestSortSemanticVersions(t *testing.T) {
 	sortSemanticVersions(actual)
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("%v != %v", actual, expected)
+	}
+}
+
+func TestCheckForUpgrade(t *testing.T) {
+	for _, testCase := range []struct {
+		name       string
+		conditions []configv1.ClusterOperatorStatusCondition
+		expected   error
+	}{
+		{
+			name: "no conditions",
+		},
+		{
+			name: "invalid",
+			conditions: []configv1.ClusterOperatorStatusCondition{{
+				Type:    configv1.ClusterStatusConditionType("Invalid"),
+				Status:  configv1.ConditionTrue,
+				Reason:  "SomeReason",
+				Message: "Some message.",
+			}},
+			expected: errors.New("the cluster version object is invalid, you must correct the invalid state first:\n\n  Reason: SomeReason\n  Message: Some message.\n\n"),
+		},
+		{
+			name: "degraded and progressing",
+			conditions: []configv1.ClusterOperatorStatusCondition{{
+				Type:    configv1.OperatorProgressing,
+				Status:  configv1.ConditionTrue,
+				Reason:  "RollingOut",
+				Message: "Updating to v2.",
+			}, {
+				Type:    configv1.OperatorDegraded,
+				Status:  configv1.ConditionTrue,
+				Reason:  "BadStuff",
+				Message: "The widgets are slow.",
+			}},
+			expected: errors.New("the cluster is experiencing an upgrade-blocking error:\n\n  Reason: BadStuff\n  Message: The widgets are slow.\n\nthe cluster is already upgrading:\n\n  Reason: RollingOut\n  Message: Updating to v2.\n\n"),
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			clusterVersion := &configv1.ClusterVersion{}
+			clusterVersion.Status.Conditions = testCase.conditions
+			actual := checkForUpgrade(clusterVersion)
+			if !reflect.DeepEqual(actual, testCase.expected) {
+				t.Errorf("%v != %v", actual, testCase.expected)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Since it landed in cd30f2f864, `oc adm upgrade` has had client-side guards .  Those guards were then, and until this commit still were, sequential, so the caller would only hear about the first guard that fails.  Then the user will be prompted, with modern `oc`, to set `--allow-upgrade-with-warnings` to waive the warnings.  This commit adjusts `checkForUpgrade` to complain about all failing checks, so the user can see all the guards they're waiving before the set the override (and also to see all the guards they waived if the do set the override).