### PR TITLE
Unwrap completion command to fix oc completion zsh

### DIFF
--- a/contrib/completions/bash/oc
+++ b/contrib/completions/bash/oc
@@ -1,4 +1,3 @@
-
 # bash completion for oc                                   -*- shell-script -*-
 
 __oc_debug()

--- a/contrib/completions/zsh/oc
+++ b/contrib/completions/zsh/oc
@@ -1,5 +1,3 @@
-#compdef oc
-compdef _oc oc
 #compdef _oc oc
 
 # zsh completion for oc                                   -*- shell-script -*-

--- a/contrib/completions/zsh/oc
+++ b/contrib/completions/zsh/oc
@@ -1,3 +1,5 @@
+#compdef oc
+compdef _oc oc
 #compdef _oc oc
 
 # zsh completion for oc                                   -*- shell-script -*-

--- a/contrib/completions/zsh/oc
+++ b/contrib/completions/zsh/oc
@@ -1,6 +1,5 @@
-#compdef kubectl
-compdef _kubectl kubectl
-
+#compdef oc
+compdef _oc oc
 #compdef _oc oc
 
 # zsh completion for oc                                   -*- shell-script -*-

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/openshift/oc/pkg/cli/admin"
 	"github.com/openshift/oc/pkg/cli/cancelbuild"
+	"github.com/openshift/oc/pkg/cli/completion"
 	"github.com/openshift/oc/pkg/cli/debug"
 	"github.com/openshift/oc/pkg/cli/deployer"
 	"github.com/openshift/oc/pkg/cli/expose"
@@ -258,7 +259,7 @@ func NewOcCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 				logout.NewCmdLogout(f, ioStreams),
 				kubectlwrappers.NewCmdConfig(f, ioStreams),
 				whoami.NewCmdWhoAmI(f, ioStreams),
-				kubectlwrappers.NewCmdCompletion(ioStreams),
+				completion.NewCmdCompletion(ioStreams),
 			},
 		},
 	}

--- a/pkg/cli/completion/completion.go
+++ b/pkg/cli/completion/completion.go
@@ -1,6 +1,8 @@
 package completion
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -91,10 +93,13 @@ func RunCompletion(streams genericclioptions.IOStreams, cmd *cobra.Command, args
 	return run(streams, cmd.Parent())
 }
 
-func runCompletionBash(streams genericclioptions.IOStreams, oc *cobra.Command) error {
-	return oc.GenBashCompletion(streams.Out)
+func runCompletionBash(streams genericclioptions.IOStreams, cmd *cobra.Command) error {
+	return cmd.GenBashCompletion(streams.Out)
 }
 
-func runCompletionZsh(streams genericclioptions.IOStreams, oc *cobra.Command) error {
-	return oc.GenZshCompletion(streams.Out)
+func runCompletionZsh(streams genericclioptions.IOStreams, cmd *cobra.Command) error {
+	zshHead := fmt.Sprintf("#compdef %[1]s\ncompdef _%[1]s %[1]s\n", cmd.Name())
+	streams.Out.Write([]byte(zshHead))
+
+	return cmd.GenZshCompletion(streams.Out)
 }

--- a/pkg/cli/completion/completion.go
+++ b/pkg/cli/completion/completion.go
@@ -1,8 +1,6 @@
 package completion
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -21,22 +19,33 @@ var (
 		Note for zsh users: [1] zsh completions are only supported in versions of zsh >= 5.2.`))
 
 	completionExample = templates.Examples(i18n.T(`
+		# Installing bash completion on macOS using homebrew
+		## If running Bash 3.2 included with macOS
+		brew install bash-completion
+		## or, if running Bash 4.1+
+		brew install bash-completion@2
+		## If oc is installed via homebrew, this should start working immediately
+		## If you've installed via other means, you may need add the completion to your completion directory
+		oc completion bash > $(brew --prefix)/etc/bash_completion.d/oc
+
+
 		# Installing bash completion on Linux
 		## If bash-completion is not installed on Linux, install the 'bash-completion' package
 		## via your distribution's package manager.
 		## Load the oc completion code for bash into the current shell
-		    source <(oc completion bash)
+		source <(oc completion bash)
 		## Write bash completion code to a file and source it from .bash_profile
-		    oc completion bash > ~/.kube/completion.bash.inc
-		    printf "
-		      # Kubectl shell completion
-		      source '$HOME/.kube/completion.bash.inc'
-		      " >> $HOME/.bash_profile
-		    source $HOME/.bash_profile
+		oc completion bash > ~/.kube/completion.bash.inc
+		printf "
+		# Kubectl shell completion
+		source '$HOME/.kube/completion.bash.inc'
+		" >> $HOME/.bash_profile
+		source $HOME/.bash_profile
+
 		# Load the oc completion code for zsh[1] into the current shell
-		    source <(oc completion zsh)
+		source <(oc completion zsh)
 		# Set the oc completion code for zsh[1] to autoload on startup
-		    oc completion zsh > "${fpath[1]}/_oc"`))
+		oc completion zsh > "${fpath[1]}/_oc"`))
 
 	completionShells = map[string]func(streams genericclioptions.IOStreams, cmd *cobra.Command) error{
 		"bash": runCompletionBash,
@@ -87,8 +96,5 @@ func runCompletionBash(streams genericclioptions.IOStreams, oc *cobra.Command) e
 }
 
 func runCompletionZsh(streams genericclioptions.IOStreams, oc *cobra.Command) error {
-	commandName := oc.Name()
-	zshHead := fmt.Sprintf("#compdef %[1]s\ncompdef _%[1]s %[1]s\n", commandName)
-	streams.Out.Write([]byte(zshHead))
 	return oc.GenZshCompletion(streams.Out)
 }

--- a/pkg/cli/completion/completion.go
+++ b/pkg/cli/completion/completion.go
@@ -1,6 +1,8 @@
 package completion
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -85,7 +87,8 @@ func runCompletionBash(streams genericclioptions.IOStreams, oc *cobra.Command) e
 }
 
 func runCompletionZsh(streams genericclioptions.IOStreams, oc *cobra.Command) error {
-	zshHead := "#compdef oc\ncompdef _oc oc\n"
+	commandName := oc.Name()
+	zshHead := fmt.Sprintf("#compdef %[1]s\ncompdef _%[1]s %[1]s\n", commandName)
 	streams.Out.Write([]byte(zshHead))
 	return oc.GenZshCompletion(streams.Out)
 }

--- a/pkg/cli/completion/completion.go
+++ b/pkg/cli/completion/completion.go
@@ -1,0 +1,91 @@
+package completion
+
+import (
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+var (
+	completionLong = templates.LongDesc(i18n.T(`
+		Output shell completion code for the specified shell (bash, zsh).
+		The shell code must be evaluated to provide interactive
+		completion of oc commands.  This can be done by sourcing it from
+		the .bash_profile.
+
+		Note for zsh users: [1] zsh completions are only supported in versions of zsh >= 5.2.`))
+
+	completionExample = templates.Examples(i18n.T(`
+		# Installing bash completion on Linux
+		## If bash-completion is not installed on Linux, install the 'bash-completion' package
+		## via your distribution's package manager.
+		## Load the oc completion code for bash into the current shell
+		    source <(oc completion bash)
+		## Write bash completion code to a file and source it from .bash_profile
+		    oc completion bash > ~/.kube/completion.bash.inc
+		    printf "
+		      # Kubectl shell completion
+		      source '$HOME/.kube/completion.bash.inc'
+		      " >> $HOME/.bash_profile
+		    source $HOME/.bash_profile
+		# Load the oc completion code for zsh[1] into the current shell
+		    source <(oc completion zsh)
+		# Set the oc completion code for zsh[1] to autoload on startup
+		    oc completion zsh > "${fpath[1]}/_oc"`))
+
+	completionShells = map[string]func(streams genericclioptions.IOStreams, cmd *cobra.Command) error{
+		"bash": runCompletionBash,
+		"zsh":  runCompletionZsh,
+	}
+)
+
+// NewCmdCompletion creates the `completion` command
+func NewCmdCompletion(streams genericclioptions.IOStreams) *cobra.Command {
+	shells := []string{}
+	for s := range completionShells {
+		shells = append(shells, s)
+	}
+
+	cmd := &cobra.Command{
+		Use:                   "completion SHELL",
+		DisableFlagsInUseLine: true,
+		Short:                 i18n.T("Output shell completion code for the specified shell (bash or zsh"),
+		Long:                  completionLong,
+		Example:               completionExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			kcmdutil.CheckErr(RunCompletion(streams, cmd, args))
+		},
+		ValidArgs: shells,
+	}
+
+	return cmd
+}
+
+// RunCompletion checks given arguments and executes command
+func RunCompletion(streams genericclioptions.IOStreams, cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return kcmdutil.UsageErrorf(cmd, "Shell not specified.")
+	}
+	if len(args) > 1 {
+		return kcmdutil.UsageErrorf(cmd, "Too many arguments. Expected only the shell type.")
+	}
+	run, found := completionShells[args[0]]
+	if !found {
+		return kcmdutil.UsageErrorf(cmd, "Unsupported shell type %q.", args[0])
+	}
+
+	return run(streams, cmd.Parent())
+}
+
+func runCompletionBash(streams genericclioptions.IOStreams, oc *cobra.Command) error {
+	return oc.GenBashCompletion(streams.Out)
+}
+
+func runCompletionZsh(streams genericclioptions.IOStreams, oc *cobra.Command) error {
+	zshHead := "#compdef oc\ncompdef _oc oc\n"
+	streams.Out.Write([]byte(zshHead))
+	return oc.GenZshCompletion(streams.Out)
+}

--- a/pkg/cli/kubectlwrappers/wrappers.go
+++ b/pkg/cli/kubectlwrappers/wrappers.go
@@ -15,7 +15,6 @@ import (
 	kcmdauth "k8s.io/kubectl/pkg/cmd/auth"
 	"k8s.io/kubectl/pkg/cmd/autoscale"
 	"k8s.io/kubectl/pkg/cmd/clusterinfo"
-	"k8s.io/kubectl/pkg/cmd/completion"
 	"k8s.io/kubectl/pkg/cmd/config"
 	"k8s.io/kubectl/pkg/cmd/cp"
 	kcreate "k8s.io/kubectl/pkg/cmd/create"
@@ -102,21 +101,6 @@ func NewCmdCreate(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobr
 	return cmd
 }
 
-var (
-	completionLong = templates.LongDesc(`
-		Output shell completion code for the specified shell (bash or zsh).
-		The shell code must be evaluated to provide interactive
-		completion of oc commands.  This can be done by sourcing it from
-		the .bash_profile.
-
-		Note for zsh users: [1] zsh completions are only supported in versions of zsh >= 5.2`)
-)
-
-func NewCmdCompletion(streams genericclioptions.IOStreams) *cobra.Command {
-	cmd := cmdutil.ReplaceCommandName("kubectl", "oc", templates.Normalize(completion.NewCmdCompletion(streams.Out, "\n")))
-	cmd.Long = completionLong
-	return cmd
-}
 
 // NewCmdExec is a wrapper for the Kubernetes cli exec command
 func NewCmdExec(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {


### PR DESCRIPTION
CC: eifrach@redhat.com

Related Issue/Bugzilla:

https://github.com/openshift/oc/issues/968
https://bugzilla.redhat.com/show_bug.cgi?id=2024427

`oc completion zsh` is currently hardcoded to add a `kubectl` compdef header.

This PR is one possible solution where we could unwrap the `oc completion` command to properly generate completions for `oc`

Ideally, the upstream could also use the `*cobra.Command.Name` value instead of hard-coding the command.

Current upstream function:

```go
func runCompletionZsh(out io.Writer, boilerPlate string, kubectl *cobra.Command) error {
	zshHead := "#compdef kubectl\ncompdef _kubectl kubectl\n"
	out.Write([]byte(zshHead))
        // Removed some boilerplate
        return kubectl.GenZshCompletion(out)
}
```

Proposed:

```go
func runCompletionZsh(streams genericclioptions.IOStreams, oc *cobra.Command) error {
        // EDIT: Removed zshHead
	return oc.GenZshCompletion(streams.Out)
}
```
This should generate a working `zsh` completion regardless of what is wrapping the original command.

Note that the `contrib` was generated by the scripts in `hack`

Thoughts?