### PR TITLE
Bug 1893999: guide user to provide username with basic auth error/only password IDP and no username provided

### DIFF
--- a/pkg/helpers/tokencmd/basicauth.go
+++ b/pkg/helpers/tokencmd/basicauth.go
@@ -14,12 +14,13 @@ import (
 	"github.com/openshift/oc/pkg/helpers/term"
 )
 
-// BasicAuthNoUsernameError is an error that means that basic authentication challenge handling was attempted
+// BasicAuthNoUsernameError when basic authentication challenge handling was attempted
 // but the required username was not provided from the command line options
 type BasicAuthNoUsernameError struct{}
 
+//
 func (e *BasicAuthNoUsernameError) Error() string {
-	return "did not receive username - print token url instead of basic prompt"
+	return "did not receive username. Pass 'oc login --username <username>' for the password prompt"
 }
 
 // NewBasicAuthNoUsernameError returns an error for a basic challenge without a username

--- a/pkg/helpers/tokencmd/request_token.go
+++ b/pkg/helpers/tokencmd/request_token.go
@@ -237,7 +237,7 @@ func (o *RequestTokenOptions) RequestToken() (string, error) {
 				if err != nil {
 					if _, ok := err.(*BasicAuthNoUsernameError); ok {
 						tokenPromptErr := apierrs.NewUnauthorized(BasicAuthNoUsernameMessage)
-						klog.V(4).Infof("%v", err)
+						klog.V(2).Infof("%v", err)
 						tokenPromptErr.ErrStatus.Details = &metav1.StatusDetails{
 							Causes: []metav1.StatusCause{
 								{Message: fmt.Sprintf("You must obtain an API token by visiting %s/request", o.OsinConfig.TokenUrl)},


### PR DESCRIPTION
This PR bumps printing error for BasicAuthNoUsernameError to v=2 from v=4. Also, adds a bit to guide users to provide a username for the password prompt. 

Fixes https://github.com/openshift/oc/issues/817