### PR TITLE
runAsNonRoot in Pod SCC should be nil when oc debug run with `--as-root` 

### DIFF
--- a/pkg/cli/debug/debug.go
+++ b/pkg/cli/debug/debug.go
@@ -799,6 +799,13 @@ func (o *DebugOptions) transformPodForDebug(annotations map[string]string) (*cor
 		container.SecurityContext.RunAsNonRoot = nil
 	}
 
+	// if DebugOptions set container.SecurityContext.RunAsNonRoot to nil,
+	// pod.Spec.SecurityContext.runAsNonRoot should be nil also.
+	if container.SecurityContext.RunAsNonRoot == nil &&
+		pod.Spec.SecurityContext != nil {
+		pod.Spec.SecurityContext.RunAsNonRoot = nil
+	}
+
 	switch {
 	case o.OneContainer:
 		pod.Spec.InitContainers = nil


### PR DESCRIPTION
When running oc debug with `--as-root`, Pod with `.spec.securityContext.runAsNonRoot: true` fails with `Error: container's runAsUser breaks non-root policy`.
See also: #879 