### PR TITLE
GitHub-38217: Removing old example that mentions limitSecretReferences

### DIFF
--- a/pkg/cli/secrets/link.go
+++ b/pkg/cli/secrets/link.go
@@ -28,9 +28,6 @@ var (
 
 		# Add an image pull secret to a service account to automatically use it for both pulling and pushing build images
 		oc secrets link builder builder-image-secret --for=pull,mount
-
-		# If the cluster's serviceAccountConfig is operating with limitSecretReferences: True, secrets must be added to the pod's service account whitelist in order to be available to the pod
-		oc secrets link pod-sa pod-secret
 	`)
 )
 


### PR DESCRIPTION
Per https://github.com/openshift/openshift-docs/issues/38217