### PR TITLE
Bug 1957295: Must gather pod should have priority class

### DIFF
--- a/pkg/cli/admin/mustgather/mustgather.go
+++ b/pkg/cli/admin/mustgather/mustgather.go
@@ -606,8 +606,12 @@ func (o *MustGatherOptions) newPod(node, image string) *corev1.Pod {
 			},
 		},
 		Spec: corev1.PodSpec{
-			NodeName:      node,
-			RestartPolicy: corev1.RestartPolicyNever,
+			NodeName: node,
+			// This pod is ok to be OOMKilled but not preempted. Following the conventions mentioned at:
+			// https://github.com/openshift/enhancements/blob/master/CONVENTIONS.md#priority-classes
+			// so setting priority class to system-cluster-critical
+			PriorityClassName: "system-cluster-critical",
+			RestartPolicy:     corev1.RestartPolicyNever,
 			Volumes: []corev1.Volume{
 				{
 					Name: "must-gather-output",


### PR DESCRIPTION
Must-gather pod should not preemptable but it
is ok to be OOMKilled if there is resource
crunch on the node. So, it should have a
priority class of `system-cluster-critical`