### PR TITLE
Bug 1976112: Fixed warnings about deprecated CronJob in image-pruner pods

### DIFF
--- a/pkg/cli/admin/prune/imageprune/prune.go
+++ b/pkg/cli/admin/prune/imageprune/prune.go
@@ -18,7 +18,6 @@ import (
 
 	kappsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	kerrapi "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -254,7 +253,7 @@ type PrunerOptions struct {
 	// Jobs is the entire list of jobs across all namespaces in the cluster.
 	Jobs *batchv1.JobList
 	// CronJobs is the entire list of cron jobs across all namespaces in the cluster.
-	CronJobs *batchv1beta1.CronJobList
+	CronJobs *batchv1.CronJobList
 	// LimitRanges is a map of LimitRanges across namespaces, being keys in this map.
 	LimitRanges map[string][]*corev1.LimitRange
 	// DryRun indicates that no changes will be made to the cluster and nothing
@@ -415,7 +414,7 @@ func (p *pruner) analyzeImageStreamsReferences(options PrunerOptions) kerrors.Ag
 	return kerrors.NewAggregate(errs)
 }
 
-func (p *pruner) analyzeReferencesFromCronJobs(cronjobs *batchv1beta1.CronJobList) []error {
+func (p *pruner) analyzeReferencesFromCronJobs(cronjobs *batchv1.CronJobList) []error {
 	var errs []error
 	for _, cj := range cronjobs.Items {
 		ref := resourceReference{

--- a/pkg/cli/admin/prune/imageprune/prune_test.go
+++ b/pkg/cli/admin/prune/imageprune/prune_test.go
@@ -16,7 +16,6 @@ import (
 
 	kappsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -81,7 +80,7 @@ func TestImagePruning(t *testing.T) {
 		rss                                  kappsv1.ReplicaSetList
 		ssets                                kappsv1.StatefulSetList
 		jobs                                 batchv1.JobList
-		cronjobs                             batchv1beta1.CronJobList
+		cronjobs                             batchv1.CronJobList
 		limits                               map[string][]*corev1.LimitRange
 		imageDeleterErr                      error
 		imageStreamDeleterErr                error
@@ -2122,7 +2121,7 @@ func TestRegistryPruning(t *testing.T) {
 				RSs:              &kappsv1.ReplicaSetList{},
 				SSets:            &kappsv1.StatefulSetList{},
 				Jobs:             &batchv1.JobList{},
-				CronJobs:         &batchv1beta1.CronJobList{},
+				CronJobs:         &batchv1.CronJobList{},
 			}
 			p, err := NewPruner(options)
 			if err != nil {

--- a/pkg/cli/admin/prune/images/images.go
+++ b/pkg/cli/admin/prune/images/images.go
@@ -378,7 +378,7 @@ func (o PruneImagesOptions) Run() error {
 		return err
 	}
 
-	allCronJobs, err := o.KubeClient.BatchV1beta1().CronJobs(o.Namespace).List(context.TODO(), metav1.ListOptions{})
+	allCronJobs, err := o.KubeClient.BatchV1().CronJobs(o.Namespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/helpers/image/test/util.go
+++ b/pkg/helpers/image/test/util.go
@@ -10,7 +10,6 @@ import (
 
 	kappsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -290,22 +289,22 @@ func DS(namespace, name string, containerImages ...string) kappsv1.DaemonSet {
 }
 
 // CronJobList turns the given stateful sets into JobList.
-func CronJobList(cjs ...batchv1beta1.CronJob) batchv1beta1.CronJobList {
-	return batchv1beta1.CronJobList{
+func CronJobList(cjs ...batchv1.CronJob) batchv1.CronJobList {
+	return batchv1.CronJobList{
 		Items: cjs,
 	}
 }
 
 // CronJob creates and returns a CronJob object.
-func CronJob(namespace, name string, containerImages ...string) batchv1beta1.CronJob {
-	return batchv1beta1.CronJob{
+func CronJob(namespace, name string, containerImages ...string) batchv1.CronJob {
+	return batchv1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
-			SelfLink:  "/apis/batch/v1beta1/cronjobs/" + name,
+			SelfLink:  "/apis/batch/v1/cronjobs/" + name,
 		},
-		Spec: batchv1beta1.CronJobSpec{
-			JobTemplate: batchv1beta1.JobTemplateSpec{
+		Spec: batchv1.CronJobSpec{
+			JobTemplate: batchv1.JobTemplateSpec{
 				Spec: batchv1.JobSpec{
 					Template: corev1.PodTemplateSpec{
 						Spec: PodSpecInternal(containerImages...),


### PR DESCRIPTION
Replaced batch/v1beta1 with batch/v1 so warnings about deprecated CronJob would stop appearing in image-pruner pods.