### PR TITLE
Bug 2097334: ensure kubectl name is replaced in plugin cmd

### DIFF
--- a/pkg/cli/kubectlwrappers/wrappers.go
+++ b/pkg/cli/kubectlwrappers/wrappers.go
@@ -214,7 +214,7 @@ func NewCmdPlugin(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobr
 	// when executing a plugin. Order matters here, we want to first see if a user
 	// has prefixed their plugin with "oc-", before defaulting to upstream behavior.
 	plugin.ValidPluginFilenamePrefixes = []string{"oc", "kubectl"}
-	return plugin.NewCmdPlugin(streams)
+	return cmdutil.ReplaceCommandName("kubectl", "oc", templates.Normalize(plugin.NewCmdPlugin(streams)))
 }
 
 func NewCmdApiResources(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {


### PR DESCRIPTION
/assign @ardaguclu @bergerhoffer 