### PR TITLE
Bug 2052034: make sure that we check for resorces and files before picking the simplest path

### DIFF
--- a/pkg/cli/debug/debug.go
+++ b/pkg/cli/debug/debug.go
@@ -368,7 +368,7 @@ func (o *DebugOptions) RunDebug() error {
 	var infos []*resource.Info
 
 	// the simplest possible debug is an image
-	if len(o.Resources) == 0 {
+	if len(o.Resources) == 0 && len(o.FilenameOptions.Filenames) == 0 {
 		image := o.Image
 
 		if len(image) == 0 {


### PR DESCRIPTION
/assign @deejross 