### PR TITLE
[WIP] Bug 2075638: Specify an architecture when retrieving release payloads 

### DIFF
--- a/pkg/cli/admin/release/release.go
+++ b/pkg/cli/admin/release/release.go
@@ -1,7 +1,10 @@
 package release
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -25,4 +28,24 @@ func NewCmd(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Comm
 	cmd.AddCommand(NewExtract(f, streams))
 	cmd.AddCommand(NewMirror(f, streams))
 	return cmd
+}
+
+func (o *ArchOptions) Bind(flags *pflag.FlagSet) {
+	flags.StringVar(&o.Arch, "arch", o.Arch, "Specify a release's architecture (amd64|arm64|ppc64le|s390x). When used, it will bypass searching the current connected cluster for the release payload.")
+}
+
+type ArchOptions struct {
+	Arch string
+}
+
+// Validating Arch, if --arch is passed
+func (o *ArchOptions) Validate() error {
+	if len(o.Arch) > 0 {
+		switch o.Arch {
+		case "", "amd64", "arm64", "ppc64le", "s390x":
+			return nil
+		}
+		return fmt.Errorf("%s is not a valid arch", o.Arch)
+	}
+	return nil
 }


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2075638

Currently ,if a user is not connected to an arm64/s390x/ppc64le cluster they can only search x86 release payloads when using `oc adm release info|extract|mirror`

We would like to be able to pass `--arch` to specify which cincinnati graph to query from `https://api.openshift.com/api/upgrades_info/v1/graph` 

cc: @Prashanth684 