### PR TITLE
Introduce an option to retrieve rotated log files for a pod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
+	golang.org/x/net v0.0.0-20210520170846-37e1c6afe023
 	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac
 	gopkg.in/ldap.v2 v2.5.1

--- a/pkg/cli/admin/inspect/inspect.go
+++ b/pkg/cli/admin/inspect/inspect.go
@@ -75,6 +75,7 @@ type InspectOptions struct {
 	namespace      string
 	sinceTime      string
 	allNamespaces  bool
+	rotatedPodLogs bool
 	sinceInt       int64
 	sinceTimestamp metav1.Time
 
@@ -115,6 +116,11 @@ func NewCmdInspect(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd.Flags().BoolVarP(&o.allNamespaces, "all-namespaces", "A", o.allNamespaces, "If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
 	cmd.Flags().StringVar(&o.sinceTime, "since-time", o.sinceTime, "Only return logs after a specific date (RFC3339). Defaults to all logs. Only one of since-time / since may be used.")
 	cmd.Flags().DurationVar(&o.since, "since", o.since, "Only return logs newer than a relative duration like 5s, 2m, or 3h. Defaults to all logs. Only one of since-time / since may be used.")
+	cmd.Flags().BoolVar(&o.rotatedPodLogs, "rotated-pod-logs", o.rotatedPodLogs, "Experimental: If present, retrieve rotated log files that are available for selected pods. This can significantly increase the collected logs size. since/since-time is ignored for rotated logs.")
+
+	// The rotated-pod-logs option should be removed once support for retrieving rotated logs is added to kubelet
+	// https://github.com/kubernetes/kubernetes/issues/59902
+	cmd.Flags().MarkHidden("rotated-pod-logs")
 
 	o.configFlags.AddFlags(cmd.Flags())
 	return cmd

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -663,6 +663,7 @@ golang.org/x/crypto/ssh/terminal
 # golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6
 golang.org/x/exp/mmap
 # golang.org/x/net v0.0.0-20210520170846-37e1c6afe023
+## explicit
 golang.org/x/net/context
 golang.org/x/net/context/ctxhttp
 golang.org/x/net/html


### PR DESCRIPTION
Currently the pod logs API does not expose [rotated logs](https://github.com/kubernetes/kubernetes/blob/b0bc8adbc2178e15872f9ef040355c51c45d04bb/pkg/kubelet/kuberuntime/logs/logs.go#L42). This means that we are not getting all the pod logs that might be available on the node.

The introduced hidden flag enables getting the rotated log files available on the node for a specific container.
It uses the same approach as `node-logs`, it reads the HTML and extracts file names that represent specific log files.

Example:
```
./oc adm inspect ns/default --rotated-pod-logs

tree namespaces/default/pods/bbx/bbx/bbx/
namespaces/default/pods/bbx/bbx/bbx/
└── logs
    ├── current.log
    ├── previous.insecure.log
    ├── previous.log
    └── rotated
        ├── 0.log.20211110-131044.gz
        └── 0.log.20211110-131209
```

This flag can be removed once kubernetes supports getting the rotated logs through the API:
https://github.com/kubernetes/kubernetes/issues/59902

Signed-off-by: Patryk Diak <pdiak@redhat.com>