### PR TITLE
Add release version annotation to extracted credentials requests

### DIFF
--- a/pkg/cli/admin/release/annotations.go
+++ b/pkg/cli/admin/release/annotations.go
@@ -16,6 +16,10 @@ const (
 	// This LABEL is set on images to indicate the manifest digest that was used
 	// as the base layer for the release image (usually the cluster-version-operator).
 	annotationReleaseBaseImageDigest = "io.openshift.release.base-image-digest"
+	// This is an annotation set on extracted Credentials Request manifests to indicate
+	// release version that can be consumed by ccoctl tool to create required credentials
+	// infrastructure in the cloud provider
+	annotationReleaseVersion = "io.openshift.release.version"
 	// This LABEL is a comma-delimited list of key=version pairs that can be consumed
 	// by other manifests within the payload to hardcode version strings. Version must
 	// be a semantic version with no build label (+ is not allowed) and key must be

--- a/pkg/cli/admin/release/extract.go
+++ b/pkg/cli/admin/release/extract.go
@@ -351,6 +351,21 @@ func (o *ExtractOptions) Run() error {
 						continue
 					}
 				}
+
+				// set release version annotation
+				infoOpts := NewInfoOptions(o.IOStreams)
+				release, err := infoOpts.LoadReleaseInfo(o.From, false)
+				if err != nil {
+					return false, errors.Wrapf(err, "error loading release info")
+				}
+
+				a := m.Obj.GetAnnotations()
+				if a == nil {
+					a = make(map[string]string)
+				}
+				a[annotationReleaseVersion] = release.Metadata.Version
+				m.Obj.SetAnnotations(a)
+
 				credRequestManifests = append(credRequestManifests, m)
 			}
 			if len(credRequestManifests) == 0 {
@@ -365,7 +380,7 @@ func (o *ExtractOptions) Run() error {
 				}
 			}
 			for _, m := range credRequestManifests {
-				yamlBytes, err := yaml.JSONToYAML(m.Raw)
+				yamlBytes, err := yaml.Marshal(m.Obj)
 				if err != nil {
 					return false, errors.Wrapf(err, "error serializing manifest in %s", hdr.Name)
 				}


### PR DESCRIPTION
The ccoctl tools needs to know the release version from the credentials
request manifests extracted using `oc adm release extract` in order to
create required infrastructure in the cloud provider.

x-ref: https://issues.redhat.com/browse/CCO-84