### PR TITLE
Allow oc adm inspect ns to collect ingresses resources, fix #1075

### DIFF
--- a/pkg/cli/admin/inspect/namespace.go
+++ b/pkg/cli/admin/inspect/namespace.go
@@ -24,6 +24,7 @@ func namespaceResourcesToCollect() []schema.GroupResource {
 		{Resource: "events"},
 		{Resource: "endpoints"},
 		{Resource: "endpointslices"},
+		{Resource: "ingresses"},
 		{Resource: "persistentvolumeclaims"},
 		{Resource: "poddisruptionbudgets"},
 		{Resource: "secrets"},


### PR DESCRIPTION
Allow `oc adm inspect ns/<namespace>` to collect ingress.networking.k8s.io resources