### PR TITLE
Add note about Go 1.17 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ runtime layer.
 To build oc invoke `make oc`. At any time you can invoke `make help` and you'll
 get a list of all supported make sub-commands.
 
-In order to build `oc`, you will need the GSSAPI sources. On a Fedora/CentOS/RHEL
-workstation, install them with:
+In order to build `oc`, you will need Go 1.17 or above. Also, you will need the 
+GSSAPI sources. On a Fedora/CentOS/RHEL workstation, install them with:
 
 ```
 dnf install krb5-devel


### PR DESCRIPTION
On my Fedora 35 system with go 1.16, `make oc` fails with:
```sh
vendor/sigs.k8s.io/json/internal/golang/encoding/json/encode.go:1249:12: sf.IsExported undefined (type reflect.StructField has no field or method IsExported)
vendor/sigs.k8s.io/json/internal/golang/encoding/json/encode.go:1255:18: sf.IsExported undefined (type reflect.StructField has no field or method IsExported)
make: *** [vendor/github.com/openshift/build-machinery-go/make/targets/golang/build.mk:16: build] Error 2
```
I remember hitting the same some time back while building `kubectl` binary. The way I managed to get it working in both cases was by updating my Go environment to 1.17. So, I opened this PR which mentions Go 1.17 requirement in the README.