### PR TITLE
fix: set Makefile shell to bash; seems to be a requirement in target(s)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL := /bin/bash
+
 all: build
 .PHONY: all
 


### PR DESCRIPTION
I am considering a PR to fix a dependency issue in `oc`, and the initial problem was that `make` does not work in my local env:

````bash
D:~/projects/github/oc $ make help
/bin/sh: 1: set: Illegal option -o pipefail
vendor/github.com/openshift/build-machinery-go/make/targets/golang/../../lib/golang.mk:22: *** `go` is required with minimal version "1.15.2", detected version "1.17.6". You can override this check by using `make GO_REQUIRED_MIN_VERSION:=`.  Stop.
````

I am not an expert on this, but after googling a bit, I found this [SO answer](https://stackoverflow.com/a/589300). That suggestion seems to fix the issues on my Ubuntu-based workstation:
````bash
D:~/projects/github/oc $ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 20.04.4 LTS
Release:        20.04
Codename:       focal
````