### PR TITLE
Bug 2002950: Define a Command instead of Arguments for Container

### DIFF
--- a/pkg/cli/create/deploymentconfig.go
+++ b/pkg/cli/create/deploymentconfig.go
@@ -33,8 +33,8 @@ var (
 type CreateDeploymentConfigOptions struct {
 	CreateSubcommandOptions *CreateSubcommandOptions
 
-	Image string
-	Args  []string
+	Image   string
+	Command []string
 
 	Client appsv1client.DeploymentConfigsGetter
 }
@@ -66,7 +66,7 @@ func NewCmdCreateDeploymentConfig(f genericclioptions.RESTClientGetter, streams 
 
 func (o *CreateDeploymentConfigOptions) Complete(cmd *cobra.Command, f genericclioptions.RESTClientGetter, args []string) error {
 	if len(args) > 1 {
-		o.Args = args[1:]
+		o.Command = args[1:]
 	}
 
 	clientConfig, err := f.ToRESTConfig()
@@ -95,9 +95,9 @@ func (o *CreateDeploymentConfigOptions) Run() error {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:  "default-container",
-							Image: o.Image,
-							Args:  o.Args,
+							Name:    "default-container",
+							Image:   o.Image,
+							Command: o.Command,
 						},
 					},
 				},


### PR DESCRIPTION
* Description: To define a command, consistently include the "command" field instead of "arg" in the configuration file like "Deployment" object. Refer [here](https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/) more details at the k8s docs.
* Reference: https://bugzilla.redhat.com/show_bug.cgi?id=2002950
