### PR TITLE
Bug 1999246: adm catalog mirror should ignore .indexignore files

### DIFF
--- a/pkg/cli/admin/catalog/mirror.go
+++ b/pkg/cli/admin/catalog/mirror.go
@@ -472,10 +472,14 @@ type declcfgRelatedImage struct {
 
 type declcfgRelatedImagesParser struct{}
 
+const (
+	indexIgnoreFilename = ".indexignore"
+)
+
 func (_ declcfgRelatedImagesParser) Parse(root string) (map[string]struct{}, error) {
 	rootFS := os.DirFS(root)
 
-	matcher, err := ignore.NewMatcher(rootFS, ".indexignore")
+	matcher, err := ignore.NewMatcher(rootFS, indexIgnoreFilename)
 	if err != nil {
 		return nil, err
 	}
@@ -485,7 +489,7 @@ func (_ declcfgRelatedImagesParser) Parse(root string) (map[string]struct{}, err
 		if err != nil {
 			return err
 		}
-		if entry.IsDir() || matcher.Match(path, false) {
+		if entry.IsDir() || entry.Name() == indexIgnoreFilename || matcher.Match(path, false) {
 			return nil
 		}
 		f, err := rootFS.Open(path)

--- a/pkg/cli/admin/catalog/testdata/test-declcfg/.indexignore
+++ b/pkg/cli/admin/catalog/testdata/test-declcfg/.indexignore
@@ -1,0 +1,1 @@
+README.md

--- a/pkg/cli/admin/catalog/testdata/test-declcfg/README.md
+++ b/pkg/cli/admin/catalog/testdata/test-declcfg/README.md
@@ -1,0 +1,1 @@
+Placeholder to ensure .indexignore functionality


### PR DESCRIPTION
When loading file-based catalogs, oc adm catalog mirror should
automatically ignore .indexignore files it finds rather than requiring
an explicit pattern in the .indexignore file to ignore itself. There is
no circumstance where a .indexignore file would be expected to be
understood as an catalog file.

Signed-off-by: Joe Lanford <joe.lanford@gmail.com>