### PR TITLE
pkg/cli/debug: suggest pod security labels on violations

### DIFF
--- a/pkg/cli/debug/debug.go
+++ b/pkg/cli/debug/debug.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
 
+	ocmdhelpers "github.com/openshift/oc/pkg/helpers/cmd"
 	kappsv1 "k8s.io/api/apps/v1"
 	kappsv1beta1 "k8s.io/api/apps/v1beta1"
 	kappsv1beta2 "k8s.io/api/apps/v1beta2"
@@ -204,7 +205,7 @@ func NewCmdDebug(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra
 		Run: func(cmd *cobra.Command, args []string) {
 			kcmdutil.CheckErr(o.Complete(cmd, f, args))
 			kcmdutil.CheckErr(o.Validate())
-			kcmdutil.CheckErr(o.RunDebug())
+			ocmdhelpers.CheckPodSecurityErr(o.RunDebug())
 		},
 	}
 

--- a/pkg/helpers/cmd/errors.go
+++ b/pkg/helpers/cmd/errors.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
+)
+
+// CheckPodSecurityErr introspects the given error for pod security violations.
+// Upon successful detection it wraps it with suggestions on pod security labels
+// and delegates to k8s.io/kubectl/pkg/cmd/util#CheckErr.
+func CheckPodSecurityErr(err error) {
+	if agg, ok := err.(utilerrors.Aggregate); ok && len(agg.Errors()) == 1 {
+		err = agg.Errors()[0]
+	}
+
+	if err == nil {
+		return
+	}
+
+	if errors.IsForbidden(err) && strings.Contains(err.Error(), "violates PodSecurity") {
+		err = fmt.Errorf(`PodSecurity violation error: ensure the target namespace has the appropriate security level set `+
+			`or consider creating a dedicated privileged namespace using `+
+			`"oc create ns <namespace> -o yaml | oc label -f - pod-security.kubernetes.io/enforce=privileged pod-security.kubernetes.io/audit=privileged pod-security.kubernetes.io/warn=privileged": %w`, err)
+	}
+
+	kcmdutil.CheckErr(err)
+}


### PR DESCRIPTION
This gives suggestions on how to act in case of `oc debug` pod security violations.

Example on starting a node debug pod:

```
$ oc debug node/master0
error: PodSecurity violation error: ensure the target namespace has the appropriate security level set or consider creating a dedicated privileged namespace using "oc create ns <namespace> -o yaml | oc label -f - pod-security.kubernetes.io/enforce=privileged pod-security.kubernetes.io/audit=privileged pod-security.kubernetes.io/warn=privileged":
pods "surbania050302-qghrx-master-0copenshift-gce-develinternal-debug" is forbidden:
violates PodSecurity "restricted:latest":
host namespaces (hostNetwork=true, hostPID=true), hostPath volumes (volume "host"), privileged (container "container-00" must not set securityContext.privileged=true), allowPrivilegeEscalation != false (container "container-00" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "container-00" must set securityContext.capabilities.drop=["ALL"]), restricted volume types (volume "host" uses restricted volume type "hostPath"), runAsNonRoot != true (pod or container "container-00" must set securityContext.runAsNonRoot=true), runAsUser=0 (container "container-00" must not set runAsUser=0), seccompProfile (pod or container "container-00" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
```

Example on starting a pod debug pod on a restricted namespace:
```
$ oc debug pod/nginx-deployment-6ffcf46499-6fzf7
error: PodSecurity violation error:
ensure the target namespace has the appropriate security level set or consider creating a dedicated privileged namespace using "oc create ns <namespace> -o yaml | oc label -f - pod-security.kubernetes.io/enforce=privileged pod-security.kubernetes.io/audit=privileged pod-security.kubernetes.io/warn=privileged":
pods "nginx-deployment-6ffcf46499-6fzf7-debug" is forbidden: violates PodSecurity "restricted:latest": runAsNonRoot != true (pod or container "nginx" must set securityContext.runAsNonRoot=true)
```

Unfortunately I didn't find better heuristics or a better central place to generate this error message. Please advise, if necessary:

a) better heuristics
b) a better code location
c) better messaging

/cc @soltysh @deads2k 