### PR TITLE
Bug 1999159: Update the catalog-related owner alias'

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -16,9 +16,9 @@ aliases:
     - vrutkovs
     - wking
   catalog-approvers:
-    - ecordell
+    - kevinrizza
   catalog-reviewers:
-    - ecordell
+    - kevinrizza
   build-reviewers:
     - adambkaplan
     - gabemontero


### PR DESCRIPTION
Update catalog-approvers and catalog-reviewers alias' in the root OWNERS_ALIASES.