### PR TITLE
Bug 1937020: Releases from image streams must prefer status tag

### DIFF
--- a/pkg/cli/admin/release/new.go
+++ b/pkg/cli/admin/release/new.go
@@ -820,11 +820,10 @@ func resolveImageStreamTagsToReferenceMode(inputIS, is *imageapi.ImageStream, re
 					if generation > newest.Generation {
 						return fmt.Errorf("the tag %q in the source input stream has not been imported yet", statusRef.Tag)
 					}
-					// status tags that are newer should be chosen over the spec tag, otherwise we
-					// process them here depending on the type of tag
-					if generation < newest.Generation {
-						continue
-					}
+					// status tags should be used over spec tags because a push to a status tag can happen right after a
+					// spec tag was imported, so the status tag items have two images at generation N. Status tags always
+					// win except when the latest status tag hasn't been imported, which means "wait"
+					continue
 				}
 			}
 


### PR DESCRIPTION
In the previous change a key scenario was omitted. An image stream
tag might have the form:

```
spec:
  tags:
  - name: foo
    generation: 5
    from: {name: "image1"}
status:
  tags:
  - tag: foo
    items:
    - generation: 5
      image: image2
    - generation: 5
      image: image1
```

because a push happened immediately after a spec tagging (generation
only changes on import). Switch oc adm release new to always prefer
status tag, and to let the image stream decide what pull spec should
be used.