### PR TITLE
*: add relevant code owners for catalog alias

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -15,9 +15,12 @@ aliases:
     - vrutkovs
     - wking
   catalog-approvers:
-    - kevinrizza
+    - awgreene
+    - perdasilva
   catalog-reviewers:
-    - kevinrizza
+    - awgreene
+    - perdasilva
+    - tylerslaton
   build-reviewers:
     - adambkaplan
     - gabemontero


### PR DESCRIPTION
While working on #1152, we realized that the owners of this component is way too small. This PR adds the relevant owners (namely from the OLM team) to be able to review/approve code.