### PR TITLE
Bug 1926522: oc adm catalog mirror tmp directory cleanup

### DIFF
--- a/pkg/cli/admin/catalog/mirror.go
+++ b/pkg/cli/admin/catalog/mirror.go
@@ -536,6 +536,9 @@ func (o *MirrorCatalogOptions) Validate() error {
 }
 
 func (o *MirrorCatalogOptions) Run() error {
+	// Run PostRun to clean up after the run
+	defer o.PostRun()
+
 	indexMirrorer, err := NewIndexImageMirror(o.IndexImageMirrorerOptions.ToOption(),
 		WithSource(o.SourceRef),
 		WithDest(o.DestRef),


### PR DESCRIPTION
WIP: This PR supersedes [PR 741](https://github.com/openshift/oc/pull/741).