### PR TITLE
Bug 2039359: Fix adm prune rs orphans

### DIFF
--- a/pkg/cli/admin/prune/deployments/data.go
+++ b/pkg/cli/admin/prune/deployments/data.go
@@ -93,6 +93,16 @@ func FilterDeploymentsPredicate(item metav1.Object) bool {
 	}
 }
 
+// FilterReplicaSets is a function that returns false if the item is a replicaset.
+func FilterReplicaSets(item metav1.Object) bool {
+	switch item.(type) {
+	case *kappsv1.ReplicaSet:
+		return false
+	default:
+		return true
+	}
+}
+
 // FilterZeroReplicaSize is a function that returns true if the replication controller or replicaset size is 0.
 func FilterZeroReplicaSize(item metav1.Object) bool {
 	switch v := item.(type) {

--- a/pkg/cli/admin/prune/deployments/data_test.go
+++ b/pkg/cli/admin/prune/deployments/data_test.go
@@ -21,14 +21,21 @@ func mockDeployment(namespace, name string) *kappsv1.Deployment {
 	return &kappsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name}}
 }
 
-func withSize(item *corev1.ReplicationController, replicas int32) *corev1.ReplicationController {
-	item.Spec.Replicas = &replicas
-	item.Status.Replicas = int32(replicas)
+func withSize(item metav1.Object, replicas int32) metav1.Object {
+	switch v := item.(type) {
+	case *corev1.ReplicationController:
+		v.Spec.Replicas = &replicas
+		v.Status.Replicas = replicas
+	case *kappsv1.ReplicaSet:
+		v.Spec.Replicas = &replicas
+		v.Status.Replicas = replicas
+	}
+
 	return item
 }
 
-func withCreated(item *corev1.ReplicationController, creationTimestamp metav1.Time) *corev1.ReplicationController {
-	item.CreationTimestamp = creationTimestamp
+func withCreated(item metav1.Object, creationTimestamp metav1.Time) metav1.Object {
+	item.SetCreationTimestamp(creationTimestamp)
 	return item
 }
 

--- a/pkg/cli/admin/prune/deployments/deployments.go
+++ b/pkg/cli/admin/prune/deployments/deployments.go
@@ -184,6 +184,7 @@ func (o PruneDeploymentsOptions) Run() error {
 	options := PrunerOptions{
 		KeepYoungerThan: o.KeepYoungerThan,
 		Orphans:         o.Orphans,
+		ReplicaSets:     o.ReplicaSets,
 		KeepComplete:    o.KeepComplete,
 		KeepFailed:      o.KeepFailed,
 		Deployments:     deployments,

--- a/pkg/cli/admin/prune/deployments/prune.go
+++ b/pkg/cli/admin/prune/deployments/prune.go
@@ -60,11 +60,15 @@ func NewPruner(options PrunerOptions) Pruner {
 
 	filter := &andFilter{
 		filterPredicates: []FilterPredicate{
-			FilterDeploymentsPredicate,
 			FilterZeroReplicaSize,
 			NewFilterBeforePredicate(options.KeepYoungerThan),
 		},
 	}
+
+	if !options.Orphans {
+		filter.filterPredicates = append(filter.filterPredicates, FilterDeploymentsPredicate)
+	}
+
 	replicas := filter.Filter(options.Replicas)
 	dataSet := NewDataSet(options.Deployments, replicas)
 

--- a/pkg/cli/admin/prune/deployments/prune.go
+++ b/pkg/cli/admin/prune/deployments/prune.go
@@ -69,6 +69,10 @@ func NewPruner(options PrunerOptions) Pruner {
 		filter.filterPredicates = append(filter.filterPredicates, FilterDeploymentsPredicate)
 	}
 
+	if !options.ReplicaSets {
+		filter.filterPredicates = append(filter.filterPredicates, FilterReplicaSets)
+	}
+
 	replicas := filter.Filter(options.Replicas)
 	dataSet := NewDataSet(options.Deployments, replicas)
 

--- a/pkg/cli/admin/prune/deployments/prune_test.go
+++ b/pkg/cli/admin/prune/deployments/prune_test.go
@@ -34,95 +34,167 @@ func (m *mockDeleteRecorder) Verify(t *testing.T, expected sets.String) {
 }
 
 func TestPruneTask(t *testing.T) {
-	deploymentStatusOptions := []appsv1.DeploymentStatus{
-		appsv1.DeploymentStatusComplete,
-		appsv1.DeploymentStatusFailed,
-		appsv1.DeploymentStatusNew,
-		appsv1.DeploymentStatusPending,
-		appsv1.DeploymentStatusRunning,
-	}
-	deploymentStatusFilter := []appsv1.DeploymentStatus{
-		appsv1.DeploymentStatusComplete,
-		appsv1.DeploymentStatusFailed,
-	}
-	deploymentStatusFilterSet := sets.String{}
-	for _, deploymentStatus := range deploymentStatusFilter {
-		deploymentStatusFilterSet.Insert(string(deploymentStatus))
+	now := metav1.Now()
+	old := metav1.NewTime(now.Time.Add(-1 * time.Hour))
+
+	deployments := []metav1.Object{
+		mockDeploymentConfig("a", "deployment-config"),
+		mockDeployment("b", "deployment"),
 	}
 
-	for _, orphans := range []bool{true, false} {
-		for _, deploymentStatusOption := range deploymentStatusOptions {
-			keepYoungerThan := time.Hour
+	replicas := []metav1.Object{
+		withCreated(withStatus(mockReplicationController("a", "build-1", deployments[0]), appsv1.DeploymentStatusComplete), now),
+		withCreated(withStatus(mockReplicationController("a", "build-2", deployments[0]), appsv1.DeploymentStatusComplete), old),
+		withCreated(withStatus(mockReplicationController("a", "build-3", deployments[0]), appsv1.DeploymentStatusFailed), old),
+		withSize(withCreated(withStatus(mockReplicationController("a", "build-3-with-replicas", deployments[0]), appsv1.DeploymentStatusRunning), old), 4),
+		withCreated(withStatus(mockReplicationController("a", "orphan-build-1", nil), appsv1.DeploymentStatusFailed), now),
+		withCreated(withStatus(mockReplicationController("a", "orphan-build-2", nil), appsv1.DeploymentStatusComplete), old),
+		withSize(withCreated(withStatus(mockReplicationController("a", "orphan-build-3-with-replicas", nil), appsv1.DeploymentStatusRunning), old), 4),
+		mockReplicaSet("b", "rs1", deployments[1]),
+		mockReplicaSet("b", "orphan-rs1", nil),
+		withCreated(mockReplicaSet("b", "rs2", deployments[1]), now),
+		withCreated(mockReplicaSet("b", "rs3", deployments[1]), old),
+		withCreated(withSize(mockReplicaSet("b", "rs4", deployments[1]), 3), now),
+		withCreated(withSize(mockReplicaSet("b", "rs5", deployments[1]), 3), old),
+		withCreated(withSize(mockReplicaSet("b", "orphan-rs2-with-replicas", nil), 3), old),
+	}
 
-			now := metav1.Now()
-			old := metav1.NewTime(now.Time.Add(-1 * keepYoungerThan))
+	testCases := map[string]struct {
+		Orphans            bool
+		ReplicaSets        bool
+		KeepToungerThan    time.Duration
+		KeepComplete       int
+		KeepFailed         int
+		ExpectedPruneNames []string
+	}{
+		"prune nothing": {
+			Orphans:            false,
+			ReplicaSets:        false,
+			KeepToungerThan:    24 * time.Hour,
+			KeepComplete:       5,
+			KeepFailed:         5,
+			ExpectedPruneNames: []string{},
+		},
+		"prune all failed, non-orphan replicationControlers": {
+			Orphans:         false,
+			ReplicaSets:     false,
+			KeepToungerThan: 0,
+			KeepComplete:    5,
+			KeepFailed:      0,
+			ExpectedPruneNames: []string{
+				"build-3",
+			},
+		},
+		"prune all completed and failed, non-orphan replicas": {
+			Orphans:         false,
+			ReplicaSets:     true,
+			KeepToungerThan: 0,
+			KeepComplete:    0,
+			KeepFailed:      0,
+			ExpectedPruneNames: []string{
+				"build-1",
+				"build-2",
+				"build-3",
+				"rs1",
+				"rs2",
+				"rs3",
+			},
+		},
+		"prune all old non-orphan replicas": {
+			Orphans:         false,
+			ReplicaSets:     true,
+			KeepToungerThan: time.Hour,
+			KeepComplete:    0,
+			KeepFailed:      0,
+			ExpectedPruneNames: []string{
+				"build-2",
+				"build-3",
+				"rs1",
+				"rs3",
+			},
+		},
+		"prune all orphan replicationControlers": {
+			Orphans:         true,
+			ReplicaSets:     false,
+			KeepToungerThan: 0,
+			KeepComplete:    10,
+			KeepFailed:      1,
+			ExpectedPruneNames: []string{
+				"orphan-build-1",
+				"orphan-build-2",
+			},
+		},
+		"prune all orphans + failed replicas": {
+			Orphans:         true,
+			ReplicaSets:     true,
+			KeepToungerThan: 0,
+			KeepComplete:    10,
+			KeepFailed:      0,
+			ExpectedPruneNames: []string{
+				"build-3",
+				"orphan-build-1",
+				"orphan-build-2",
+				"orphan-rs1",
+			},
+		},
+		"prune keep 2 non-orphaned, completed relpicas": {
+			Orphans:         false,
+			ReplicaSets:     true,
+			KeepToungerThan: 0,
+			KeepComplete:    2,
+			KeepFailed:      0,
+			ExpectedPruneNames: []string{
+				"build-3",
+				"rs1",
+			},
+		},
+		"prune keep 1 non-orphaned, failed relpicas and 2 non-orphaned, completed replicas": {
+			Orphans:         false,
+			ReplicaSets:     true,
+			KeepToungerThan: 0,
+			KeepComplete:    2,
+			KeepFailed:      1,
+			ExpectedPruneNames: []string{
+				"rs1",
+			},
+		},
+		"prune everything not running": {
+			Orphans:         true,
+			ReplicaSets:     true,
+			KeepToungerThan: 0,
+			KeepComplete:    0,
+			KeepFailed:      0,
+			ExpectedPruneNames: []string{
+				"build-1",
+				"build-2",
+				"build-3",
+				"orphan-build-1",
+				"orphan-build-2",
+				"orphan-rs1",
+				"rs1",
+				"rs2",
+				"rs3",
+			},
+		},
+	}
 
-			deployments := []metav1.Object{}
-			replicas := []metav1.Object{}
+	for testName, test := range testCases {
+		recorder := &mockDeleteRecorder{set: sets.String{}}
 
-			deploymentConfig := mockDeploymentConfig("a", "deployment-config")
-			deployment := mockDeployment("b", "deployment")
-			deployments = append(deployments, deploymentConfig, deployment)
-
-			replicas = append(replicas, withCreated(withStatus(mockReplicationController("a", "build-1", deploymentConfig), deploymentStatusOption), now))
-			replicas = append(replicas, withCreated(withStatus(mockReplicationController("a", "build-2", deploymentConfig), deploymentStatusOption), old))
-			replicas = append(replicas, withSize(withCreated(withStatus(mockReplicationController("a", "build-3-with-replicas", deploymentConfig), deploymentStatusOption), old), 4))
-			replicas = append(replicas, withCreated(withStatus(mockReplicationController("a", "orphan-build-1", nil), deploymentStatusOption), now))
-			replicas = append(replicas, withCreated(withStatus(mockReplicationController("a", "orphan-build-2", nil), deploymentStatusOption), old))
-			replicas = append(replicas, withSize(withCreated(withStatus(mockReplicationController("a", "orphan-build-3-with-replicas", nil), deploymentStatusOption), old), 4))
-			replicas = append(replicas, mockReplicaSet("b", "rs1", deployment))
-			replicas = append(replicas, mockReplicaSet("b", "orphan-rs1", nil))
-
-			keepComplete := 1
-			keepFailed := 1
-			expectedValues := sets.String{}
-			filter := &andFilter{
-				filterPredicates: []FilterPredicate{
-					FilterZeroReplicaSize,
-					NewFilterBeforePredicate(keepYoungerThan),
-				},
-			}
-
-			if !orphans {
-				for i := 0; i < len(replicas)-1; i++ {
-					if len(replicas[i].GetOwnerReferences()) == 0 {
-						replicas = append(replicas[:i], replicas[i+1:]...)
-					}
-				}
-			}
-
-			dataSet := NewDataSet(deployments, filter.Filter(replicas))
-			resolver := NewPerDeploymentResolver(dataSet, keepComplete, keepFailed)
-			if orphans {
-				resolver = &mergeResolver{
-					resolvers: []Resolver{resolver, NewOrphanReplicaResolver(dataSet, deploymentStatusFilter)},
-				}
-			}
-			expectedDeployments, err := resolver.Resolve()
-			if err != nil {
-				t.Errorf("Unexpected error %v", err)
-			}
-			for _, item := range expectedDeployments {
-				expectedValues.Insert(item.GetName())
-			}
-
-			recorder := &mockDeleteRecorder{set: sets.String{}}
-
-			options := PrunerOptions{
-				KeepYoungerThan: keepYoungerThan,
-				Orphans:         orphans,
-				KeepComplete:    keepComplete,
-				KeepFailed:      keepFailed,
-				Deployments:     deployments,
-				Replicas:        replicas,
-				ReplicaSets:     true,
-			}
-			pruner := NewPruner(options)
-			if err := pruner.Prune(recorder); err != nil {
-				t.Errorf("Unexpected error %v", err)
-			}
-			recorder.Verify(t, expectedValues)
+		options := PrunerOptions{
+			KeepYoungerThan: test.KeepToungerThan,
+			Orphans:         test.Orphans,
+			ReplicaSets:     test.ReplicaSets,
+			KeepComplete:    test.KeepComplete,
+			KeepFailed:      test.KeepFailed,
+			Deployments:     deployments,
+			Replicas:        replicas,
 		}
-	}
+		pruner := NewPruner(options)
+		if err := pruner.Prune(recorder); err != nil {
+			t.Errorf("Unexpected error in test: %s: %v", testName, err)
+		}
 
+		recorder.Verify(t, sets.NewString(test.ExpectedPruneNames...))
+	}
 }

--- a/pkg/cli/admin/prune/deployments/resolvers.go
+++ b/pkg/cli/admin/prune/deployments/resolvers.go
@@ -123,8 +123,6 @@ func (o *perDeploymentResolver) Resolve() ([]metav1.Object, error) {
 			return nil, err
 		}
 
-		sort.Sort(ByMostRecent(replicas))
-
 		completeDeployments, failedDeployments := []metav1.Object{}, []metav1.Object{}
 		for _, replica := range replicas {
 			var status appsv1.DeploymentStatus


### PR DESCRIPTION
This allows `oc adm prune deployments --replica-sets=true --orphans=true` to work on orphaned ReplicaSets.