### PR TITLE
Bug 1980118: Keep workload annotations during the `oc debug` call.

### DIFF
--- a/pkg/cli/debug/debug.go
+++ b/pkg/cli/debug/debug.go
@@ -58,6 +58,10 @@ import (
 const (
 	debugPodAnnotationSourceContainer = "debug.openshift.io/source-container"
 	debugPodAnnotationSourceResource  = "debug.openshift.io/source-resource"
+	// containerResourcesAnnotationPrefix contains resource annotation prefix that will be used by CRI-O to set cpu shares
+	containerResourcesAnnotationPrefix = "resources.workload.openshift.io/"
+	// podWorkloadTargetAnnotationPrefix contains the prefix for the pod workload target annotation
+	podWorkloadTargetAnnotationPrefix = "target.workload.openshift.io/"
 )
 
 var (
@@ -805,6 +809,14 @@ func (o *DebugOptions) transformPodForDebug(annotations map[string]string) (*cor
 	}
 
 	clearHostPorts(pod)
+
+	// keep workload annotations
+	for k, v := range pod.Annotations {
+		if strings.HasPrefix(k, containerResourcesAnnotationPrefix) ||
+			strings.HasPrefix(k, podWorkloadTargetAnnotationPrefix) {
+			annotations[k] = v
+		}
+	}
 
 	// reset the pod
 	if pod.Annotations == nil || !o.KeepAnnotations {


### PR DESCRIPTION
During the call to `oc debug` for the pod with management resources
it possible that the debug pod will lose workload annotations and
the admission will reject the debug pod because of it.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>