### PR TITLE
Bug 1987257: Always set User-Agent header for registries

### DIFF
--- a/pkg/cli/admin/verifyimagesignature/manifest.go
+++ b/pkg/cli/admin/verifyimagesignature/manifest.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/docker/distribution/registry/client/transport"
 	godigest "github.com/opencontainers/go-digest"
 
 	"k8s.io/client-go/rest"
@@ -21,14 +20,13 @@ func getImageManifestByIDFromRegistry(registry *url.URL, repositoryName, imageID
 	credentials := registryclient.NewBasicCredentials()
 	credentials.Add(registry, username, password)
 
-	insecureRT, err := rest.TransportFor(&rest.Config{TLSClientConfig: rest.TLSClientConfig{Insecure: true}})
+	insecureRT, err := rest.TransportFor(&rest.Config{TLSClientConfig: rest.TLSClientConfig{Insecure: true}, UserAgent: rest.DefaultKubernetesUserAgent()})
 	if err != nil {
 		return nil, err
 	}
 
 	repo, err := registryclient.NewContext(http.DefaultTransport, insecureRT).
 		WithCredentials(credentials).
-		WithRequestModifiers(transport.NewHeaderRequestModifier(http.Header{http.CanonicalHeaderKey("User-Agent"): []string{rest.DefaultKubernetesUserAgent()}})).
 		Repository(ctx, registry, repositoryName, insecure)
 	if err != nil {
 		return nil, err

--- a/pkg/cli/registry/login/login.go
+++ b/pkg/cli/registry/login/login.go
@@ -13,7 +13,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/docker/distribution/registry/client/transport"
 	"github.com/spf13/cobra"
 
 	corev1 "k8s.io/api/core/v1"
@@ -286,12 +285,11 @@ func (o *LoginOptions) Run() error {
 		creds := registryclient.NewBasicCredentials()
 		url := &url.URL{Host: o.HostPort}
 		creds.Add(url, o.Credentials.Username, o.Credentials.Password)
-		insecureRT, err := rest.TransportFor(&rest.Config{TLSClientConfig: rest.TLSClientConfig{Insecure: true}})
+		insecureRT, err := rest.TransportFor(&rest.Config{TLSClientConfig: rest.TLSClientConfig{Insecure: true}, UserAgent: rest.DefaultKubernetesUserAgent()})
 		if err != nil {
 			return err
 		}
-		c := registryclient.NewContext(http.DefaultTransport, insecureRT).WithCredentials(creds).
-			WithRequestModifiers(transport.NewHeaderRequestModifier(http.Header{http.CanonicalHeaderKey("User-Agent"): []string{rest.DefaultKubernetesUserAgent()}}))
+		c := registryclient.NewContext(http.DefaultTransport, insecureRT).WithCredentials(creds)
 		if _, err := c.Repository(ctx, url, "does_not_exist", o.Insecure); err != nil {
 			return fmt.Errorf("unable to check your credentials - pass --skip-check to bypass this error: %v", err)
 		}


### PR DESCRIPTION
The previous fix for this used RequestModifiers, which only get applied after authentication. This PR uses kubectl's UserAgent config option to set the header using its underlying Transport before RequestModifiers get applied.