### PR TITLE
Bug 2100708: Lower chosen platform architecture/OS log level

### DIFF
--- a/pkg/cli/image/manifest/manifest.go
+++ b/pkg/cli/image/manifest/manifest.go
@@ -439,7 +439,7 @@ func ProcessManifestList(ctx context.Context, srcDigest digest.Digest, srcManife
 			if err != nil {
 				return nil, nil, "", err
 			}
-			klog.Warningf("Chose %s/%s manifest from the manifest list.", t.Manifests[0].Platform.OS, t.Manifests[0].Platform.Architecture)
+			klog.V(2).Infof("Chose %s/%s manifest from the manifest list.", t.Manifests[0].Platform.OS, t.Manifests[0].Platform.Architecture)
 			return srcManifests, srcManifests[0], manifestDigest, nil
 		default:
 			return append(srcManifests, manifestList), manifestList, manifestDigest, nil


### PR DESCRIPTION
"Chose %s/%s manifest from the manifest list." log creates noise
especially for the commands calling image extraction in a multi-threaded way.

This PR lowers of this log's level. Users will still be able to see
these logs by passing `-v=2` but log will be disabled by default.