### PR TITLE
pkg/cli/admin/mustgather: label must-gather ns as privileged

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	k8s.io/component-base v0.23.2
 	k8s.io/klog/v2 v2.40.1
 	k8s.io/kubectl v0.23.2
+	k8s.io/pod-security-admission v0.23.2
 	k8s.io/utils v0.0.0-20211208161948-7d6a63dca704
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1721,6 +1721,8 @@ k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65/go.mod h1:sX9MT8g7NVZM5lV
 k8s.io/kubernetes v1.13.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/metrics v0.23.0 h1:hJH0UMmgmOZHuVuOjbxE/b3710DbwpmWLT6qh33RiJY=
 k8s.io/metrics v0.23.0/go.mod h1:NDiZTwppEtAuKJ1Rxt3S4dhyRzdp6yUcJf0vo023dPo=
+k8s.io/pod-security-admission v0.23.2 h1:ePNricRxtKZVV5rgQVtfcp3qCntHGjrQGXgA/XohBmY=
+k8s.io/pod-security-admission v0.23.2/go.mod h1:qbwG5XF7vHgTTk8XemjkR1GXAmyNHQQAo5bHWAJSskE=
 k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20200229041039-0a110f9eb7ab/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=

--- a/pkg/cli/admin/mustgather/mustgather.go
+++ b/pkg/cli/admin/mustgather/mustgather.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/kubectl/pkg/polymorphichelpers"
 	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util/templates"
+	admissionapi "k8s.io/pod-security-admission/api"
 )
 
 var (
@@ -285,7 +286,8 @@ func (o *MustGatherOptions) Run() error {
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "openshift-must-gather-",
 			Labels: map[string]string{
-				"openshift.io/run-level": "0",
+				"openshift.io/run-level":       "0",
+				admissionapi.EnforceLevelLabel: string(admissionapi.LevelPrivileged),
 			},
 			Annotations: map[string]string{
 				"oc.openshift.io/command":    "oc adm must-gather",

--- a/vendor/k8s.io/pod-security-admission/LICENSE
+++ b/vendor/k8s.io/pod-security-admission/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/k8s.io/pod-security-admission/api/attributes.go
+++ b/vendor/k8s.io/pod-security-admission/api/attributes.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// Attributes exposes the admission request parameters consumed by the PodSecurity admission controller.
+type Attributes interface {
+	// GetName is the name of the object associated with the request.
+	GetName() string
+	// GetNamespace is the namespace associated with the request (if any)
+	GetNamespace() string
+	// GetResource is the name of the resource being requested.  This is not the kind.  For example: pods
+	GetResource() schema.GroupVersionResource
+	// GetKind is the name of the kind being requested.  For example: Pod
+	GetKind() schema.GroupVersionKind
+	// GetSubresource is the name of the subresource being requested.  This is a different resource, scoped to the parent resource, but it may have a different kind.
+	// For instance, /pods has the resource "pods" and the kind "Pod", while /pods/foo/status has the resource "pods", the sub resource "status", and the kind "Pod"
+	// (because status operates on pods). The binding resource for a pod though may be /pods/foo/binding, which has resource "pods", subresource "binding", and kind "Binding".
+	GetSubresource() string
+	// GetOperation is the operation being performed
+	GetOperation() admissionv1.Operation
+
+	// GetObject returns the typed Object from incoming request.
+	// For objects in the core API group, the result must use the v1 API.
+	GetObject() (runtime.Object, error)
+	// GetOldObject returns the typed existing object. Only populated for UPDATE requests.
+	// For objects in the core API group, the result must use the v1 API.
+	GetOldObject() (runtime.Object, error)
+	// GetUserName is the requesting user's authenticated name.
+	GetUserName() string
+}
+
+// AttributesRecord is a simple struct implementing the Attributes interface.
+type AttributesRecord struct {
+	Name        string
+	Namespace   string
+	Kind        schema.GroupVersionKind
+	Resource    schema.GroupVersionResource
+	Subresource string
+	Operation   admissionv1.Operation
+	Object      runtime.Object
+	OldObject   runtime.Object
+	Username    string
+}
+
+func (a *AttributesRecord) GetName() string {
+	return a.Name
+}
+func (a *AttributesRecord) GetNamespace() string {
+	return a.Namespace
+}
+func (a *AttributesRecord) GetKind() schema.GroupVersionKind {
+	return a.Kind
+}
+func (a *AttributesRecord) GetResource() schema.GroupVersionResource {
+	return a.Resource
+}
+func (a *AttributesRecord) GetSubresource() string {
+	return a.Subresource
+}
+func (a *AttributesRecord) GetOperation() admissionv1.Operation {
+	return a.Operation
+}
+func (a *AttributesRecord) GetUserName() string {
+	return a.Username
+}
+func (a *AttributesRecord) GetObject() (runtime.Object, error) {
+	return a.Object, nil
+}
+func (a *AttributesRecord) GetOldObject() (runtime.Object, error) {
+	return a.OldObject, nil
+}
+
+var _ Attributes = &AttributesRecord{}
+
+// RequestAttributes adapts an admission.Request to the Attributes interface.
+func RequestAttributes(request *admissionv1.AdmissionRequest, decoder runtime.Decoder) Attributes {
+	return &attributes{
+		r:       request,
+		decoder: decoder,
+	}
+}
+
+// attributes is an interface used by AdmissionController to get information about a request
+// that is used to make an admission decision.
+type attributes struct {
+	r       *admissionv1.AdmissionRequest
+	decoder runtime.Decoder
+}
+
+func (a *attributes) GetName() string {
+	return a.r.Name
+}
+func (a *attributes) GetNamespace() string {
+	return a.r.Namespace
+}
+func (a *attributes) GetKind() schema.GroupVersionKind {
+	return schema.GroupVersionKind(a.r.Kind)
+}
+func (a *attributes) GetResource() schema.GroupVersionResource {
+	return schema.GroupVersionResource(a.r.Resource)
+}
+func (a *attributes) GetSubresource() string {
+	return a.r.RequestSubResource
+}
+func (a *attributes) GetOperation() admissionv1.Operation {
+	return a.r.Operation
+}
+func (a *attributes) GetUserName() string {
+	return a.r.UserInfo.Username
+}
+func (a *attributes) GetObject() (runtime.Object, error) {
+	return a.decode(a.r.Object)
+}
+func (a *attributes) GetOldObject() (runtime.Object, error) {
+	return a.decode(a.r.OldObject)
+}
+func (a *attributes) decode(in runtime.RawExtension) (runtime.Object, error) {
+	if in.Raw == nil {
+		return nil, nil
+	}
+	gvk := schema.GroupVersionKind(a.r.Kind)
+	out, _, err := a.decoder.Decode(in.Raw, &gvk, nil)
+	return out, err
+}
+
+var _ Attributes = &attributes{}

--- a/vendor/k8s.io/pod-security-admission/api/constants.go
+++ b/vendor/k8s.io/pod-security-admission/api/constants.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+type Level string
+
+const (
+	LevelPrivileged Level = "privileged"
+	LevelBaseline   Level = "baseline"
+	LevelRestricted Level = "restricted"
+)
+
+var validLevels = []string{
+	string(LevelPrivileged),
+	string(LevelBaseline),
+	string(LevelRestricted),
+}
+
+const VersionLatest = "latest"
+
+const AuditAnnotationPrefix = labelPrefix
+
+const (
+	labelPrefix = "pod-security.kubernetes.io/"
+
+	EnforceLevelLabel   = labelPrefix + "enforce"
+	EnforceVersionLabel = labelPrefix + "enforce-version"
+	AuditLevelLabel     = labelPrefix + "audit"
+	AuditVersionLabel   = labelPrefix + "audit-version"
+	WarnLevelLabel      = labelPrefix + "warn"
+	WarnVersionLabel    = labelPrefix + "warn-version"
+
+	ExemptionReasonAnnotationKey = "exempt"
+	AuditViolationsAnnotationKey = "audit-violations"
+	EnforcedPolicyAnnotationKey  = "enforce-policy"
+)

--- a/vendor/k8s.io/pod-security-admission/api/doc.go
+++ b/vendor/k8s.io/pod-security-admission/api/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package api contains constants and helpers for PodSecurity admission label keys and values
+package api // import "k8s.io/pod-security-admission/api"

--- a/vendor/k8s.io/pod-security-admission/api/helpers.go
+++ b/vendor/k8s.io/pod-security-admission/api/helpers.go
@@ -1,0 +1,230 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/component-base/version"
+)
+
+type Version struct {
+	major  int
+	minor  int
+	latest bool
+}
+
+func (v Version) String() string {
+	if v.latest {
+		return "latest"
+	}
+	return fmt.Sprintf("v%d.%d", v.major, v.minor)
+}
+
+// Older returns true if this version v is older than the other.
+func (v *Version) Older(other Version) bool {
+	if v.latest { // Latest is always consider newer, even than future versions.
+		return false
+	}
+	if other.latest {
+		return true
+	}
+	if v.major != other.major {
+		return v.major < other.major
+	}
+	return v.minor < other.minor
+}
+
+func (v *Version) Major() int {
+	return v.major
+}
+func (v *Version) Minor() int {
+	return v.minor
+}
+func (v *Version) Latest() bool {
+	return v.latest
+}
+
+func MajorMinorVersion(major, minor int) Version {
+	return Version{major: major, minor: minor}
+}
+
+// GetAPIVersion get the version of apiServer and return the version major and minor
+func GetAPIVersion() Version {
+	var err error
+	v := Version{}
+	apiVersion := version.Get()
+	major, err := strconv.Atoi(apiVersion.Major)
+	if err != nil {
+		return v
+	}
+	// split the "normal" + and - for semver stuff to get the leading minor number
+	minorString := strings.FieldsFunc(apiVersion.Minor, func(r rune) bool {
+		return !unicode.IsDigit(r)
+	})[0]
+	minor, err := strconv.Atoi(minorString)
+	if err != nil {
+		return v
+	}
+	v = MajorMinorVersion(major, minor)
+	return v
+}
+
+func LatestVersion() Version {
+	return Version{latest: true}
+}
+
+// ParseLevel returns the level that should be evaluated.
+// level must be "privileged", "baseline", or "restricted".
+// if level does not match one of those strings, "restricted" and an error is returned.
+func ParseLevel(level string) (Level, error) {
+	switch Level(level) {
+	case LevelPrivileged, LevelBaseline, LevelRestricted:
+		return Level(level), nil
+	default:
+		return LevelRestricted, fmt.Errorf(`must be one of %s`, strings.Join(validLevels, ", "))
+	}
+}
+
+// Valid checks whether the level l is a valid level.
+func (l *Level) Valid() bool {
+	switch *l {
+	case LevelPrivileged, LevelBaseline, LevelRestricted:
+		return true
+	default:
+		return false
+	}
+}
+
+var versionRegexp = regexp.MustCompile(`^v1\.([0-9]|[1-9][0-9]*)$`)
+
+// ParseVersion returns the policy version that should be evaluated.
+// version must be "latest" or "v1.x".
+// If version does not match one of those patterns, the latest version and an error is returned.
+func ParseVersion(version string) (Version, error) {
+	if version == "latest" {
+		return Version{latest: true}, nil
+	}
+	match := versionRegexp.FindStringSubmatch(version)
+	if len(match) != 2 {
+		return Version{latest: true}, fmt.Errorf(`must be "latest" or "v1.x"`)
+	}
+	versionNumber, err := strconv.Atoi(match[1])
+	if err != nil || versionNumber < 0 {
+		return Version{latest: true}, fmt.Errorf(`must be "latest" or "v1.x"`)
+	}
+	return Version{major: 1, minor: versionNumber}, nil
+}
+
+type LevelVersion struct {
+	Level
+	Version
+}
+
+func (lv LevelVersion) String() string {
+	return fmt.Sprintf("%s:%s", lv.Level, lv.Version)
+}
+
+type Policy struct {
+	Enforce LevelVersion
+	Audit   LevelVersion
+	Warn    LevelVersion
+}
+
+// PolicyToEvaluate resolves the PodSecurity namespace labels to the policy for that namespace,
+// falling back to the provided defaults when a label is unspecified. A valid policy is always
+// returned, even when an error is returned. If labels cannot be parsed correctly, the values of
+// "restricted" and "latest" are used for level and version respectively.
+func PolicyToEvaluate(labels map[string]string, defaults Policy) (Policy, field.ErrorList) {
+	var (
+		err  error
+		errs field.ErrorList
+
+		p = defaults
+	)
+	if len(labels) == 0 {
+		return p, nil
+	}
+	if level, ok := labels[EnforceLevelLabel]; ok {
+		p.Enforce.Level, err = ParseLevel(level)
+		errs = appendErr(errs, err, EnforceLevelLabel, level)
+	}
+	if version, ok := labels[EnforceVersionLabel]; ok {
+		p.Enforce.Version, err = ParseVersion(version)
+		errs = appendErr(errs, err, EnforceVersionLabel, version)
+	}
+	if level, ok := labels[AuditLevelLabel]; ok {
+		p.Audit.Level, err = ParseLevel(level)
+		errs = appendErr(errs, err, AuditLevelLabel, level)
+		if err != nil {
+			p.Audit.Level = LevelPrivileged // Fail open for audit.
+		}
+	}
+	if version, ok := labels[AuditVersionLabel]; ok {
+		p.Audit.Version, err = ParseVersion(version)
+		errs = appendErr(errs, err, AuditVersionLabel, version)
+	}
+	if level, ok := labels[WarnLevelLabel]; ok {
+		p.Warn.Level, err = ParseLevel(level)
+		errs = appendErr(errs, err, WarnLevelLabel, level)
+		if err != nil {
+			p.Warn.Level = LevelPrivileged // Fail open for warn.
+		}
+	}
+	if version, ok := labels[WarnVersionLabel]; ok {
+		p.Warn.Version, err = ParseVersion(version)
+		errs = appendErr(errs, err, WarnVersionLabel, version)
+	}
+	return p, errs
+}
+
+// CompareLevels returns an integer comparing two levels by strictness. The result will be 0 if
+// a==b, -1 if a is less strict than b, and +1 if a is more strict than b.
+func CompareLevels(a, b Level) int {
+	if a == b {
+		return 0
+	}
+	switch a {
+	case LevelPrivileged:
+		return -1
+	case LevelRestricted:
+		return 1
+	default:
+		if b == LevelPrivileged {
+			return 1
+		} else if b == LevelRestricted {
+			return -1
+		}
+	}
+	// This should only happen if both a & b are invalid levels.
+	return 0
+}
+
+var labelsPath = field.NewPath("metadata", "labels")
+
+// appendErr is a helper function to collect label-specific errors.
+func appendErr(errs field.ErrorList, err error, label, value string) field.ErrorList {
+	if err != nil {
+		return append(errs, field.Invalid(labelsPath.Key(label), value, err.Error()))
+	}
+	return errs
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1351,6 +1351,9 @@ k8s.io/metrics/pkg/client/clientset/versioned
 k8s.io/metrics/pkg/client/clientset/versioned/scheme
 k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1
 k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1
+# k8s.io/pod-security-admission v0.23.2
+## explicit; go 1.16
+k8s.io/pod-security-admission/api
 # k8s.io/utils v0.0.0-20211208161948-7d6a63dca704
 ## explicit; go 1.12
 k8s.io/utils/buffer


### PR DESCRIPTION
This labels the must-gather namespace as privileged. Depending on the options (i.e. host-network) this namespace has to be privileged.

```
$ for f in registry-*/audit_logs/kube-apiserver/*audit.log.gz; do gzcat $f; done | jq  '. | select((.annotations | has("pod-security.kubernetes.io/audit-violations"))) | {objectRef: (.objectRef.namespace + "/" + .objectRef.resource + "/"+ .objectRef.name), "pod-security.kubernetes.io/audit-violations": .annotations["pod-security.kubernetes.io/audit-violations"]}' | jq -C -s --sort-keys '. | unique | .[]'

{
  "objectRef": "openshift-must-gather-lhspw/pods/",
  "pod-security.kubernetes.io/audit-violations": "would violate PodSecurity \"restricted:latest\": allowPrivilegeEscalation != false (containers \"gather\", \"copy\" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (containers \"gather\", \"copy\" must set securityContext.capabilities.drop=[\"ALL\"]), runAsNonRoot != true (pod or containers \"gather\", \"copy\" must set securityContext.runAsNonRoot=true), seccompProfile (pod or containers \"gather\", \"copy\" must set securityContext.seccompProfile.type to \"RuntimeDefault\" or \"Localhost\")"
}
 ```

/cc @soltysh @stlaz 