### PR TITLE
Bug 2049234: Fix mirroring images that have dots in their namespace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/openshift/api v0.0.0-20220124143425-d74727069f6f
 	github.com/openshift/build-machinery-go v0.0.0-20220121085309-f94edc2d6874
 	github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3
-	github.com/openshift/library-go v0.0.0-20220124121022-2bc87c4fc9dd
+	github.com/openshift/library-go v0.0.0-20220210170159-18f172cff934
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/russross/blackfriday v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -880,8 +880,8 @@ github.com/openshift/kubernetes-cli-runtime v0.0.0-20211209151317-e6fb6de9735e h
 github.com/openshift/kubernetes-cli-runtime v0.0.0-20211209151317-e6fb6de9735e/go.mod h1:B5N3YH0KP1iKr6gEuJ/RRmGjO0mJQ/f/JrsmEiPQAlU=
 github.com/openshift/kubernetes-kubectl v0.0.0-20220124124213-df787b5b471c h1:YYOynNZGrC/BcZ/qQLy2L6Ap6M6+hxc+ordPlIUKx0E=
 github.com/openshift/kubernetes-kubectl v0.0.0-20220124124213-df787b5b471c/go.mod h1:TfcGEs3u4dkmoC2eku1GYymdGaMtPMcaLLFrX/RB2kI=
-github.com/openshift/library-go v0.0.0-20220124121022-2bc87c4fc9dd h1:ytkKe9YmynqosVwvPHKP8kYcCnp/rz/PI3ps+bixOw4=
-github.com/openshift/library-go v0.0.0-20220124121022-2bc87c4fc9dd/go.mod h1:6AmNM4N4nHftckybV/U7bQW+5AvK5TW81ndSI6KEidw=
+github.com/openshift/library-go v0.0.0-20220210170159-18f172cff934 h1:J3cN1DNqF0/R8sDkg6n56iE/tka3bm/uRUy4vmuUTdg=
+github.com/openshift/library-go v0.0.0-20220210170159-18f172cff934/go.mod h1:6AmNM4N4nHftckybV/U7bQW+5AvK5TW81ndSI6KEidw=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/ostreedev/ostree-go v0.0.0-20190702140239-759a8c1ac913/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/vendor/github.com/openshift/library-go/pkg/image/registryclient/client.go
+++ b/vendor/github.com/openshift/library-go/pkg/image/registryclient/client.go
@@ -237,11 +237,18 @@ func (c *Context) Repository(ctx context.Context, registry *url.URL, repoName st
 	if err != nil {
 		return nil, err
 	}
-	ref, err := imagereference.Parse(repoName)
+
+	registryName := registry.Host
+	if registryName == "registry-1.docker.io" {
+		registryName = "docker.io"
+	}
+	fullReference := fmt.Sprintf("%s/%s", registryName, repoName)
+
+	ref, err := imagereference.Parse(fullReference)
 	if err != nil {
 		return nil, err
 	}
-	ref.Registry = registry.Host
+
 	locator := repositoryLocator{
 		named: named,
 		ref:   ref,

--- a/vendor/github.com/openshift/library-go/pkg/image/registryclient/client_mirrored.go
+++ b/vendor/github.com/openshift/library-go/pkg/image/registryclient/client_mirrored.go
@@ -64,6 +64,7 @@ type blobMirroredRepoRetriever interface {
 
 // repositoryLocator caches the components necessary to connect to a single image repository.
 type repositoryLocator struct {
+	// ref is the full image reference as it is provided by the client.
 	ref reference.DockerImageReference
 	// url may specify a default protocol (http) instead of (https), but is otherwise calculated
 	// by taking ref.Registry and applying it to url.Host

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -650,7 +650,7 @@ github.com/openshift/client-go/user/clientset/versioned/fake
 github.com/openshift/client-go/user/clientset/versioned/scheme
 github.com/openshift/client-go/user/clientset/versioned/typed/user/v1
 github.com/openshift/client-go/user/clientset/versioned/typed/user/v1/fake
-# github.com/openshift/library-go v0.0.0-20220124121022-2bc87c4fc9dd
+# github.com/openshift/library-go v0.0.0-20220210170159-18f172cff934
 ## explicit; go 1.17
 github.com/openshift/library-go/pkg/apps/appsserialization
 github.com/openshift/library-go/pkg/apps/appsutil


### PR DESCRIPTION
This PR bumps library-go to get a new registryclient that can correctly
handle image references like

    registry.example.com/namespace.with.dot/foo