### PR TITLE
Bug 2015321: Add destdir special character validation in must-gather

### DIFF
--- a/pkg/cli/admin/mustgather/mustgather.go
+++ b/pkg/cli/admin/mustgather/mustgather.go
@@ -270,6 +270,9 @@ func (o *MustGatherOptions) Validate() error {
 	if len(o.NodeName) > 0 && strings.ContainsAny(o.NodeName, "/%") {
 		return fmt.Errorf("--node-name may not contain '/' or '%%'")
 	}
+	if strings.Contains(o.DestDir, ":") {
+		return fmt.Errorf("--dest-dir may not contain special characters such as colon(:)")
+	}
 	return nil
 }
 


### PR DESCRIPTION
Colon character is used by rsync command to extract pod name and
determine the type of path is local or remote.

This PR adds validation to ensure that dest-dir option does not
contain any special character possibly affecting rsync.