### PR TITLE
Bug 2083770: Change release signature file extension to json

### DIFF
--- a/pkg/cli/admin/release/mirror.go
+++ b/pkg/cli/admin/release/mirror.go
@@ -59,7 +59,7 @@ const configFilesBaseDir = "config"
 const maxDigestHashLen = 16
 
 // signatureFileNameFmt defines format of the release image signature file name.
-const signatureFileNameFmt = "signature-%s-%s.yaml"
+const signatureFileNameFmt = "signature-%s-%s.json"
 
 // archMap maps Go architecture strings to OpenShift supported values for any that differ.
 var archMap = map[string]string{


### PR DESCRIPTION
Release signatures are written in file in json format. However,
file extension is in yaml. This PR changes extension to json.

`oc-mirror` uses correct extension 
https://github.com/openshift/oc-mirror/blob/7bde4c7bde6b829a34592b2d12115fb38b15576f/pkg/cli/mirror/release.go#L39