### PR TITLE
Bug 2039491: Remove `git://` from new-app tests

### DIFF
--- a/pkg/cli/admin/buildchain/test/multiple-namespaces-bcs.yaml
+++ b/pkg/cli/admin/buildchain/test/multiple-namespaces-bcs.yaml
@@ -98,7 +98,7 @@ items:
     resources: {}
     source:
       git:
-        uri: git://github.com/openshift/ruby-hello-world.git
+        uri: https://github.com/openshift/ruby-hello-world.git
       type: Git
     strategy:
       sourceStrategy:
@@ -129,7 +129,7 @@ items:
     resources: {}
     source:
       git:
-        uri: git://github.com/openshift/ruby-hello-world.git
+        uri: https://github.com/openshift/ruby-hello-world.git
       type: Git
     strategy:
       sourceStrategy:

--- a/pkg/cli/admin/buildchain/test/single-namespace-bcs.yaml
+++ b/pkg/cli/admin/buildchain/test/single-namespace-bcs.yaml
@@ -94,7 +94,7 @@ items:
     resources: {}
     source:
       git:
-        uri: git://github.com/openshift/ruby-hello-world.git
+        uri: https://github.com/openshift/ruby-hello-world.git
       type: Git
     strategy:
       sourceStrategy:
@@ -125,7 +125,7 @@ items:
     resources: {}
     source:
       git:
-        uri: git://github.com/openshift/ruby-hello-world.git
+        uri: https://github.com/openshift/ruby-hello-world.git
       type: Git
     strategy:
       sourceStrategy:

--- a/pkg/helpers/describe/projectstatus_test.go
+++ b/pkg/helpers/describe/projectstatus_test.go
@@ -215,7 +215,7 @@ func TestProjectStatus(t *testing.T) {
 				"In project example on server https://example.com:8443\n",
 				"svc/sinatra-example-2 - 172.30.17.48:8080",
 				"deploys istag/sinatra-example-2:latest <-",
-				"builds git://github.com",
+				"builds https://github.com",
 				"on docker.io/centos/ruby-25-centos7:latest",
 				"not built yet",
 				"deployment #1 waiting on image or update",
@@ -275,7 +275,7 @@ func TestProjectStatus(t *testing.T) {
 			Contains: []string{
 				"In project example on server https://example.com:8443\n",
 				"svc/sinatra-example-1 - 172.30.17.47:8080",
-				"builds git://github.com",
+				"builds https://github.com",
 				"on docker.io/centos/ruby-25-centos7:latest",
 				"build #1 running for about a minute",
 				"deployment #1 waiting on image or update",

--- a/pkg/helpers/graph/genericgraph/test/new-project-deployed-app.yaml
+++ b/pkg/helpers/graph/genericgraph/test/new-project-deployed-app.yaml
@@ -17,7 +17,7 @@ items:
     resources: {}
     source:
       git:
-        uri: git://github.com/openshift/ruby-hello-world.git
+        uri: https://github.com/openshift/ruby-hello-world.git
       type: Git
     strategy:
       sourceStrategy:
@@ -56,7 +56,7 @@ items:
     resources: {}
     source:
       git:
-        uri: git://github.com/openshift/ruby-hello-world.git
+        uri: https://github.com/openshift/ruby-hello-world.git
       type: Git
     strategy:
       sourceStrategy:

--- a/pkg/helpers/graph/genericgraph/test/new-project-no-build.yaml
+++ b/pkg/helpers/graph/genericgraph/test/new-project-no-build.yaml
@@ -13,7 +13,7 @@ items:
     resources: {}
     source:
       git:
-        uri: git://github.com/mfojtik/sinatra-example-2
+        uri: https://github.com/mfojtik/sinatra-example-2
       type: Git
     strategy:
       sourceStrategy:

--- a/pkg/helpers/graph/genericgraph/test/new-project-one-build.yaml
+++ b/pkg/helpers/graph/genericgraph/test/new-project-one-build.yaml
@@ -14,7 +14,7 @@ items:
     resources: {}
     source:
       git:
-        uri: git://github.com/mfojtik/sinatra-example-1
+        uri: https://github.com/mfojtik/sinatra-example-1
       type: Git
     strategy:
       sourceStrategy:
@@ -56,7 +56,7 @@ items:
     resources: {}
     source:
       git:
-        uri: git://github.com/mfojtik/sinatra-example-1
+        uri: https://github.com/mfojtik/sinatra-example-1
       type: Git
     strategy:
       sourceStrategy:

--- a/pkg/helpers/graph/genericgraph/test/new-project-two-deployment-configs.yaml
+++ b/pkg/helpers/graph/genericgraph/test/new-project-two-deployment-configs.yaml
@@ -13,7 +13,7 @@ items:
     resources: {}
     source:
       git:
-        uri: git://github.com/mfojtik/sinatra-app-example
+        uri: https://github.com/mfojtik/sinatra-app-example
       type: Git
     strategy:
       sourceStrategy:
@@ -62,7 +62,7 @@ items:
       type: git
     source:
       git:
-        uri: git://github.com/mfojtik/sinatra-app-example
+        uri: https://github.com/mfojtik/sinatra-app-example
       type: Git
     strategy:
       sourceStrategy:

--- a/pkg/helpers/newapp/cmd/newapp_test.go
+++ b/pkg/helpers/newapp/cmd/newapp_test.go
@@ -94,11 +94,11 @@ func TestValidate(t *testing.T) {
 		"components+source": {
 			cfg: AppConfig{
 				ComponentInputs: ComponentInputs{
-					Components: []string{"mysql+ruby~git://github.com/namespace/repo.git"},
+					Components: []string{"mysql+ruby~https://github.com/namespace/repo.git"},
 				},
 			},
 			componentValues:     []string{"mysql", "ruby"},
-			sourceRepoLocations: []string{"git://github.com/namespace/repo.git"},
+			sourceRepoLocations: []string{"https://github.com/namespace/repo.git"},
 			env:                 map[string]string{},
 			buildEnv:            map[string]string{},
 			parms:               map[string]string{},

--- a/pkg/helpers/newapp/newapptest/newapp_test.go
+++ b/pkg/helpers/newapp/newapptest/newapp_test.go
@@ -90,8 +90,8 @@ func TestNewAppAddArguments(t *testing.T) {
 			unknown:    []string{},
 		},
 		"source": {
-			args:    []string{".", testDir, "git://github.com/openshift/origin.git"},
-			repos:   []string{".", testDir, "git://github.com/openshift/origin.git"},
+			args:    []string{".", testDir, "https://github.com/openshift/origin.git"},
+			repos:   []string{".", testDir, "https://github.com/openshift/origin.git"},
 			unknown: []string{},
 		},
 		"source custom ref": {
@@ -105,8 +105,8 @@ func TestNewAppAddArguments(t *testing.T) {
 			unknown: []string{},
 		},
 		"mix 1": {
-			args:       []string{"git://github.com/openshift/origin.git", "mysql+ruby~git@github.com/openshift/origin.git", "env1=test", "ruby-helloworld-sample"},
-			repos:      []string{"git://github.com/openshift/origin.git"},
+			args:       []string{"https://github.com/openshift/origin.git", "mysql+ruby~git@github.com/openshift/origin.git", "env1=test", "ruby-helloworld-sample"},
+			repos:      []string{"https://github.com/openshift/origin.git"},
 			components: []string{"mysql+ruby~git@github.com/openshift/origin.git", "ruby-helloworld-sample"},
 			env:        []string{"env1=test"},
 			unknown:    []string{},


### PR DESCRIPTION
GitHub is removing support for the unsecured "git://" protocol when
cloning source code [1]. This is being done in phases, with full
removal happening on March 15, 2022. Some of the new-app unit tests
connect to GitHub and attempt to clone source code - this updates the
tests to use HTTPS instead of `git://`.

[1] https://github.blog/2021-09-01-improving-git-protocol-security-github/