### PR TITLE
Add MacOS local building instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ workstation, install them with:
 dnf install krb5-devel
 ```
 
+For MacOS you'll need to install a few brew packages before building locally. Install them with:
+```
+brew install heimdal
+brew install gpgme
+```
 ## Testing
 
 All PRs will have to pass a series of automated tests starting from go tools


### PR DESCRIPTION
When debugging another issue and getting this repo started for the first time it was necassary to install two packages via brew.

```
brew install heimdal
brew install gpgme
```

As a result I am proposing a change to add these into the README for the future.