### PR TITLE
Bug 1971332: revert incorrect allowance of ssh:// prefix with scp styled URLs

### DIFF
--- a/pkg/helpers/source-to-image/git/url.go
+++ b/pkg/helpers/source-to-image/git/url.go
@@ -86,8 +86,6 @@ func splitOnByte(s string, c byte) (string, string) {
 // Parse parses a "Git URL"
 func Parse(rawurl string) (*URL, error) {
 	if urlSchemeRegexp.MatchString(rawurl) &&
-		// at least through golang 1.14.9, url.Parse cannot handle ssh://git@github.com:sclorg/nodejs-ex
-		!strings.HasPrefix(rawurl, "ssh://") &&
 		(runtime.GOOS != "windows" || !dosDriveRegexp.MatchString(rawurl)) {
 		u, err := url.Parse(rawurl)
 		if err != nil {
@@ -106,12 +104,6 @@ func Parse(rawurl string) (*URL, error) {
 			URL:  *u,
 			Type: URLTypeURL,
 		}, nil
-	}
-
-	// if ssh://git@github.com:sclorg/nodejs-ex then strip ssh:// a la what we
-	// see in other upstream git parsing handling of scp styled git URLs;
-	if strings.HasPrefix(rawurl, "ssh://") {
-		rawurl = strings.Trim(rawurl, "ssh://")
 	}
 
 	s, fragment := splitOnByte(rawurl, '#')

--- a/pkg/helpers/source-to-image/git/url_test.go
+++ b/pkg/helpers/source-to-image/git/url_test.go
@@ -10,7 +10,6 @@ import (
 
 type parseTest struct {
 	rawurl         string
-	ammendedRawURL string
 	expectedGitURL *URL
 	expectedError  bool
 }
@@ -186,15 +185,19 @@ func TestParse(t *testing.T) {
 			},
 		},
 		parseTest{
-			rawurl:         "ssh://git@github.com:sclorg/nodejs-ex",
-			ammendedRawURL: "git@github.com:sclorg/nodejs-ex",
+			rawurl:        "ssh://git@github.com:sclorg/nodejs-ex",
+			expectedError: true,
+		},
+		parseTest{
+			rawurl: "ssh://git@github.com:22/user/repo.git",
 			expectedGitURL: &URL{
 				URL: url.URL{
-					User: url.User("git"),
-					Host: "github.com",
-					Path: "sclorg/nodejs-ex",
+					Scheme: "ssh",
+					User:   url.User("git"),
+					Host:   "github.com:22",
+					Path:   "/user/repo.git",
 				},
-				Type: URLTypeSCP,
+				Type: URLTypeURL,
 			},
 			expectedError: false,
 		},
@@ -235,24 +238,14 @@ func TestParse(t *testing.T) {
 			t.Errorf("%s: Parse() returned\n\t%#v\nWanted\n\t%#v", test.rawurl, parsedURL, test.expectedGitURL)
 		}
 
-		if len(test.ammendedRawURL) > 0 {
-			if parsedURL.String() != test.ammendedRawURL {
-				t.Errorf("%s: String() returned %s", test.ammendedRawURL, parsedURL.String())
-			}
-
-			if parsedURL.StringNoFragment() != strings.SplitN(test.ammendedRawURL, "#", 2)[0] {
-				t.Errorf("%s: StringNoFragment() returned %s", test.ammendedRawURL, parsedURL.StringNoFragment())
-			}
-
-		} else {
-			if parsedURL.String() != test.rawurl {
-				t.Errorf("%s: String() returned %s", test.rawurl, parsedURL.String())
-			}
-
-			if parsedURL.StringNoFragment() != strings.SplitN(test.rawurl, "#", 2)[0] {
-				t.Errorf("%s: StringNoFragment() returned %s", test.rawurl, parsedURL.StringNoFragment())
-			}
+		if parsedURL.String() != test.rawurl {
+			t.Errorf("%s: String() returned %s", test.rawurl, parsedURL.String())
 		}
+
+		if parsedURL.StringNoFragment() != strings.SplitN(test.rawurl, "#", 2)[0] {
+			t.Errorf("%s: StringNoFragment() returned %s", test.rawurl, parsedURL.StringNoFragment())
+		}
+
 	}
 }
 


### PR DESCRIPTION
/hold

for now

want to discuss with @adambkaplan when he returns from PTO

this is a possible reconciliation with the concerns in this BZ with conclusions drawn from https://bugzilla.redhat.com/show_bug.cgi?id=1884270

but I'm not ready to make an executive decsion here 