### PR TITLE
OCPBUGS-10615: debug node: Run under an unconfined SELinux context

### DIFF
--- a/pkg/cli/debug/debug.go
+++ b/pkg/cli/debug/debug.go
@@ -1045,6 +1045,12 @@ func (o *DebugOptions) approximatePodTemplateForObject(object runtime.Object) (*
 						SecurityContext: &corev1.SecurityContext{
 							Privileged: &isTrue,
 							RunAsUser:  &zero,
+							SELinuxOptions: &corev1.SELinuxOptions{
+								User:  "unconfined_u",
+								Role:  "unconfined_r",
+								Type:  "unconfined_t",
+								Level: "s0-s0:c0.c1023",
+							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
 							{


### PR DESCRIPTION
Run the node debug pod under an unconfined SELinux context
(unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023) to avoid issues
with the `spc_t` context.

Fixes: https://github.com/openshift/oc/issues/641
See also:
 - https://bugzilla.redhat.com/show_bug.cgi?id=1839065
 - https://bugzilla.redhat.com/show_bug.cgi?id=1896369