### PR TITLE
Replace temporary show-managed fields hack with a proper solution

### DIFF
--- a/pkg/cli/admin/inspect/inspect.go
+++ b/pkg/cli/admin/inspect/inspect.go
@@ -18,7 +18,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
@@ -88,8 +87,12 @@ type InspectOptions struct {
 }
 
 func NewInspectOptions(streams genericclioptions.IOStreams) *InspectOptions {
+	printFlags := genericclioptions.NewPrintFlags("gathered").WithDefaultOutput("yaml").WithTypeSetter(scheme.Scheme)
+	if printFlags.JSONYamlPrintFlags != nil {
+		printFlags.JSONYamlPrintFlags.ShowManagedFields = true
+	}
 	return &InspectOptions{
-		printFlags:  genericclioptions.NewPrintFlags("gathered").WithDefaultOutput("yaml").WithTypeSetter(scheme.Scheme),
+		printFlags:  printFlags,
 		configFlags: genericclioptions.NewConfigFlags(true),
 		overwrite:   true,
 		IOStreams:   streams,
@@ -174,13 +177,6 @@ func (o *InspectOptions) Complete(args []string) error {
 	printer, err := o.printFlags.ToPrinter()
 	if err != nil {
 		return err
-	}
-	// TODO (soltysh) change this to set WithManagedFields in PrintFlags creation
-	// above when https://github.com/kubernetes/kubernetes/pull/107947 merges
-	if tsp, ok := printer.(*printers.TypeSetterPrinter); ok {
-		if omp, ok := tsp.Delegate.(*printers.OmitManagedFieldsPrinter); ok {
-			printer = &printers.TypeSetterPrinter{Typer: scheme.Scheme, Delegate: omp.Delegate}
-		}
 	}
 	o.fileWriter = NewMultiSourceWriter(printer)
 


### PR DESCRIPTION
This is followup to https://github.com/openshift/oc/pull/1051 after we landed k8s 1.24. It removes that temporary hack in favor of directly setting `ShowManagedFields` in printers. 

/assign @deejross 