### PR TITLE
Allow triggers on batch/v1 CronJobs

### DIFF
--- a/pkg/cli/set/triggers.go
+++ b/pkg/cli/set/triggers.go
@@ -13,6 +13,7 @@ import (
 	kappsv1 "k8s.io/api/apps/v1"
 	kappsv1beta1 "k8s.io/api/apps/v1beta1"
 	kappsv1beta2 "k8s.io/api/apps/v1beta2"
+	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
@@ -805,7 +806,7 @@ func (t *TriggerDefinition) Apply(obj runtime.Object) error {
 	case *extensionsv1beta1.DaemonSet, *kappsv1beta2.DaemonSet, *kappsv1.DaemonSet,
 		*extensionsv1beta1.Deployment, *kappsv1beta1.Deployment, *kappsv1beta2.Deployment, *kappsv1.Deployment,
 		*kappsv1beta1.StatefulSet, *kappsv1beta2.StatefulSet, *kappsv1.StatefulSet,
-		*batchv1beta1.CronJob:
+		*batchv1beta1.CronJob, *batchv1.CronJob:
 
 		if len(t.GitHubWebHooks) > 0 {
 			return fmt.Errorf("does not support GitHub web hooks")
@@ -1039,7 +1040,7 @@ func UpdateTriggersForObject(obj runtime.Object, fn func(*TriggerDefinition) err
 	case *extensionsv1beta1.DaemonSet, *kappsv1beta2.DaemonSet, *kappsv1.DaemonSet,
 		*extensionsv1beta1.Deployment, *kappsv1beta1.Deployment, *kappsv1beta2.Deployment, *kappsv1.Deployment,
 		*kappsv1beta1.StatefulSet, *kappsv1beta2.StatefulSet, *kappsv1.StatefulSet,
-		*batchv1beta1.CronJob:
+		*batchv1beta1.CronJob, *batchv1.CronJob:
 		triggers, err := NewAnnotationTriggers(obj)
 		if err != nil {
 			return false, err


### PR DESCRIPTION
OKD 4.8 uses Kubernetes 1.21 which has changed the `CronJob`'s version to `batch/v1`. Unfortunately, `oc set triggers` isn't aware of that change yet which means it is impossible to configure `Image` triggers on a `CronJob`.