### PR TITLE
Bug 1957668: show console URL when asking for Authentication

### DIFF
--- a/pkg/helpers/tokencmd/basicauth.go
+++ b/pkg/helpers/tokencmd/basicauth.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/openshift/oc/pkg/helpers/term"
+	"github.com/openshift/oc/pkg/version"
 )
 
 // BasicAuthNoUsernameError when basic authentication challenge handling was attempted
@@ -31,6 +32,9 @@ func NewBasicAuthNoUsernameError() error {
 type BasicChallengeHandler struct {
 	// Host is the server being authenticated to. Used only for displaying messages when prompting for username/password
 	Host string
+
+	// serverVersionRetriever is used for fetching server version
+	serverVersionRetriever version.ServerVersionRetriever
 
 	// Reader is used to prompt for username/password. If nil, no prompting is done
 	Reader io.Reader
@@ -86,6 +90,13 @@ func (c *BasicChallengeHandler) HandleChallenge(requestURL string, headers http.
 			fmt.Fprintf(w, "Authentication required for %s (%s)\n", c.Host, realm)
 		} else {
 			fmt.Fprintf(w, "Authentication required for %s\n", c.Host)
+		}
+		if c.serverVersionRetriever != nil {
+			serverVersion, err := c.serverVersionRetriever.RetrieveServerVersion()
+			// this feature was introduced in Openshift 4.11 which should correspond to 1.24
+			if err == nil && serverVersion.MajorNumber >= 1 && serverVersion.MinorNumber >= 24 {
+				fmt.Fprintf(w, "Console URL: %s/console\n", c.Host)
+			}
 		}
 		fmt.Fprintf(w, "Username: %s\n", username)
 		if missingPassword {

--- a/pkg/helpers/tokencmd/negotiator_sspi_unsupported.go
+++ b/pkg/helpers/tokencmd/negotiator_sspi_unsupported.go
@@ -3,12 +3,16 @@
 
 package tokencmd
 
-import "io"
+import (
+	"io"
+
+	"github.com/openshift/oc/pkg/version"
+)
 
 func SSPIEnabled() bool {
 	return false
 }
 
-func NewSSPINegotiator(string, string, string, io.Reader) Negotiator {
+func NewSSPINegotiator(string, string, string, io.Reader, version.ServerVersionRetriever) Negotiator {
 	return newUnsupportedNegotiator("SSPI")
 }

--- a/pkg/version/server_version.go
+++ b/pkg/version/server_version.go
@@ -1,0 +1,64 @@
+package version
+
+import (
+	"errors"
+	"regexp"
+	"strconv"
+
+	apimachineryversion "k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/discovery"
+	restclient "k8s.io/client-go/rest"
+)
+
+type ServerVersion struct {
+	apimachineryversion.Info
+	MajorNumber int
+	MinorNumber int
+}
+
+var (
+	firstNumberRegex = regexp.MustCompile("[0-9]+")
+)
+
+func NewServerVersion(version apimachineryversion.Info) (*ServerVersion, error) {
+	major, err := strconv.Atoi(firstNumberRegex.FindString(version.Major))
+	if err != nil {
+		return nil, err
+	}
+	minor, err := strconv.Atoi(firstNumberRegex.FindString(version.Minor))
+	if err != nil {
+		return nil, err
+	}
+	return &ServerVersion{version, major, minor}, nil
+}
+
+func RetrieveServerVersion(clientConfig *restclient.Config) (*ServerVersion, error) {
+	if clientConfig == nil {
+		return nil, errors.New("clientConfig is nil")
+	}
+	client, err := discovery.NewDiscoveryClientForConfig(clientConfig)
+	if err != nil {
+		return nil, err
+	}
+	serverVersion, err := client.ServerVersion()
+	if err != nil {
+		return nil, err
+	}
+	return NewServerVersion(*serverVersion)
+}
+
+type ServerVersionRetriever interface {
+	RetrieveServerVersion() (*ServerVersion, error)
+}
+
+func NewServerVersionRetriever(clientConfig *restclient.Config) ServerVersionRetriever {
+	return &serverVersionDetector{clientConfig}
+}
+
+type serverVersionDetector struct {
+	clientConfig *restclient.Config
+}
+
+func (s *serverVersionDetector) RetrieveServerVersion() (*ServerVersion, error) {
+	return RetrieveServerVersion(s.clientConfig)
+}


### PR DESCRIPTION
~There is no easy access for not logged in users to the console.~

~We have to guess the console URL, since we are not authenticated yet and we cannot be sure of the real URL (configurability docs: https://docs.openshift.com/container-platform/4.7/web_console/configuring-web-console.html)~

show console URL when asking for Authentication
- the URL will redirect to the real URL
- added check for a server version since this feature is not generally available before OpenShift 4.11 (Kubernetes 1.24)


The output of the command:

```bash
> oc login -u test
Authentication required for https://api.my-cluster0.com:6443 (openshift)
Console URL: https://api.my-cluster0.com:6443/console
Username: test
Password:

```