### PR TITLE
Bug 1964936: fix error log for "oc adm catalog mirror"

### DIFF
--- a/pkg/cli/admin/catalog/mirror.go
+++ b/pkg/cli/admin/catalog/mirror.go
@@ -223,7 +223,7 @@ func (o *MirrorCatalogOptions) Complete(cmd *cobra.Command, args []string) error
 				fmt.Fprintf(w, "  %s\t%s\n", imagemanifest.PlatformSpecString(manifest.Platform), manifest.Digest)
 			}
 			w.Flush()
-			return nil, fmt.Errorf("the image is a manifest list and contains multiple images - use --filter-by-os to select from:\n\n%s\n", buf.String())
+			return nil, fmt.Errorf("the image is a manifest list and contains multiple images - use --index-filter-by-os to select from:\n\n%s\n", buf.String())
 		},
 
 		ImageMetadataCallback: func(from string, i *info.Image, err error) error {


### PR DESCRIPTION
since the "--filter-by-os" is deprecated, the error log should be "--index-filter-by-os"

[root@preserve-olm-agent-test openshift-tests-private]# oc adm catalog mirror  --index-filter-by-os='linux/abc'  registry.redhat.io/redhat/redhat-operator-index:v4.6 localhost:5000 --manifests-only 
error: the image is a manifest list and contains multiple images - use **--filter-by-os** to select from:

  OS            DIGEST
  linux/amd64   sha256:4f0299265620cb29f8010308b0cfac15a8d3fe22b0422f1fdbb86ad5a3383b2a
  linux/ppc64le sha256:9959915cad81b4f2b5c14316ec95980f5fd64b38ea6a1f35bcf4183f5c6147ef
  linux/s390x   sha256:a57764ff56ec696f372810b1202988cb0a71fc1482b13a1726e9d4e9d74715bc