### PR TITLE
Bug 2071614: Remove network CRDs scheme registration

### DIFF
--- a/cmd/oc/oc.go
+++ b/cmd/oc/oc.go
@@ -20,7 +20,6 @@ import (
 	"github.com/openshift/api/authorization"
 	"github.com/openshift/api/build"
 	"github.com/openshift/api/image"
-	"github.com/openshift/api/network"
 	"github.com/openshift/api/oauth"
 	"github.com/openshift/api/project"
 	quotav1 "github.com/openshift/api/quota/v1"
@@ -62,7 +61,6 @@ func main() {
 	utilruntime.Must(authorization.Install(scheme.Scheme))
 	utilruntime.Must(build.Install(scheme.Scheme))
 	utilruntime.Must(image.Install(scheme.Scheme))
-	utilruntime.Must(network.Install(scheme.Scheme))
 	utilruntime.Must(oauth.Install(scheme.Scheme))
 	utilruntime.Must(project.Install(scheme.Scheme))
 	utilruntime.Must(installNonCRDQuota(scheme.Scheme))


### PR DESCRIPTION
Api server does not permit strategic merge patch type for CRDs during
patch operations. This is ensured by not registering CRDs schemes.

Therefore, `oc` must only register non-crds into scheme. This PR removes
`network.openshift.io` registration because it does not contain any non-crd.
ref: https://github.com/openshift/api/blob/2f6f4d85d80b3f39d66e7e1674aeff71f8a68b3d/network/v1/register.go#L33-L40