### PR TITLE
fix: remove duplicate alias on `oc adm top imagestream`

### DIFF
--- a/pkg/cli/admin/top/imagestreams.go
+++ b/pkg/cli/admin/top/imagestreams.go
@@ -67,7 +67,7 @@ func NewCmdTopImageStreams(f kcmdutil.Factory, streams genericclioptions.IOStrea
 			kcmdutil.CheckErr(o.Validate(cmd))
 			kcmdutil.CheckErr(o.Run())
 		},
-		Aliases: []string{"imagestreams", "is"},
+		Aliases: []string{"is"},
 	}
 
 	return cmd


### PR DESCRIPTION
Fixes https://github.com/openshift/oc/issues/911