### PR TITLE
feat/oc-release-extract-cco: add support for alibabacloud

### DIFF
--- a/pkg/cli/admin/release/extract.go
+++ b/pkg/cli/admin/release/extract.go
@@ -37,14 +37,15 @@ var (
 	credentialsRequestGVK = schema.GroupVersionKind{Group: "cloudcredential.openshift.io", Version: "v1", Kind: "CredentialsRequest"}
 
 	credRequestCloudProviderSpecKindMapping = map[string]string{
-		"aws":       "AWSProviderSpec",
-		"azure":     "AzureProviderSpec",
-		"openstack": "OpenStackProviderSpec",
-		"gcp":       "GCPProviderSpec",
-		"ibmcloud":  "IBMCloudProviderSpec",
-		"ovirt":     "OvirtProviderSpec",
-		"powervs":   "IBMCloudPowerVSProviderSpec",
-		"vsphere":   "VSphereProviderSpec",
+		"alibabacloud": "AlibabaCloudProviderSpec",
+		"aws":          "AWSProviderSpec",
+		"azure":        "AzureProviderSpec",
+		"gcp":          "GCPProviderSpec",
+		"ibmcloud":     "IBMCloudProviderSpec",
+		"openstack":    "OpenStackProviderSpec",
+		"ovirt":        "OvirtProviderSpec",
+		"powervs":      "IBMCloudPowerVSProviderSpec",
+		"vsphere":      "VSphereProviderSpec",
 	}
 )
 
@@ -82,7 +83,7 @@ func NewExtract(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.
 
 			The --credentials-requests flag filters extracted manifests to only cloud credential
 			requests. The --cloud flag further filters credential requests to a specific cloud.
-			Valid values for --cloud include aws, gcp, ibmcloud, azure, openstack, ovirt, powervs, and vsphere.
+			Valid values for --cloud include alibabacloud, aws, azure, gcp, ibmcloud, openstack, ovirt, powervs, and vsphere.
 
 			Instead of extracting the manifests, you can specify --git=DIR to perform a Git
 			checkout of the source code that comprises the release. A warning will be printed


### PR DESCRIPTION
This PR enables "alibabacloud" to be specified as part of the cloud argument to `oc adm release extract". An example would look like this:

```
oc adm release extract --credentials-requests --cloud=alibabacloud --to=./credrequests <RELEASE_IMAGE>
```

This is related to this CCO PR: https://github.com/openshift/cloud-credential-operator/pull/412

/cc @kwoodson @joelddiaz 