### PR TITLE
Bug 2057633: add validations for a pod & container to rsync

### DIFF
--- a/pkg/cli/rsync/copy_rsync.go
+++ b/pkg/cli/rsync/copy_rsync.go
@@ -74,7 +74,7 @@ func NewRsyncStrategy(o *RsyncOptions) CopyStrategy {
 		RshCommand:     o.RshCmd,
 		RemoteExecutor: newRemoteExecutor(o),
 		LocalExecutor:  newLocalExecutor(),
-		podChecker:     podAPIChecker{o.Client, o.Namespace, podName},
+		podChecker:     podAPIChecker{o.Client, o.Namespace, podName, o.ContainerName, o.Quiet, o.ErrOut},
 	}
 }
 


### PR DESCRIPTION
The oc rsync fails, complaining that rsync and tar are missing in the
container:

```
$ oc rsync --container foo -n openshift-storage pod/rook-ceph-tools-56f88ff6cb-tvpg5:/etc/redhat-release /tmp
WARNING: cannot use rsync: rsync not available in container
WARNING: cannot use tar: tar not available in container
error: No available strategies to copy.
```