### PR TITLE
Bug 1989505: bump kubernetes-client-go library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,6 @@ replace (
 	github.com/apcera/gssapi => github.com/openshift/gssapi v0.0.0-20161010215902-5fb4217df13b
 	k8s.io/apimachinery => github.com/openshift/kubernetes-apimachinery v0.0.0-20210730111815-c26349f8e2c9
 	k8s.io/cli-runtime => github.com/openshift/kubernetes-cli-runtime v0.0.0-20210730111823-1570202448c3
-	k8s.io/client-go => github.com/openshift/kubernetes-client-go v0.0.0-20210730111819-978c4383ac68
+	k8s.io/client-go => github.com/openshift/kubernetes-client-go v0.0.0-20210826123502-7208c21f5119
 	k8s.io/kubectl => github.com/openshift/kubernetes-kubectl v0.0.0-20210730111826-9c6734b9d97d
 )

--- a/go.sum
+++ b/go.sum
@@ -813,8 +813,8 @@ github.com/openshift/kubernetes-apimachinery v0.0.0-20210730111815-c26349f8e2c9 
 github.com/openshift/kubernetes-apimachinery v0.0.0-20210730111815-c26349f8e2c9/go.mod h1:O3oNtNadZdeOMxHFVxOreoznohCpy0z6mocxbZr7oJ0=
 github.com/openshift/kubernetes-cli-runtime v0.0.0-20210730111823-1570202448c3 h1:GNwUoCvGpmMbLgDXOT2WM34mluWoXrpHZ9FlaELGXC4=
 github.com/openshift/kubernetes-cli-runtime v0.0.0-20210730111823-1570202448c3/go.mod h1:M/w0bryClqcYKNQ5ofMMNDJE1r5rvYaAj8GswxUNUJY=
-github.com/openshift/kubernetes-client-go v0.0.0-20210730111819-978c4383ac68 h1:3GnE93sa4l0gNL3m83DSRZZ3/h6SnEQDnvdG7uu1QX0=
-github.com/openshift/kubernetes-client-go v0.0.0-20210730111819-978c4383ac68/go.mod h1:BZGppBKJh4UtgDZcIIh6vHJsJ1iZiXS7EwKZYWhyklo=
+github.com/openshift/kubernetes-client-go v0.0.0-20210826123502-7208c21f5119 h1:ikXqVJrPK8H4mgILzVTSvixJbNeBACXCfpiWqP5GTvE=
+github.com/openshift/kubernetes-client-go v0.0.0-20210826123502-7208c21f5119/go.mod h1:BZGppBKJh4UtgDZcIIh6vHJsJ1iZiXS7EwKZYWhyklo=
 github.com/openshift/kubernetes-kubectl v0.0.0-20210730111826-9c6734b9d97d h1:3mDOdg1bim6uNUJhh16fhwW2ScjYzLFgS9sHHj+QDx8=
 github.com/openshift/kubernetes-kubectl v0.0.0-20210730111826-9c6734b9d97d/go.mod h1:7/NjJzIH3rgPmfO9C8V3u/yIKeJdK7ptpFbPWQGKYas=
 github.com/openshift/library-go v0.0.0-20210730125111-f3b4cc9813a9 h1:rNxENnlgP5FU17ux5RJk2R4H8X2D3pCQA5emQYB06Is=

--- a/vendor/k8s.io/client-go/util/jsonpath/jsonpath.go
+++ b/vendor/k8s.io/client-go/util/jsonpath/jsonpath.go
@@ -132,9 +132,6 @@ func (j *JSONPath) FindResults(data interface{}) ([][]reflect.Value, error) {
 			}
 			continue
 		}
-		if len(results) == 0 {
-			break
-		}
 		fullResult = append(fullResult, results)
 	}
 	return fullResult, nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -913,7 +913,7 @@ k8s.io/cli-runtime/pkg/genericclioptions
 k8s.io/cli-runtime/pkg/genericclioptions/openshiftpatch
 k8s.io/cli-runtime/pkg/printers
 k8s.io/cli-runtime/pkg/resource
-# k8s.io/client-go v0.22.0-rc.0 => github.com/openshift/kubernetes-client-go v0.0.0-20210730111819-978c4383ac68
+# k8s.io/client-go v0.22.0-rc.0 => github.com/openshift/kubernetes-client-go v0.0.0-20210826123502-7208c21f5119
 ## explicit
 k8s.io/client-go/applyconfigurations/admissionregistration/v1
 k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1
@@ -1315,5 +1315,5 @@ sigs.k8s.io/yaml
 # github.com/apcera/gssapi => github.com/openshift/gssapi v0.0.0-20161010215902-5fb4217df13b
 # k8s.io/apimachinery => github.com/openshift/kubernetes-apimachinery v0.0.0-20210730111815-c26349f8e2c9
 # k8s.io/cli-runtime => github.com/openshift/kubernetes-cli-runtime v0.0.0-20210730111823-1570202448c3
-# k8s.io/client-go => github.com/openshift/kubernetes-client-go v0.0.0-20210730111819-978c4383ac68
+# k8s.io/client-go => github.com/openshift/kubernetes-client-go v0.0.0-20210826123502-7208c21f5119
 # k8s.io/kubectl => github.com/openshift/kubernetes-kubectl v0.0.0-20210730111826-9c6734b9d97d


### PR DESCRIPTION
to bring in: revert "fix wrong output when using jsonpath"


links:
- https://github.com/openshift/kubernetes-client-go/pull/29
- upstream: https://github.com/kubernetes/kubernetes/pull/104172