### PR TITLE
Bug 2100166: Add new IsManifestList flag into ReleaseInfo struct

### DIFF
--- a/pkg/cli/admin/release/extract.go
+++ b/pkg/cli/admin/release/extract.go
@@ -173,7 +173,7 @@ type ExtractOptions struct {
 	ExtractManifests bool
 	Manifests        []manifest.Manifest
 
-	ImageMetadataCallback func(m *extract.Mapping, dgst, contentDigest digest.Digest, config *dockerv1client.DockerImageConfig)
+	ImageMetadataCallback func(m *extract.Mapping, dgst, contentDigest digest.Digest, config *dockerv1client.DockerImageConfig, isManifestList bool)
 }
 
 func (o *ExtractOptions) Complete(f kcmdutil.Factory, cmd *cobra.Command, args []string) error {
@@ -413,10 +413,10 @@ func (o *ExtractOptions) Run() error {
 			},
 		}
 		verifier := imagemanifest.NewVerifier()
-		opts.ImageMetadataCallback = func(m *extract.Mapping, dgst, contentDigest digest.Digest, config *dockerv1client.DockerImageConfig) {
+		opts.ImageMetadataCallback = func(m *extract.Mapping, dgst, contentDigest digest.Digest, config *dockerv1client.DockerImageConfig, isManifestList bool) {
 			verifier.Verify(dgst, contentDigest)
 			if o.ImageMetadataCallback != nil {
-				o.ImageMetadataCallback(m, dgst, contentDigest, config)
+				o.ImageMetadataCallback(m, dgst, contentDigest, config, isManifestList)
 			}
 			if len(ref.Ref.ID) > 0 {
 				fmt.Fprintf(o.Out, "Extracted release payload created at %s\n", config.Created.Format(time.RFC3339))

--- a/pkg/cli/admin/release/extract_tools.go
+++ b/pkg/cli/admin/release/extract_tools.go
@@ -371,7 +371,11 @@ func (o *ExtractOptions) extractCommand(command string) error {
 	releaseName := release.PreferredName()
 	refExact := release.ImageRef
 	refExact.Ref.Tag = ""
-	refExact.Ref.ID = release.Digest.String()
+	// if the release image is manifestlist image, we'll not change digest with
+	// arch based sha. Because we want that the extracted tool can be used for all archs.
+	if !release.IsManifestList {
+		refExact.Ref.ID = release.Digest.String()
+	}
 	exactReleaseImage := refExact.String()
 
 	// resolve target image references to their pull specs

--- a/pkg/cli/admin/release/mirror.go
+++ b/pkg/cli/admin/release/mirror.go
@@ -491,7 +491,7 @@ func (o *MirrorOptions) Run() error {
 			}
 			extractOpts.FilterOptions.OSFilter = re
 		}
-		extractOpts.ImageMetadataCallback = func(m *extract.Mapping, dgst, contentDigest digest.Digest, config *dockerv1client.DockerImageConfig) {
+		extractOpts.ImageMetadataCallback = func(m *extract.Mapping, dgst, contentDigest digest.Digest, config *dockerv1client.DockerImageConfig, isManifestList bool) {
 			releaseDigest = contentDigest.String()
 			verifier.Verify(dgst, contentDigest)
 			if config != nil {

--- a/pkg/cli/admin/release/new.go
+++ b/pkg/cli/admin/release/new.go
@@ -384,7 +384,7 @@ func (o *NewOptions) Run() error {
 				From:     "release-manifests/",
 			},
 		}
-		extractOpts.ImageMetadataCallback = func(m *extract.Mapping, dgst, contentDigest digest.Digest, config *dockerv1client.DockerImageConfig) {
+		extractOpts.ImageMetadataCallback = func(m *extract.Mapping, dgst, contentDigest digest.Digest, config *dockerv1client.DockerImageConfig, isManifestList bool) {
 			verifier.Verify(dgst, contentDigest)
 			releaseDigest = contentDigest
 			if config.Config != nil {
@@ -937,7 +937,7 @@ func (o *NewOptions) extractManifests(is *imageapi.ImageStream, name string, met
 		opts.FilterOptions.OSFilter = re
 	}
 	opts.OnlyFiles = true
-	opts.ImageMetadataCallback = func(m *extract.Mapping, dgst, contentDigest digest.Digest, config *dockerv1client.DockerImageConfig) {
+	opts.ImageMetadataCallback = func(m *extract.Mapping, dgst, contentDigest digest.Digest, config *dockerv1client.DockerImageConfig, isManifestList bool) {
 		verifier.Verify(dgst, contentDigest)
 
 		lock.Lock()

--- a/pkg/cli/image/extract/extract.go
+++ b/pkg/cli/image/extract/extract.go
@@ -138,7 +138,7 @@ type ExtractOptions struct {
 
 	// ImageMetadataCallback is invoked once per image retrieved, and may be called in parallel if
 	// MaxPerRegistry is set higher than 1.
-	ImageMetadataCallback func(m *Mapping, dgst, contentDigest digest.Digest, imageConfig *dockerv1client.DockerImageConfig)
+	ImageMetadataCallback func(m *Mapping, dgst, contentDigest digest.Digest, imageConfig *dockerv1client.DockerImageConfig, isManifestList bool)
 	// TarEntryCallback, if set, is passed each entry in the viewed layers. Entries will be filtered
 	// by name and only the entry in the highest layer will be passed to the callback. Returning false
 	// will halt processing of the image.
@@ -518,7 +518,7 @@ func (o *ExtractOptions) Run() error {
 				}
 
 				if o.ImageMetadataCallback != nil {
-					o.ImageMetadataCallback(&mapping, location.Manifest, contentDigest, imageConfig)
+					o.ImageMetadataCallback(&mapping, location.Manifest, contentDigest, imageConfig, location.IsList())
 				}
 				return nil
 			})


### PR DESCRIPTION
`release info` and `release extract` commands need manifestlist image's
sha value instead filtered by os image sha.

Thanks to that, extracted tools will be used for all archs. This PR
adds IsManifestList field into ReleaseInfo and uses it when digest needs
to be set for these commands.