### PR TITLE
Bug 2041454: Validate reference-policy for import-image command

### DIFF
--- a/pkg/cli/importimage/importimage.go
+++ b/pkg/cli/importimage/importimage.go
@@ -197,6 +197,16 @@ func (o *ImportImageOptions) Validate() error {
 		return fmt.Errorf("you must specify the name of an image stream")
 	}
 
+	switch strings.ToLower(o.ReferencePolicy) {
+	case tag.SourceReferencePolicy:
+	case "":
+		o.ReferencePolicy = tag.SourceReferencePolicy
+	case tag.LocalReferencePolicy:
+		o.ReferencePolicy = tag.LocalReferencePolicy
+	default:
+		return fmt.Errorf("valid reference policy values are source or local")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This PR adds validation for reference-policy flag for import-image
command. It will return error when reference-policy is other than
source or local. In addition to that upper or lower cases will be treated
as valid(ie. Local, loCal, Source, etc.)