### PR TITLE
Bug 2033751: pkg/cli/admin/inspect: Fix "ocurred" -> "occurred" typos

### DIFF
--- a/pkg/cli/admin/inspect/inspect.go
+++ b/pkg/cli/admin/inspect/inspect.go
@@ -249,7 +249,7 @@ func (o *InspectOptions) Run() error {
 
 	fmt.Fprintf(o.Out, "Wrote inspect data to %s.\n", o.DestDir)
 	if len(allErrs) > 0 {
-		return fmt.Errorf("errors ocurred while gathering data:\n    %v", errors.NewAggregate(allErrs))
+		return fmt.Errorf("errors occurred while gathering data:\n    %v", errors.NewAggregate(allErrs))
 	}
 
 	return nil
@@ -293,7 +293,7 @@ func (o *InspectOptions) gatherConfigResourceData(destDir string, ctx *resourceC
 	}
 
 	if len(errs) > 0 {
-		return fmt.Errorf("one or more errors ocurred while gathering config.openshift.io resource data:\n\n    %v", errors.NewAggregate(errs))
+		return fmt.Errorf("one or more errors occurred while gathering config.openshift.io resource data:\n\n    %v", errors.NewAggregate(errs))
 	}
 	return nil
 }
@@ -334,7 +334,7 @@ func (o *InspectOptions) gatherOperatorResourceData(destDir string, ctx *resourc
 	}
 
 	if len(errs) > 0 {
-		return fmt.Errorf("one or more errors ocurred while gathering operator.openshift.io resource data:\n\n    %v", errors.NewAggregate(errs))
+		return fmt.Errorf("one or more errors occurred while gathering operator.openshift.io resource data:\n\n    %v", errors.NewAggregate(errs))
 	}
 	return nil
 }

--- a/pkg/cli/admin/inspect/namespace.go
+++ b/pkg/cli/admin/inspect/namespace.go
@@ -84,7 +84,7 @@ func (o *InspectOptions) gatherNamespaceData(baseDir, namespace string) error {
 	}
 
 	if len(errs) > 0 {
-		return fmt.Errorf("one or more errors ocurred while gathering pod-specific data for namespace: %s\n\n    %v", namespace, errors.NewAggregate(errs))
+		return fmt.Errorf("one or more errors occurred while gathering pod-specific data for namespace: %s\n\n    %v", namespace, errors.NewAggregate(errs))
 	}
 	return nil
 }

--- a/pkg/cli/admin/inspect/pod.go
+++ b/pkg/cli/admin/inspect/pod.go
@@ -43,7 +43,7 @@ func (o *InspectOptions) gatherPodData(destDir, namespace string, pod *corev1.Po
 	}
 
 	if len(errs) > 0 {
-		return fmt.Errorf("one or more errors ocurred while gathering container data for pod %s:\n\n    %v", pod.Name, utilerrors.NewAggregate(errs))
+		return fmt.Errorf("one or more errors occurred while gathering container data for pod %s:\n\n    %v", pod.Name, utilerrors.NewAggregate(errs))
 	}
 	return nil
 }


### PR DESCRIPTION
For example, see [here](https://en.wiktionary.org/wiki/occurred).