### PR TITLE
print the docker file path

### DIFF
--- a/pkg/helpers/image/credentialprovider/config.go
+++ b/pkg/helpers/image/credentialprovider/config.go
@@ -147,6 +147,7 @@ func ReadSpecificDockerConfigJSONFile(filePath string) (cfg DockerConfig, err er
 	if contents, err = ioutil.ReadFile(filePath); err != nil {
 		return nil, err
 	}
+	klog.V(4).Infof("start to read Docker Config JSON file: %s", filePath)
 	return readDockerConfigJSONFileFromBytes(contents)
 }
 


### PR DESCRIPTION
When debugging the `oc adm catalog mirror` issues, I used the `--loglevel=8`, but it only display the default docker config file, it's very confusing.
```yaml
[root@preserve-olm-env jian]# ./oc adm catalog mirror --loglevel=8 --index-filter-by-os='.*' quay.io/openshifttest/etcd-index:latest ec2-3-133-132-46.us-east-2.compute.amazonaws.com:5000 --to-manifests=etcd-mirror  --manifests-only -a ./mirror_docker.json --insecure
I0517 10:30:31.607485   26012 config.go:128] looking for config.json at /root/.docker/config.json
I0517 10:30:31.607824   26012 config.go:136] found valid config.json at /root/.docker/config.json
F0517 10:30:31.607971   26012 helpers.go:115] error: unable to load --registry-config: error occurred while trying to unmarshal json
goroutine 1 [running]:
k8s.io/klog/v2.stacks(0xc000010001, 0xc000fca780, 0x85, 0xb4)
        /go/src/github.com/openshift/oc/vendor/k8s.io/klog/v2/klog.go:1021 +0xb9
k8s.io/klog/v2.(*loggingT).output(0x5948140, 0xc000000003, 0x0, 0x0, 0xc000316070, 0x47e9b85, 0xa, 0x73, 0x1136700)
...
```
So, I submitted this PR to print the exact used docker config file.
```yaml
[root@preserve-olm-env jian]# ./oc version
Client Version: 4.8.0-0.nightly-2021-05-15-141455
```