### PR TITLE
Bug 2036826: Improved prune deployments

### DIFF
--- a/pkg/cli/admin/prune/deployments/data_test.go
+++ b/pkg/cli/admin/prune/deployments/data_test.go
@@ -45,6 +45,16 @@ func mockReplicationController(namespace, name string, deploymentConfig metav1.O
 	}
 	if deploymentConfig != nil {
 		item.Annotations[appsv1.DeploymentConfigAnnotation] = deploymentConfig.GetName()
+
+		if deploymentConfig != nil {
+			item.OwnerReferences = []metav1.OwnerReference{
+				{
+					APIVersion: "apps.openshift.io/v1",
+					Kind:       "DeploymentConfig",
+					Name:       deploymentConfig.GetName(),
+				},
+			}
+		}
 	}
 	item.Annotations[appsv1.DeploymentStatusAnnotation] = string(appsv1.DeploymentStatusNew)
 	return item


### PR DESCRIPTION
This is a followup to https://github.com/openshift/oc/pull/1015 that improves a few aspects of pruning ReplicaSets and switches to matching replicas and deployments using OwnerReferences rather than Annotations.