### PR TITLE
Bug 2032111: requestproject: use agnhost serve-hostname

### DIFF
--- a/pkg/cli/requestproject/request_project.go
+++ b/pkg/cli/requestproject/request_project.go
@@ -60,7 +60,7 @@ You can add applications to this project with the 'new-app' command. For example
 
 to build a new example application in Ruby. Or use kubectl to deploy a simple Kubernetes application:
 
-    kubectl create deployment hello-node --image=k8s.gcr.io/serve_hostname
+    kubectl create deployment hello-node --image=k8s.gcr.io/e2e-test-images/agnhost:2.33 -- /agnhost serve-hostname
 
 `
 	requestProjectSwitchProjectOutput = `Project %[1]q created on server %[2]q.


### PR DESCRIPTION
k8s.gcr.io/serve_hostname is deprecated and single-arch.  agnhost is the literal replacement in the E2E test suite.
