### PR TITLE
contrib/completions/OWNERS: Delegate to all approver aliases

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,11 +1,5 @@
 reviewers:
-  - deads2k
-  - mfojtik
-  - smarterclayton
-  - soltysh
+  - root-approvers
 approvers:
-  - deads2k
-  - mfojtik
-  - smarterclayton
-  - soltysh
+  - root-approvers
 component: "oc"

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,6 +1,11 @@
 # See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#OWNERS_ALIASES
 
 aliases:
+  root-approvers:
+    - deads2k
+    - mfojtik
+    - smarterclayton
+    - soltysh
   update-approvers:
     - abhinavdahiya
     - crawford

--- a/contrib/completions/OWNERS
+++ b/contrib/completions/OWNERS
@@ -1,0 +1,13 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - build-approvers
+  - catalog-approvers
+  - root-approvers
+  - update-approvers
+reviewers:
+  - build-reviewers
+  - catalog-reviewers
+  - root-approvers
+  - update-approvers


### PR DESCRIPTION
So folks can touch commands/options within their sections and not need to reach out to root apporovers.  To make it convenient to continue to include the root approvers here, I've shifted them into a new alias.