### PR TITLE
Bug 2087103: pkg/cli/admin/upgrade: "Updating to" -> "Requesting update to"

### DIFF
--- a/pkg/cli/admin/upgrade/upgrade.go
+++ b/pkg/cli/admin/upgrade/upgrade.go
@@ -332,9 +332,9 @@ func (o *Options) Run() error {
 		}
 
 		if len(update.Version) > 0 {
-			fmt.Fprintf(o.Out, "Updating to %s\n", update.Version)
+			fmt.Fprintf(o.Out, "Requesting update to %s\n", update.Version)
 		} else {
-			fmt.Fprintf(o.Out, "Updating to release image %s\n", update.Image)
+			fmt.Fprintf(o.Out, "Requesting update to release image %s\n", update.Image)
 		}
 
 		return nil


### PR DESCRIPTION
The outgoing wording is from 3abf60a31e.  But the flow is:

1. User calls `oc adm upgrade ...` to request an update.
2. `oc` performs some client-side checks, which can be overridden with `--allow-upgrade-with-warnings`.
3. `oc` accepts the update, and patches ClusterVersion's `spec.desiredUpdate`.
4. The cluster-version operator performs some checks, which can be overridden with `--force`.
6. The CVO accepts the update, and begins updating.

The message I'm touching happens just after 3, but the outgoing wording [could be misinterpreted][1] as a claim about being at step 6. This commit pivots to wording that is more clearly tied to step 3.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=2087103