### PR TITLE
Bug 1786835: Check for out of range condition

### DIFF
--- a/pkg/cli/admin/catalog/mirrorer.go
+++ b/pkg/cli/admin/catalog/mirrorer.go
@@ -208,7 +208,12 @@ func mount(in, dest imagesource.TypedImageReference, maxComponents int) (out ima
 	} else if maxComponents == 0 {
 		out.Ref.Name = strings.Join(components[1:], "/")
 	} else if len(components) > 1 {
-		out.Ref.Name = strings.Join(components[1:maxComponents], "/")
+		endIndex := maxComponents
+		if endIndex > len(components) {
+			endIndex = len(components)
+		}
+
+		out.Ref.Name = strings.Join(components[1:endIndex], "/")
 	} else {
 		// only one component, make it the name, not the namespace
 		out.Ref.Name = in.Ref.Name


### PR DESCRIPTION
When attempting to mirror a registry using `oc adm catalog mirror`, an out of range panic occurs.

This fixes the panic by ensuring we stay in the correct range of the slice that generates image name.