### PR TITLE
pkg/cli/admin/upgrade: Mention channel choices

### DIFF
--- a/pkg/cli/admin/upgrade/upgrade.go
+++ b/pkg/cli/admin/upgrade/upgrade.go
@@ -45,7 +45,7 @@ func New(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command
 	o := NewOptions(streams)
 	cmd := &cobra.Command{
 		Use:     "upgrade --to=VERSION",
-		Short:   "Upgrade a cluster",
+		Short:   "Upgrade a cluster or adjust the upgrade channel",
 		Example: upgradeExample,
 		Long: templates.LongDesc(`
 			Check on upgrade status or upgrade the cluster to a newer version


### PR DESCRIPTION
Making it easier for folks to find the `oc adm upgrade channel` subcommand from 4b8f0fd876 (#576), when they look at `oc adm --help`.