### PR TITLE
Pass non-zero exit code to debug command

### DIFF
--- a/pkg/helpers/conditions/conditions.go
+++ b/pkg/helpers/conditions/conditions.go
@@ -71,6 +71,9 @@ func PodContainerRunning(containerName string, coreClient corev1client.CoreV1Int
 					continue
 				}
 				if s.State.Terminated != nil {
+					if s.State.Terminated.ExitCode != 0 {
+						return false, ErrNonZeroExitCode
+					}
 					return false, ErrContainerTerminated
 				}
 				return s.State.Running != nil, nil


### PR DESCRIPTION
`oc debug node/nodename -- chroot /host invalidcommand` returns failure
as expected but does not pass exit code to caller.

This PR handles non-zero code cases and if debug pod is terminated,
it passes to it.