### PR TITLE
Re-use DialContext and Proxy configuration from original http.Transport

### DIFF
--- a/pkg/helpers/tokencmd/request_token.go
+++ b/pkg/helpers/tokencmd/request_token.go
@@ -427,7 +427,7 @@ func transportWithSystemRoots(issuer string, clientConfig *restclient.Config) (h
 	// perform the retrieval with insecure transport, otherwise oauth-server
 	// logs remote tls error which is confusing during troubleshooting
 	client := http.Client{
-		Transport: insecureTransport(issuerURL),
+		Transport: insecureTransport(clientConfig.Transport, issuerURL),
 	}
 	resp, err := client.Head(issuer)
 	if err != nil {
@@ -493,13 +493,21 @@ func verifyServerCertChain(dnsName string, chain []*x509.Certificate) ([][]*x509
 	})
 }
 
-func insecureTransport(issuerURL *url.URL) *http.Transport {
+func insecureTransport(roundTripper http.RoundTripper, issuerURL *url.URL) *http.Transport {
+	tlsConfig := &tls.Config{
+		Certificates:       []tls.Certificate{},
+		InsecureSkipVerify: true,
+		ServerName:         issuerURL.Hostname(),
+	}
+	if transport, ok := roundTripper.(*http.Transport); ok {
+		return &http.Transport{
+			Proxy:           transport.Proxy,
+			DialContext:     transport.DialContext,
+			TLSClientConfig: tlsConfig,
+		}
+	}
 	return &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		TLSClientConfig: &tls.Config{
-			Certificates:       []tls.Certificate{},
-			InsecureSkipVerify: true,
-			ServerName:         issuerURL.Hostname(),
-		},
+		Proxy:           http.ProxyFromEnvironment,
+		TLSClientConfig: tlsConfig,
 	}
 }

--- a/pkg/helpers/tokencmd/request_token.go
+++ b/pkg/helpers/tokencmd/request_token.go
@@ -427,14 +427,7 @@ func transportWithSystemRoots(issuer string, clientConfig *restclient.Config) (h
 	// perform the retrieval with insecure transport, otherwise oauth-server
 	// logs remote tls error which is confusing during troubleshooting
 	client := http.Client{
-		Transport: &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-			TLSClientConfig: &tls.Config{
-				Certificates:       []tls.Certificate{},
-				InsecureSkipVerify: true,
-				ServerName:         issuerURL.Hostname(),
-			},
-		},
+		Transport: insecureTransport(issuerURL),
 	}
 	resp, err := client.Head(issuer)
 	if err != nil {
@@ -498,4 +491,15 @@ func verifyServerCertChain(dnsName string, chain []*x509.Certificate) ([][]*x509
 		Intermediates: intermediates,
 		DNSName:       dnsName,
 	})
+}
+
+func insecureTransport(issuerURL *url.URL) *http.Transport {
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		TLSClientConfig: &tls.Config{
+			Certificates:       []tls.Certificate{},
+			InsecureSkipVerify: true,
+			ServerName:         issuerURL.Hostname(),
+		},
+	}
 }


### PR DESCRIPTION
crc uses tokencmd package to generate the kubeconfig directly after the VM is started.
To avoid DNS issues on the host, we force the http.Transport to use the IP of the VM by passing a function to DialContext (see below).

It appears that, for root CAs verification, a http.Client is built from scratch and doesn't use the given http.Transport. 
Since it doesn't use the custom DialContext function, a DNS resolution is performed in my case.

```go
	tokencmd.RequestToken(&restclient.Config{
		Transport: &http.Transport{
			DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
				port := strings.SplitN(address, ":", 2)[1]
				dialer := net.Dialer{
					Timeout:   30 * time.Second,
					KeepAlive: 30 * time.Second,
				}
				return dialer.Dial(network, fmt.Sprintf("127.0.0.1:%s", port))
			},
		},
	}, nil, username, password)
```