### PR TITLE
Bug 2101885: Set completion function for get command

### DIFF
--- a/pkg/cli/kubectlwrappers/wrappers.go
+++ b/pkg/cli/kubectlwrappers/wrappers.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/kubectl/pkg/cmd/scale"
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
 	kwait "k8s.io/kubectl/pkg/cmd/wait"
+	utilcomp "k8s.io/kubectl/pkg/util/completion"
 	"k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/openshift/oc/pkg/cli/create"
@@ -59,7 +60,9 @@ func adjustCmdExamples(cmd *cobra.Command, name string) {
 
 // NewCmdGet is a wrapper for the Kubernetes cli get command
 func NewCmdGet(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
-	return cmdutil.ReplaceCommandName("kubectl", "oc", templates.Normalize(kget.NewCmdGet("oc", f, streams)))
+	get := kget.NewCmdGet("oc", f, streams)
+	get.ValidArgsFunction = utilcomp.ResourceTypeAndNameCompletionFunc(f)
+	return cmdutil.ReplaceCommandName("kubectl", "oc", templates.Normalize(get))
 }
 
 // NewCmdReplace is a wrapper for the Kubernetes cli replace command


### PR DESCRIPTION
Completion function in get command was cut out from it and instead it is being set in [here](https://github.com/kubernetes/kubernetes/blob/e89a87f708a03c5a8331639739982d426077ad3a/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go#L325). This change was done in [this PR](https://github.com/kubernetes/kubernetes/pull/108493).

In order to support completion for get command, we need to set explicitly this in oc. This PR does this.

/cc @soltysh 