### PR TITLE
pkg/cli/admin/policy: fix dropped test error

### DIFF
--- a/pkg/cli/admin/policy/modify_roles_test.go
+++ b/pkg/cli/admin/policy/modify_roles_test.go
@@ -1341,6 +1341,10 @@ func modifyRoleAndCheck(t *testing.T, o *RoleModificationOptions, tcName, action
 	}
 
 	roleBindings, err := getRoleBindingAbstractionsList(o.RbacClient, o.RoleBindingNamespace)
+	if err != nil {
+		t.Errorf("%s: err fetching roleBindingAbstractionsList %v", tcName, err)
+	}
+
 	foundBindings := make([]string, len(expectedBindings))
 	for _, roleBinding := range roleBindings {
 		var foundBinding string


### PR DESCRIPTION
This fixes a dropped test error in `pkg/cli/admin/policy`.