### PR TITLE
Bug 2065507: Add the ReleaseAccepted condition to the oc adm upgrade command

### DIFF
--- a/pkg/cli/admin/upgrade/upgrade.go
+++ b/pkg/cli/admin/upgrade/upgrade.go
@@ -377,6 +377,10 @@ func (o *Options) Run() error {
 			fmt.Fprintf(o.Out, "Upgradeable=False\n\n  Reason: %s\n  Message: %s\n\n", c.Reason, strings.ReplaceAll(c.Message, "\n", "\n  "))
 		}
 
+		if c := findClusterOperatorStatusCondition(cv.Status.Conditions, "ReleaseAccepted"); c != nil && c.Status != configv1.ConditionTrue {
+			fmt.Fprintf(o.Out, "ReleaseAccepted=%s\n\n  Reason: %s\n  Message: %s\n\n", c.Status, c.Reason, strings.ReplaceAll(c.Message, "\n", "\n  "))
+		}
+
 		if cv.Spec.Channel != "" {
 			if cv.Spec.Upstream == "" {
 				fmt.Fprint(o.Out, "Upstream is unset, so the cluster will use an appropriate default.\n")


### PR DESCRIPTION
To accurately display the upgrade's status add the `ReleaseAccepted` condition to the `oc adm upgrade` command.

With the new logic introduced by the bug fix for the CVO (https://bugzilla.redhat.com/show_bug.cgi?id=1822752), it is necessary to accurately display the current status of the upgrade in a case where a release payload wasn't accepted.

This change will display (using the `oc adm upgrade` command) the reason and the message containing information on why the given release payload wasn't accepted and thus why the update hasn't started.

Pull request related to https://issues.redhat.com/browse/OTA-589