### PR TITLE
OSDOCS-3257: Adding in new metadata requirement for docs

### DIFF
--- a/hack/clibyexample/template
+++ b/hack/clibyexample/template
@@ -2,6 +2,7 @@
 // This template is for non-admin (not 'oc adm ...') commands
 // Uses 'source,bash' for proper syntax highlighting for comments in examples
 
+:_content-type: REFERENCE
 [id="openshift-cli-developer_{context}"]
 = OpenShift CLI (oc) developer commands
 

--- a/hack/clibyexample/template-admin
+++ b/hack/clibyexample/template-admin
@@ -2,6 +2,7 @@
 // This template is for admin ('oc adm ...') commands
 // Uses 'source,bash' for proper syntax highlighting for comments in examples
 
+:_content-type: REFERENCE
 [id="openshift-cli-admin_{context}"]
 = OpenShift CLI (oc) administrator commands
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-3257

We have a new metadata requirement on our doc files to identify the content type (REFERENCE in this case). Adding to the templates.