### PR TITLE
Comment tolerations used in must-gather

### DIFF
--- a/pkg/cli/admin/mustgather/mustgather.go
+++ b/pkg/cli/admin/mustgather/mustgather.go
@@ -703,6 +703,9 @@ func (o *MustGatherOptions) newPod(node, image string) *corev1.Pod {
 			TerminationGracePeriodSeconds: &zero,
 			Tolerations: []corev1.Toleration{
 				{
+					// An empty key with operator Exists matches all keys,
+					// values and effects which means this will tolerate everything.
+					// As noted in https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
 					Operator: "Exists",
 				},
 			},


### PR DESCRIPTION
Followup to #1003 explains why we need empty tolerations. 

/assign @ravisantoshgudimetla 