### PR TITLE
Bug 2080416: Fix project command auto completion

### DIFF
--- a/pkg/cli/project/project.go
+++ b/pkg/cli/project/project.go
@@ -80,14 +80,12 @@ func NewProjectOptions(streams genericclioptions.IOStreams) *ProjectOptions {
 func NewCmdProject(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
 	o := NewProjectOptions(streams)
 
-	validArgs := []string{"project"}
-
 	cmd := &cobra.Command{
 		Use:               "project [NAME]",
 		Short:             "Switch to another project",
 		Long:              projectLong,
 		Example:           projectExample,
-		ValidArgsFunction: completion.SpecifiedResourceTypeAndNameCompletionFunc(f, validArgs),
+		ValidArgsFunction: completion.ResourceNameCompletionFunc(f, "project"),
 		Run: func(cmd *cobra.Command, args []string) {
 			kcmdutil.CheckErr(o.Complete(f, cmd, args))
 			kcmdutil.CheckErr(o.Run())


### PR DESCRIPTION
Currently if user enters <tab> after `oc project`, it auto completes
as `oc project project`. This PR fixes that and after entering <tab>,
it lists all projects.