### PR TITLE
Support ibmcloud provider in release extract

### DIFF
--- a/pkg/cli/admin/release/extract.go
+++ b/pkg/cli/admin/release/extract.go
@@ -41,6 +41,7 @@ var (
 		"azure":     "AzureProviderSpec",
 		"openstack": "OpenStackProviderSpec",
 		"gcp":       "GCPProviderSpec",
+		"ibmcloud":  "IBMCloudProviderSpec",
 		"ovirt":     "OvirtProviderSpec",
 		"vsphere":   "VSphereProviderSpec",
 	}
@@ -80,7 +81,7 @@ func NewExtract(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.
 
 			The --credentials-requests flag filters extracted manifests to only cloud credential
 			requests. The --cloud flag further filters credential requests to a specific cloud.
-			Valid values for --cloud include aws, gcp, azure, openstack, ovirt, and vsphere.
+			Valid values for --cloud include aws, gcp, ibmcloud, azure, openstack, ovirt, and vsphere.
 
 			Instead of extracting the manifests, you can specify --git=DIR to perform a Git
 			checkout of the source code that comprises the release. A warning will be printed


### PR DESCRIPTION
This PR enables "ibmcloud" to be specified as part of the cloud argument to `oc adm release extract". An example would look like this:
```sh
oc adm release extract --credentials-requests --cloud=ibmcloud --to=./credrequests <RELEASE_IMAGE>
```

This is related to this CCO PR: https://github.com/openshift/cloud-credential-operator/pull/356 
...and this enhancement: https://github.com/openshift/enhancements/pull/773