### PR TITLE
Adding the flag --allow-not-recommended to oc adm upgrade

### DIFF
--- a/contrib/completions/bash/oc
+++ b/contrib/completions/bash/oc
@@ -8501,6 +8501,8 @@ _oc_adm_upgrade()
 
     flags+=("--allow-explicit-upgrade")
     local_nonpersistent_flags+=("--allow-explicit-upgrade")
+    flags+=("--allow-not-recommended")
+    local_nonpersistent_flags+=("--allow-not-recommended")
     flags+=("--allow-upgrade-with-warnings")
     local_nonpersistent_flags+=("--allow-upgrade-with-warnings")
     flags+=("--clear")


### PR DESCRIPTION
So that users can upgrade to a version listed in Supported but not
recommended updates. The list of versions can be seen with oc adm upgrade --include-not-recommended
For details refer to https://github.com/openshift/enhancements/blob/2cc2d9b331532c852878a7c793f3a754914c824e/enhancements/update/targeted-update-edge-blocking.md

https://issues.redhat.com/browse/OTA-528

Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>