### PR TITLE
Make sure to set the namespace for routes resources

### DIFF
--- a/pkg/cli/create/routeedge.go
+++ b/pkg/cli/create/routeedge.go
@@ -99,15 +99,9 @@ func (o *CreateEdgeRouteOptions) Run() error {
 	if err != nil {
 		return err
 	}
-	route, err := route.UnsecuredRoute(o.CreateRouteSubcommandOptions.CoreClient, o.CreateRouteSubcommandOptions.Namespace, o.CreateRouteSubcommandOptions.Name, serviceName, o.Port, false)
+	route, err := route.UnsecuredRoute(o.CreateRouteSubcommandOptions.CoreClient, o.CreateRouteSubcommandOptions.Namespace, o.CreateRouteSubcommandOptions.Name, serviceName, o.Port, false, o.CreateRouteSubcommandOptions.EnforceNamespace)
 	if err != nil {
 		return err
-	}
-
-	// If the namespace is not the default, add it. This makes sure it will eventually
-	// appear in the manifest if the dry-run is enabled.
-	if o.CreateRouteSubcommandOptions.EnforceNamespace {
-		route.Namespace = o.CreateRouteSubcommandOptions.Namespace
 	}
 
 	if len(o.WildcardPolicy) > 0 {

--- a/pkg/cli/create/routeedge.go
+++ b/pkg/cli/create/routeedge.go
@@ -104,6 +104,12 @@ func (o *CreateEdgeRouteOptions) Run() error {
 		return err
 	}
 
+	// If the namespace is not the default, add it. This makes sure it will eventually
+	// appear in the manifest if the dry-run is enabled.
+	if o.CreateRouteSubcommandOptions.EnforceNamespace {
+		route.Namespace = o.CreateRouteSubcommandOptions.Namespace
+	}
+
 	if len(o.WildcardPolicy) > 0 {
 		route.Spec.WildcardPolicy = routev1.WildcardPolicyType(o.WildcardPolicy)
 	}

--- a/pkg/cli/create/routepassthrough.go
+++ b/pkg/cli/create/routepassthrough.go
@@ -82,15 +82,9 @@ func (o *CreatePassthroughRouteOptions) Run() error {
 	if err != nil {
 		return err
 	}
-	route, err := route.UnsecuredRoute(o.CreateRouteSubcommandOptions.CoreClient, o.CreateRouteSubcommandOptions.Namespace, o.CreateRouteSubcommandOptions.Name, serviceName, o.Port, false)
+	route, err := route.UnsecuredRoute(o.CreateRouteSubcommandOptions.CoreClient, o.CreateRouteSubcommandOptions.Namespace, o.CreateRouteSubcommandOptions.Name, serviceName, o.Port, false, o.CreateRouteSubcommandOptions.EnforceNamespace)
 	if err != nil {
 		return err
-	}
-
-	// If the namespace is not the default, add it. This makes sure it will eventually
-	// appear in the manifest if the dry-run is enabled.
-	if o.CreateRouteSubcommandOptions.EnforceNamespace {
-		route.Namespace = o.CreateRouteSubcommandOptions.Namespace
 	}
 
 	if len(o.WildcardPolicy) > 0 {

--- a/pkg/cli/create/routepassthrough.go
+++ b/pkg/cli/create/routepassthrough.go
@@ -87,6 +87,12 @@ func (o *CreatePassthroughRouteOptions) Run() error {
 		return err
 	}
 
+	// If the namespace is not the default, add it. This makes sure it will eventually
+	// appear in the manifest if the dry-run is enabled.
+	if o.CreateRouteSubcommandOptions.EnforceNamespace {
+		route.Namespace = o.CreateRouteSubcommandOptions.Namespace
+	}
+
 	if len(o.WildcardPolicy) > 0 {
 		route.Spec.WildcardPolicy = routev1.WildcardPolicyType(o.WildcardPolicy)
 	}

--- a/pkg/cli/create/routereenecrypt.go
+++ b/pkg/cli/create/routereenecrypt.go
@@ -102,7 +102,7 @@ func (o *CreateReencryptRouteOptions) Run() error {
 	if err != nil {
 		return err
 	}
-	route, err := route.UnsecuredRoute(o.CreateRouteSubcommandOptions.CoreClient, o.CreateRouteSubcommandOptions.Namespace, o.CreateRouteSubcommandOptions.Name, serviceName, o.Port, false)
+	route, err := route.UnsecuredRoute(o.CreateRouteSubcommandOptions.CoreClient, o.CreateRouteSubcommandOptions.Namespace, o.CreateRouteSubcommandOptions.Name, serviceName, o.Port, false, o.CreateRouteSubcommandOptions.EnforceNamespace)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/create/routereenecrypt.go
+++ b/pkg/cli/create/routereenecrypt.go
@@ -107,6 +107,12 @@ func (o *CreateReencryptRouteOptions) Run() error {
 		return err
 	}
 
+	// If the namespace is not the default, add it. This makes sure it will eventually
+	// appear in the manifest if the dry-run is enabled.
+	if o.CreateRouteSubcommandOptions.EnforceNamespace {
+		route.Namespace = o.CreateRouteSubcommandOptions.Namespace
+	}
+
 	if len(o.WildcardPolicy) > 0 {
 		route.Spec.WildcardPolicy = routev1.WildcardPolicyType(o.WildcardPolicy)
 	}

--- a/pkg/cli/expose/expose.go
+++ b/pkg/cli/expose/expose.go
@@ -180,7 +180,7 @@ func (o *ExposeOptions) Validate(cmd *cobra.Command) error {
 			// The upstream generator will incorrectly chose service.Port instead of service.TargetPort
 			// for the route TargetPort when no port is present.  Passing forcePort=true
 			// causes UnsecuredRoute to always set a Port so the upstream default is not used.
-			route, err := route.UnsecuredRoute(o.CoreClient, o.Namespace, info.Name, info.Name, o.Port, true)
+			route, err := route.UnsecuredRoute(o.CoreClient, o.Namespace, info.Name, info.Name, o.Port, true, o.EnforceNamespace)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
When doing dry run, the namespace will not be part of the output
manifests ( i.e. yaml or json, etc. ). This commit adds the namespace
to the generated route resource if it is not the default.

How to reproduce it?
```
$ oc create route passthrough namex --service servicex -n namespacex --dry-run=client -o yaml
apiVersion: route.openshift.io/v1
kind: Route
metadata:
  creationTimestamp: null
  labels:
    app.kubernetes.io/component: identity-provider
    app.kubernetes.io/instance: e2e-test
    app.kubernetes.io/name: namex
    app.kubernetes.io/version: v2.24.0
  name: namex
spec:
  port:
    targetPort: http
  tls:
    termination: passthrough
  to:
    kind: ""
    name: servicex
    weight: null
status: {}
```