### PR TITLE
[WIP] Differentiate between Jira and Bugzilla ID's

### DIFF
--- a/pkg/cli/admin/release/info.go
+++ b/pkg/cli/admin/release/info.go
@@ -1653,14 +1653,25 @@ func describeBugs(out, errOut io.Writer, diff *ReleaseDiff, dir string, format s
 		switch format {
 		case "name":
 			for _, b := range valid {
-				fmt.Fprintln(out, b.ID)
+				switch b.Source {
+				case Jira:
+					fmt.Fprintf(out, "OCPBUGS-%d\n", b.ID)
+				default:
+					fmt.Fprintln(out, b.ID)
+				}
 			}
+
 		default:
 			tw := tabwriter.NewWriter(out, 0, 0, 1, ' ', 0)
 			fmt.Fprintln(tw, "ID\tSTATUS\tPRIORITY\tSUMMARY")
 			for _, v := range valid {
 				if bug, ok := bugs[generateBugKey(v.Source, v.ID)]; ok {
-					fmt.Fprintf(tw, "%d\t%s\t%s\t%s\n", v.ID, bug.Status, bug.Priority, bug.Summary)
+					switch bug.Source {
+					case Jira:
+						fmt.Fprintf(tw, "OCPBUGS-%d\t%s\t%s\t%s\n", v.ID, bug.Status, bug.Priority, bug.Summary)
+					default:
+						fmt.Fprintf(tw, "%d\t%s\t%s\t%s\n", v.ID, bug.Status, bug.Priority, bug.Summary)
+					}
 				}
 			}
 			tw.Flush()


### PR DESCRIPTION
We'd like to propose the ability to differentiate between Jira issues and Bugzilla ID's when calling:
`oc adm release info --bugs=/tmp/git/ <from> <to>` and/or `oc adm release info --bugs=/tmp/git/ --output=name <from> <to>`.

Our team is working on the Jira migration and tools, such as the release-controller, are using the output from the commands, mentioned above, to process fetch and process bugs/issues associated with a release.  The issue we are facing is that there currently is no definitive way to distinguish between a Bugzilla ID and a Jira Issue ID with the current output.

This PR would change the output of the ID field, for Jira issues, to be prefixed with `OCPBUGS-`:
```sh
$ oc adm release info --bugs=/tmp/git/ --output=name registry.ci.openshift.org/ocp/release:4.11.0-0.nightly-2022-06-15-222801 registry.ci.openshift.org/ocp/release:4.11.0-0.nightly-2022-06-21-040754
1859153
1902307
1993916
OCPBUGS-2027603
2036629
2043068
OCPBUGS-2049108
2067865
```