### PR TITLE
Bug 2010258: add printable-group-name validation

### DIFF
--- a/pkg/cli/admin/groups/new/new.go
+++ b/pkg/cli/admin/groups/new/new.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"unicode"
 
 	"github.com/spf13/cobra"
 
@@ -114,6 +115,12 @@ func (o *NewGroupOptions) Complete(f kcmdutil.Factory, cmd *cobra.Command, args 
 func (o *NewGroupOptions) Validate() error {
 	if len(o.Group) == 0 {
 		return fmt.Errorf("group is required")
+	}
+
+	for _, r := range o.Group {
+		if !unicode.IsPrint(r) {
+			return fmt.Errorf("group can't contain non-printable characters like %q", r)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
# What

It prevents users from creating groups with unprintable names.

# Why

- It is impossible to delete such groups after the fact.
- Some users seem to have done so, so it would be useful to prevent them from doing so ever again: https://bugzilla.redhat.com/show_bug.cgi?id=2010258

# Notes

There will be also an equivalent for the server side.

# Questions

I didn't see any tests in the group pkg, is it optional?