### PR TITLE
Bug 2038160: Inform user about inability to schedule a debug pod

### DIFF
--- a/pkg/cli/debug/debug.go
+++ b/pkg/cli/debug/debug.go
@@ -592,6 +592,10 @@ func (o *DebugOptions) RunDebug() error {
 			return fmt.Errorf(msg)
 			// switch to logging output
 		case err == krun.ErrPodCompleted, err == conditions.ErrContainerTerminated:
+			resultPod, ok := containerRunningEvent.Object.(*corev1.Pod)
+			if ok && resultPod.Status.Reason == "NodeAffinity" && len(resultPod.Spec.NodeSelector) != 0 {
+				return fmt.Errorf("debug pod could not be scheduled: %v. To fix this you may want to create a new namespace with empty node selector and run the debug there. For example: oc adm new-project --node-selector=\"\" debug", resultPod.Status.Message)
+			}
 			return o.getLogs(pod)
 		case err == conditions.ErrNonZeroExitCode:
 			if err = o.getLogs(pod); err != nil {


### PR DESCRIPTION
due to a default selector and  suggest a possible solution

@soltysh 


example output:

```bash
Starting pod/ip-10-0-149-155eu-central-1computeinternal-debug ...
To use host binaries, run `chroot /host`

Removing debug pod ...
error: debug pod could not be scheduled: Pod Predicate NodeAffinity failed. To fix this you may want to create a new namespace with empty node selector and run the debug there. For example: oc adm new-project --node-selector="" debug


```