### PR TITLE
[release-4.9] Bug 2103910: Introduce an option to retrieve the rotated log files for a pod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
+	golang.org/x/net v0.0.0-20211209124913-491a49abca63
 	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac
 	gopkg.in/ldap.v2 v2.5.1

--- a/pkg/cli/admin/inspect/inspect.go
+++ b/pkg/cli/admin/inspect/inspect.go
@@ -76,6 +76,7 @@ type InspectOptions struct {
 	namespace      string
 	sinceTime      string
 	allNamespaces  bool
+	rotatedPodLogs bool
 	sinceInt       int64
 	sinceTimestamp metav1.Time
 
@@ -116,6 +117,11 @@ func NewCmdInspect(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd.Flags().BoolVarP(&o.allNamespaces, "all-namespaces", "A", o.allNamespaces, "If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
 	cmd.Flags().StringVar(&o.sinceTime, "since-time", o.sinceTime, "Only return logs after a specific date (RFC3339). Defaults to all logs. Only one of since-time / since may be used.")
 	cmd.Flags().DurationVar(&o.since, "since", o.since, "Only return logs newer than a relative duration like 5s, 2m, or 3h. Defaults to all logs. Only one of since-time / since may be used.")
+	cmd.Flags().BoolVar(&o.rotatedPodLogs, "rotated-pod-logs", o.rotatedPodLogs, "Experimental: If present, retrieve rotated log files that are available for selected pods. This can significantly increase the collected logs size. since/since-time is ignored for rotated logs.")
+
+	// The rotated-pod-logs option should be removed once support for retrieving rotated logs is added to kubelet
+	// https://github.com/kubernetes/kubernetes/issues/59902
+	cmd.Flags().MarkHidden("rotated-pod-logs")
 
 	o.configFlags.AddFlags(cmd.Flags())
 	return cmd

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -671,6 +671,7 @@ golang.org/x/crypto/ssh/terminal
 # golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6
 golang.org/x/exp/mmap
 # golang.org/x/net v0.0.0-20211209124913-491a49abca63
+## explicit
 golang.org/x/net/context
 golang.org/x/net/context/ctxhttp
 golang.org/x/net/html


### PR DESCRIPTION
Added a flag that allows the user to get the rotated pod log files stored by kubelet.
Currently logs that were rotated are not exposed through the K8s log API.

Almost clean cherry-pick, there was a conflict in `vendor/modules.txt`: https://github.com/openshift/oc/pull/958#issuecomment-1173959866

Signed-off-by: Patryk Diak <pdiak@redhat.com>
(cherry picked from commit efb24f6f65b76c64c5143185e340dbb050349a6b)