### PR TITLE
Bug 1978629: Add oc describe output for build volumes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /genman
 /_output
 .idea/
+_tmp/


### PR DESCRIPTION
Adding `oc describe` output for build volumes
Adding tests for `oc describe` output for build volumes
Adding `_tmp` to .gitignore

Sample `oc describe` output for a build config: https://pastebin.com/1TeAfvku
Sample `oc describe` output for a build: https://pastebin.com/vEDEUhhq