### PR TITLE
Add TMOUT env to debug node pod

### DIFF
--- a/pkg/cli/debug/debug.go
+++ b/pkg/cli/debug/debug.go
@@ -1028,6 +1028,7 @@ func (o *DebugOptions) approximatePodTemplateForObject(object runtime.Object) (*
 						},
 						Env: []corev1.EnvVar{
 							{
+								// Set the Shell variable to auto-logout after 15m idle timeout
 								Name:  "TMOUT",
 								Value: "900",
 							},

--- a/pkg/cli/debug/debug.go
+++ b/pkg/cli/debug/debug.go
@@ -1026,6 +1026,12 @@ func (o *DebugOptions) approximatePodTemplateForObject(object runtime.Object) (*
 								MountPath: "/host",
 							},
 						},
+						Env: []corev1.EnvVar{
+							{
+								Name:  "TMOUT",
+								Value: "900",
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
This is to address https://issues.redhat.com/browse/RFE-2567

Setting a 15 minute idle timeout on debug node pods.