### PR TITLE
Bug 2023295: [inspect] Add namespace-scoped networking resources to inspect

### DIFF
--- a/pkg/cli/admin/inspect/namespace.go
+++ b/pkg/cli/admin/inspect/namespace.go
@@ -21,9 +21,11 @@ func namespaceResourcesToCollect() []schema.GroupResource {
 		// this is actually a group which collects most useful things
 		{Resource: "all"},
 		{Resource: "configmaps"},
+		{Resource: "egressfirewalls"},
 		{Resource: "events"},
 		{Resource: "endpoints"},
 		{Resource: "endpointslices"},
+		{Resource: "networkpolicies"},
 		{Resource: "persistentvolumeclaims"},
 		{Resource: "poddisruptionbudgets"},
 		{Resource: "secrets"},


### PR DESCRIPTION
add `egressfirewalls` and `networkpolicies` to the namespace resources.
Required for networking debugging.
`egressfirewalls` are only registered for ovn-kubernetes network plugin, but inspect will just skip them for other clusters and log
```
error: errors occurred while gathering data:
    the server doesn't have a resource type "egressfirewalls"
```

Signed-off-by: Nadia Pinaeva <npinaeva@redhat.com>