### PR TITLE
Bug 2044140: pkg/cli/admin/upgrade: Fix nextStep option sense

### DIFF
--- a/pkg/cli/admin/upgrade/upgrade.go
+++ b/pkg/cli/admin/upgrade/upgrade.go
@@ -304,7 +304,7 @@ func (o *Options) Run() error {
 			c := findClusterOperatorStatusCondition(cv.Status.Conditions, configv1.RetrievedUpdates)
 
 			toImageOption := "--to-image"
-			if o.ToImage == "" {
+			if o.ToImage != "" {
 				toImageOption = "--allow-explicit-upgrade"
 			}
 			nextStep := fmt.Sprintf("%s to continue with the update", toImageOption)


### PR DESCRIPTION
As [Evgeni points out][1], there is a bug in a0f1832b91 (#1041).  When `--to-image` is not set, we want to mention that the user may want to set it.  When `--to-image` is set, we want to mention `--allow-explicit-update`.  The previous check had the reversed sense, and mentioned `--allow-explicit-upgrade` when `--to-image` was unset.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=2044140#c8