### PR TITLE
Add Makefile target for Darwin ARM64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,10 @@ cross-build-darwin-amd64:
 	+@GOOS=darwin GOARCH=amd64 $(MAKE) --no-print-directory build GO_BUILD_PACKAGES:=./cmd/oc GO_BUILD_FLAGS:="$(GO_BUILD_FLAGS_DARWIN)" GO_BUILD_BINDIR:=$(CROSS_BUILD_BINDIR)/darwin_amd64
 .PHONY: cross-build-darwin-amd64
 
+cross-build-darwin-arm64:
+	+@GOOS=darwin GOARCH=arm64 $(MAKE) --no-print-directory build GO_BUILD_PACKAGES:=./cmd/oc GO_BUILD_FLAGS:="$(GO_BUILD_FLAGS_DARWIN)" GO_BUILD_BINDIR:=$(CROSS_BUILD_BINDIR)/darwin_arm64
+.PHONY: cross-build-darwin-arm64
+
 cross-build-windows-amd64: generate-versioninfo
 	+@GOOS=windows GOARCH=amd64 $(MAKE) --no-print-directory build GO_BUILD_PACKAGES:=./cmd/oc GO_BUILD_FLAGS:="$(GO_BUILD_FLAGS_WINDOWS)" GO_BUILD_BINDIR:=$(CROSS_BUILD_BINDIR)/windows_amd64
 	$(RM) cmd/oc/oc.syso


### PR DESCRIPTION
Related: https://github.com/Homebrew/homebrew-core/pull/81800
This just adds the Makefile target for Apple Silicon (OS=Darwin, Arch=ARM64).

This would allow M1 macOS Homebrew users to compile the latest Git repo by running `brew install --head openshift-cli`.

A similar diff at least builds in Homebrew using the last available tag `openshift-clients-4.6.0-202006250705.p0`.

Currently, I did not add this to `cross-build` target as I am not sure if fully compatible.