### PR TITLE
Deprecate oc serviceaccounts command

### DIFF
--- a/pkg/cli/serviceaccounts/create_kubeconfig.go
+++ b/pkg/cli/serviceaccounts/create_kubeconfig.go
@@ -61,10 +61,12 @@ func NewCommandCreateKubeconfig(f cmdutil.Factory, streams genericclioptions.IOS
 	options := NewCreateKubeconfigOptions(streams)
 
 	cmd := &cobra.Command{
-		Use:     "create-kubeconfig NAME",
-		Short:   createKubeconfigShort,
-		Long:    createKubeconfigLong,
-		Example: createKubeconfigExamples,
+		Use:        "create-kubeconfig NAME",
+		Short:      createKubeconfigShort,
+		Long:       createKubeconfigLong,
+		Example:    createKubeconfigExamples,
+		Hidden:     true,
+		Deprecated: "and will be removed in the future version. Use oc create token instead.",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(options.Complete(args, f, cmd))
 			cmdutil.CheckErr(options.Validate())

--- a/pkg/cli/serviceaccounts/gettoken.go
+++ b/pkg/cli/serviceaccounts/gettoken.go
@@ -56,10 +56,12 @@ func NewCommandGetServiceAccountToken(f cmdutil.Factory, streams genericclioptio
 	options := NewGetServiceAccountTokenOptions(streams)
 
 	getServiceAccountTokenCommand := &cobra.Command{
-		Use:     "get-token NAME",
-		Short:   getServiceAccountTokenShort,
-		Long:    getServiceAccountTokenLong,
-		Example: getServiceAccountTokenExamples,
+		Use:        "get-token NAME",
+		Short:      getServiceAccountTokenShort,
+		Long:       getServiceAccountTokenLong,
+		Example:    getServiceAccountTokenExamples,
+		Hidden:     true,
+		Deprecated: "and will be removed in the future version. Use oc create token instead.",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(options.Complete(args, f, cmd))
 			cmdutil.CheckErr(options.Validate())

--- a/pkg/cli/serviceaccounts/newtoken.go
+++ b/pkg/cli/serviceaccounts/newtoken.go
@@ -76,10 +76,12 @@ func NewCommandNewServiceAccountToken(f cmdutil.Factory, streams genericclioptio
 
 	var requestedLabels string
 	newServiceAccountTokenCommand := &cobra.Command{
-		Use:     "new-token",
-		Short:   newServiceAccountTokenShort,
-		Long:    newServiceAccountTokenLong,
-		Example: newServiceAccountTokenExamples,
+		Use:        "new-token",
+		Short:      newServiceAccountTokenShort,
+		Long:       newServiceAccountTokenLong,
+		Example:    newServiceAccountTokenExamples,
+		Hidden:     true,
+		Deprecated: "and will be removed in the future version. Use oc create token instead.",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(options.Complete(args, requestedLabels, f, cmd))
 			cmdutil.CheckErr(options.Validate())

--- a/pkg/cli/serviceaccounts/subcommand.go
+++ b/pkg/cli/serviceaccounts/subcommand.go
@@ -20,11 +20,13 @@ const (
 
 func NewCmdServiceAccounts(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
 	cmds := &cobra.Command{
-		Use:     "serviceaccounts",
-		Short:   serviceAccountsShort,
-		Long:    serviceAccountsLong,
-		Aliases: []string{"sa"},
-		Run:     kcmdutil.DefaultSubCommandRun(streams.ErrOut),
+		Use:        "serviceaccounts",
+		Short:      serviceAccountsShort,
+		Long:       serviceAccountsLong,
+		Hidden:     true,
+		Deprecated: "and will be removed in the future version. Use oc create token instead.",
+		Aliases:    []string{"sa"},
+		Run:        kcmdutil.DefaultSubCommandRun(streams.ErrOut),
 	}
 
 	cmds.AddCommand(NewCommandCreateKubeconfig(f, streams))


### PR DESCRIPTION
As discussed on slack, start deprecating `oc serviceaccounts` commands in favor of `oc create token`. 
/assign @stlaz @s-urbaniak