### PR TITLE
Bug 2100138: Add json support for release info bug printing

### DIFF
--- a/pkg/cli/admin/release/bug.go
+++ b/pkg/cli/admin/release/bug.go
@@ -56,11 +56,11 @@ type BugRemoteList struct {
 // BugRemoteInfo stores the detail information of bug retrieved
 // from remote url like bugzilla or jira.
 type BugRemoteInfo struct {
-	ID       int    `json:"id"`
-	Status   string `json:"status"`
-	Priority string `json:"priority"`
-	Summary  string `json:"summary"`
-	Source   BugType
+	ID       int     `json:"id"`
+	Status   string  `json:"status"`
+	Priority string  `json:"priority"`
+	Summary  string  `json:"summary"`
+	Source   BugType `json:"source"`
 }
 
 type JiraRemoteBug struct {

--- a/pkg/cli/admin/release/info.go
+++ b/pkg/cli/admin/release/info.go
@@ -430,9 +430,9 @@ func (o *InfoOptions) Validate() error {
 	switch {
 	case len(o.BugsDir) > 0:
 		switch o.Output {
-		case "", "name":
+		case "", "name", "json":
 		default:
-			return fmt.Errorf("--output only supports 'name' for --bugs")
+			return fmt.Errorf("--output only supports 'name' or 'json' for --bugs")
 		}
 	case len(o.ChangelogDir) > 0:
 		if len(o.Output) > 0 {
@@ -1655,6 +1655,18 @@ func describeBugs(out, errOut io.Writer, diff *ReleaseDiff, dir string, format s
 			for _, b := range valid {
 				fmt.Fprintln(out, b.ID)
 			}
+		case "json":
+			var printedBugs []BugRemoteInfo
+			for _, v := range valid {
+				if bug, ok := bugs[generateBugKey(v.Source, v.ID)]; ok {
+					printedBugs = append(printedBugs, bug)
+				}
+			}
+			data, err := json.MarshalIndent(printedBugs, "", "  ")
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(out, string(data))
 		default:
 			tw := tabwriter.NewWriter(out, 0, 0, 1, ' ', 0)
 			fmt.Fprintln(tw, "ID\tSTATUS\tPRIORITY\tSUMMARY")


### PR DESCRIPTION
Currently, bug source types can be Bugzilla or Jira and there is no
differentiator point for bugs in `oc adm release info`. By passing
`--output=json`, users will be able to see bugs belong to Jira or
Bugzilla.

This PR adds json output format support for release info bugs.