### PR TITLE
Bug 2034889: Fix prune deployment panic

### DIFF
--- a/pkg/cli/admin/prune/deployments/deployments.go
+++ b/pkg/cli/admin/prune/deployments/deployments.go
@@ -177,7 +177,7 @@ func (o PruneDeploymentsOptions) Run() error {
 		}
 
 		for i := range replicaSetList.Items {
-			replicas = append(deployments, &replicationControllerList.Items[i])
+			replicas = append(deployments, &replicaSetList.Items[i])
 		}
 	}
 


### PR DESCRIPTION
Specifically, this fixes a panic when using `--replica-sets`.