### PR TITLE
Bug 1960758: use recent pull spec for must-gather and debug

### DIFF
--- a/pkg/cli/admin/mustgather/mustgather.go
+++ b/pkg/cli/admin/mustgather/mustgather.go
@@ -210,9 +210,8 @@ func (o *MustGatherOptions) resolveImageStreamTag(namespace, name, tag string) (
 		return "", err
 	}
 	var image string
-	var ok bool
-	if image, ok = imageutil.ResolveLatestTaggedImage(imageStream, tag); !ok {
-		return "", fmt.Errorf("unable to resolve the imagestream tag %s/%s:%s", namespace, name, tag)
+	if image, _, _, _, err = imageutil.ResolveRecentPullSpecForTag(imageStream, tag, false); err != nil {
+		return "", fmt.Errorf("unable to resolve the imagestream tag %s/%s:%s: %v", namespace, name, tag, err)
 	}
 	return image, nil
 }

--- a/pkg/cli/debug/debug.go
+++ b/pkg/cli/debug/debug.go
@@ -1144,9 +1144,8 @@ func (o *DebugOptions) resolveImageStreamTag(namespace, name, tag string) (strin
 		return "", err
 	}
 	var image string
-	var ok bool
-	if image, ok = imageutil.ResolveLatestTaggedImage(imageStream, tag); !ok {
-		return "", fmt.Errorf("unable to resolve the imagestream tag %s/%s:%s", namespace, name, tag)
+	if image, _, _, _, err = imageutil.ResolveRecentPullSpecForTag(imageStream, tag, false); err != nil {
+		return "", fmt.Errorf("unable to resolve the imagestream tag %s/%s:%s: %v", namespace, name, tag, err)
 	}
 	return image, nil
 }


### PR DESCRIPTION
/assign @smarterclayton 

This builds on top of methods introduced in https://github.com/openshift/library-go/pull/1078/

/cc @dmage @ricardomaraschini 
since you two will be also interested in usage