### PR TITLE
[release-4.7] Bug 1970458: skip-multiple-scopes with adm catalog mirror

### DIFF
--- a/pkg/cli/admin/catalog/mirror.go
+++ b/pkg/cli/admin/catalog/mirror.go
@@ -285,6 +285,7 @@ func (o *MirrorCatalogOptions) Complete(cmd *cobra.Command, args []string) error
 		a.ParallelOptions = o.ParallelOptions
 		a.KeepManifestList = true
 		a.Mappings = mappings
+		a.SkipMultipleScopes = true
 		if err := a.Validate(); err != nil {
 			fmt.Fprintf(o.IOStreams.ErrOut, "error configuring image mirroring: %v\n", err)
 		}


### PR DESCRIPTION
Manual cherry-pick of 2nd commit from #780 

'oc adm catalog mirror' often fails with server error
'414 Request-URI Too Large' This is because mirroring the
catalog pushes a lot of content in parallel. To avoid this,
set the mirroring flag --skip-multiple-scopes to true.

/assign @ravisantoshgudimetla 