### PR TITLE
pkg/cli/admin/release: Comment to show manifest source images

### DIFF
--- a/pkg/cli/admin/release/image_mapper.go
+++ b/pkg/cli/admin/release/image_mapper.go
@@ -119,6 +119,19 @@ func readReleaseImageReferences(data []byte) (*imageapi.ImageStream, error) {
 
 type ManifestMapper func(data []byte) ([]byte, error)
 
+func newExplicitSourceManifestMapper(sourceName string, wrapped ManifestMapper) ManifestMapper {
+	return func(data []byte) ([]byte, error) {
+		data, err := wrapped(data)
+		if err != nil {
+			return nil, err
+		}
+
+		result := []byte(fmt.Sprintf("# manifest from referenced image %s", sourceName))
+		result = append(result, data...)
+		return result, nil
+	}
+}
+
 func NewTransformFromImageStreamFile(path string, input *imageapi.ImageStream, allowMissingImages bool) (ManifestMapper, error) {
 	is, err := parseImageStream(path)
 	if err != nil {

--- a/pkg/cli/admin/release/new.go
+++ b/pkg/cli/admin/release/new.go
@@ -1377,6 +1377,8 @@ func writePayload(w io.Writer, is *imageapi.ImageStream, cm *CincinnatiMetadata,
 			}
 		}
 
+		transform = newExplicitSourceManifestMapper(name, transform)
+
 		for _, fi := range contents {
 			if fi.IsDir() {
 				continue


### PR DESCRIPTION
Because sometimes it's hard to figure out where the manifest comes
from.  For example:

```console
$ oc adm release extract --to manifests registry.ci.openshift.org/ocp/release:4.10.0-0.ci-2021-11-05-164015
Extracted release payload from digest sha256:0e36c656e499209e018315b86f542cc6714ebb2952f9306860158854440dfb22 created at 2021-11-05T16:40:37Z
$ grep -r 'name: cluster-api' manifests
manifests/0000_30_capi-operator_12_clusteroperator_2.yaml:  name: cluster-api
manifests/0000_30_capi-operator_12_clusteroperator_2.yaml:    name: cluster-api
manifests/0000_30_capi-operator_12_clusteroperator.yaml:  name: cluster-api
manifests/0000_30_capi-operator_12_clusteroperator.yaml:    name: cluster-api
```

One of those is from [here][1].  What about the other?

```console
$ oc adm release info --commits registry.ci.openshift.org/ocp/release:4.10.0-0.ci-2021-11-05-164015 | grep capi-operator
cluster-capi-operator                          https://github.com/openshift/cluster-capi-operator                          e592380e9137abf1ad5cee475645f5d33848e7a3
cluster-capi-operator-src                      https://github.com/openshift/cluster-capi-operator                          e592380e9137abf1ad5cee475645f5d33848e7a3
```

suggests it might be from the src image reference, but these comments will help eliminate some of that guesswork.

[1]: https://github.com/openshift/cluster-capi-operator/blob/e592380e9137abf1ad5cee475645f5d33848e7a3/manifests/0000_30_capi-operator_12_clusteroperator.yaml