### PR TITLE
Modified MG pod tolerations

### DIFF
--- a/pkg/cli/admin/mustgather/mustgather.go
+++ b/pkg/cli/admin/mustgather/mustgather.go
@@ -594,8 +594,12 @@ func (o *MustGatherOptions) newPod(node, image string) *corev1.Pod {
 	nodeSelector := map[string]string{
 		corev1.LabelOSStable: "linux",
 	}
+
+	tolerationKey := ""
+
 	if node == "" {
 		nodeSelector["node-role.kubernetes.io/master"] = ""
+		tolerationKey = "node-role.kubernetes.io/master"
 	}
 
 	ret := &corev1.Pod{
@@ -649,7 +653,7 @@ func (o *MustGatherOptions) newPod(node, image string) *corev1.Pod {
 			TerminationGracePeriodSeconds: &zero,
 			Tolerations: []corev1.Toleration{
 				{
-					Key:      "node-role.kubernetes.io/master",
+					Key:      tolerationKey,
 					Operator: "Exists",
 				},
 			},

--- a/pkg/cli/admin/mustgather/mustgather.go
+++ b/pkg/cli/admin/mustgather/mustgather.go
@@ -649,6 +649,7 @@ func (o *MustGatherOptions) newPod(node, image string) *corev1.Pod {
 			TerminationGracePeriodSeconds: &zero,
 			Tolerations: []corev1.Toleration{
 				{
+					Key:      "node-role.kubernetes.io/master",
 					Operator: "Exists",
 				},
 			},


### PR DESCRIPTION
Fixes: https://github.com/openshift/oc/issues/941
As per the current tolerations, `Operator: Exists`, the must-gather pod is spawned with following `spec.tolerations`:

> $ oc get pods must-gather-2cnh8 -ojson -n openshift-must-gather-strbd | jq .spec.tolerations
> [
>   {
>     "operator": "Exists"
>   }
> ]

After specifying the `Key: "node-role.kubernetes.io/master"`, the pod comes up with these additional tolerations (which helps to take the `not-ready` and `unreachable` conditions into consideration):

> $ oc get pods must-gather-lcq28 -ojson -n openshift-must-gather-j245c | jq .spec.tolerations
> [
>   {
>     "key": "node-role.kubernetes.io/master",
>     "operator": "Exists"
>   },
>   {
>     "effect": "NoExecute",
>     "key": "node.kubernetes.io/not-ready",
>     "operator": "Exists",
>     "tolerationSeconds": 300
>   },
>   {
>     "effect": "NoExecute",
>     "key": "node.kubernetes.io/unreachable",
>     "operator": "Exists",
>     "tolerationSeconds": 300
>   }
> ]

