### PR TITLE
Bug 1903545: Replace colons with dashes in Windows file paths

### DIFF
--- a/pkg/cli/image/imagesource/file_unix.go
+++ b/pkg/cli/image/imagesource/file_unix.go
@@ -1,0 +1,14 @@
+// +build !windows
+
+package imagesource
+
+import "path/filepath"
+
+// generateDigestPath generates a platform-specific file path for the given digest.
+// This uses `filepath.Join` for the `elem` parameter.
+// Digests are typically in the format of `algo:hash`. Some platforms, such as
+// Windows, do not allow for the use of `:` characters in file paths. In this case,
+// the `:` character is replaced with `-`.
+func generateDigestPath(digest string, elem ...string) string {
+	return filepath.Join(append(elem, digest)...)
+}

--- a/pkg/cli/image/imagesource/file_windows.go
+++ b/pkg/cli/image/imagesource/file_windows.go
@@ -1,0 +1,16 @@
+package imagesource
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// generateDigestPath generates a platform-specific file path for the given digest.
+// This uses `filepath.Join` for the `elem` parameter.
+// Digests are typically in the format of `algo:hash`. Some platforms, such as
+// Windows, do not allow for the use of `:` characters in file paths. In this case,
+// the `:` character is replaced with `-`.
+func generateDigestPath(digest string, elem ...string) string {
+	dgst := strings.ReplaceAll(digest, ":", "-")
+	return filepath.Join(append(elem, dgst)...)
+}


### PR DESCRIPTION
When running `oc adm release mirror` with the `--to-dir` argument, it creates files on the local machine with the sha256 digest as part of the filename. Since this digest consists of `algo:hash`, this fails on Windows machines, as the `:` character is not allowed in file paths.

This PR introduces platform-specific file path generation for digests that for Windows will replace `:` with `-`. Other platforms are not affected by this change and will continue to allow `:` in file paths.