### PR TITLE
Fix squash merge regex

### DIFF
--- a/pkg/cli/admin/release/git.go
+++ b/pkg/cli/admin/release/git.go
@@ -163,7 +163,7 @@ func gitOutputToError(err error, out string) error {
 }
 
 var (
-	squashRePR = regexp.MustCompile(`#(\d+)`)
+	squashRePR = regexp.MustCompile(`[(]#(\d+)[)]`)
 	rePR       = regexp.MustCompile(`^Merge pull request #(\d+) from`)
 	rePrefix   = regexp.MustCompile(`^(\[[\w\.\-]+\]\s*)+`)
 )

--- a/pkg/cli/admin/release/git_test.go
+++ b/pkg/cli/admin/release/git_test.go
@@ -246,6 +246,17 @@ func Test_mergeLogForRepo(t *testing.T) {
 				},
 			},
 		},
+		{
+			input:  "abc\x1e1\x1efix vendoring from #123 (#145)\x1e * fix vendoring from #123",
+			squash: true,
+			want: []MergeCommit{
+				{
+					ParentCommits: []string{}, Commit: "abc", PullRequest: 145, CommitDate: time.Unix(1, 0).UTC(),
+					Bugs:    BugList{},
+					Subject: "fix vendoring from #123 (#145)",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
As stated in here https://github.com/openshift/oc/pull/1116#discussion_r859881400,
current squash-merge regex does not cover the cases when PR subject also
contains some other PR reference(#123).

This PR fixes squash merge regex to also cover the cases where
PR subject also contains some other PR number.
