### PR TITLE
Bug 2045008: bump discovery burst

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -135,7 +135,7 @@ func NewOcCommand(in io.Reader, out, errout io.Writer) *cobra.Command {
 		BashCompletionFunction: bashCompletionFunc,
 	}
 
-	kubeConfigFlags := genericclioptions.NewConfigFlags(true).WithDiscoveryBurst(250)
+	kubeConfigFlags := genericclioptions.NewConfigFlags(true).WithDiscoveryBurst(350)
 	kubeConfigFlags.AddFlags(cmds.PersistentFlags())
 	matchVersionKubeConfigFlags := kcmdutil.NewMatchVersionFlags(kubeConfigFlags)
 	matchVersionKubeConfigFlags.AddFlags(cmds.PersistentFlags())


### PR DESCRIPTION
Manual cherry-pick of a single commit bumping discovery burst from https://github.com/openshift/oc/pull/1033

/assign @deejross 