### PR TITLE
Support for identity token

### DIFF
--- a/pkg/cli/image/manifest/dockercredentials/auth_resolver.go
+++ b/pkg/cli/image/manifest/dockercredentials/auth_resolver.go
@@ -59,8 +59,9 @@ func NewAuthResolver(authFilePath string) (*AuthResolver, error) {
 				// give priority to the docker config file $HOME/.docker/config.json
 				for registry, entry := range config {
 					credentials[registry] = containertypes.DockerAuthConfig{
-						Username: entry.Username,
-						Password: entry.Password,
+						Username:      entry.Username,
+						Password:      entry.Password,
+						IdentityToken: entry.IdentityToken,
 					}
 				}
 			}

--- a/pkg/cli/image/manifest/dockercredentials/credential_store_factory.go
+++ b/pkg/cli/image/manifest/dockercredentials/credential_store_factory.go
@@ -39,7 +39,8 @@ func (c *credentialStoreFactory) CredentialStoreFor(image string) auth.Credentia
 	}
 
 	return dockerregistry.NewStaticCredentialStore(&types.AuthConfig{
-		Username: authCfg.Username,
-		Password: authCfg.Password,
+		Username:      authCfg.Username,
+		Password:      authCfg.Password,
+		IdentityToken: authCfg.IdentityToken,
 	})
 }

--- a/pkg/cli/image/manifest/dockercredentials/credential_store_factory_test.go
+++ b/pkg/cli/image/manifest/dockercredentials/credential_store_factory_test.go
@@ -31,7 +31,7 @@ func Test_CredentialStoreFactory(t *testing.T) {
 		store := credentialStoreFactory{
 			authResolver: &AuthResolver{
 				credentials: map[string]imageTypes.DockerAuthConfig{
-					image: {Username: "local_user", Password: "local_pass"},
+					image: {Username: "local_user", Password: "local_pass", IdentityToken: "somerandomtext"},
 				},
 			},
 		}

--- a/pkg/helpers/image/credentialprovider/config.go
+++ b/pkg/helpers/image/credentialprovider/config.go
@@ -35,9 +35,10 @@ type DockerConfig map[string]DockerConfigEntry
 
 // DockerConfigEntry wraps a docker config as a entry
 type DockerConfigEntry struct {
-	Username string
-	Password string
-	Email    string
+	Username      string
+	Password      string
+	Email         string
+	IdentityToken string
 }
 
 var (
@@ -247,6 +248,8 @@ type dockerConfigEntryWithAuth struct {
 	Email string `json:"email,omitempty"`
 	// +optional
 	Auth string `json:"auth,omitempty"`
+	// +optional
+	IdentityToken string `json:"identitytoken,omitempty"`
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
@@ -260,6 +263,7 @@ func (ident *DockerConfigEntry) UnmarshalJSON(data []byte) error {
 	ident.Username = tmp.Username
 	ident.Password = tmp.Password
 	ident.Email = tmp.Email
+	ident.IdentityToken = tmp.IdentityToken
 
 	if len(tmp.Auth) == 0 {
 		return nil
@@ -271,7 +275,7 @@ func (ident *DockerConfigEntry) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaler interface.
 func (ident DockerConfigEntry) MarshalJSON() ([]byte, error) {
-	toEncode := dockerConfigEntryWithAuth{ident.Username, ident.Password, ident.Email, ""}
+	toEncode := dockerConfigEntryWithAuth{ident.Username, ident.Password, ident.Email, "", ident.IdentityToken}
 	toEncode.Auth = encodeDockerConfigFieldAuth(ident.Username, ident.Password)
 
 	return json.Marshal(toEncode)

--- a/pkg/helpers/image/credentialprovider/config_test.go
+++ b/pkg/helpers/image/credentialprovider/config_test.go
@@ -133,6 +133,17 @@ func TestDockerConfigEntryJSONDecode(t *testing.T) {
 			fail: false,
 		},
 
+		// auth field decodes to username & IdentityToken
+		{
+			input: []byte(`{"auth": "aWFtYXBpa2V5Og==", "email": "foo@example.com", "identitytoken": "somerandomtoken"}`),
+			expect: DockerConfigEntry{
+				Username:      "iamapikey",
+				Email:         "foo@example.com",
+				IdentityToken: "somerandomtoken",
+			},
+			fail: false,
+		},
+
 		// auth field overrides username & password
 		{
 			// Fake values for testing.


### PR DESCRIPTION
This PR is to support the container registry with identity token.

This is how the typical `.docker/config.json` file looks like:

```json
{
        "auths": {
                "icr.io": {
                        "auth": "aWFtYXBpa2V5Og==",
                        "identitytoken": "xxxxxxxxxxxxxxxxxxxxx"
                }
         }
}
```

without this change:
```shell
$ oc adm release info icr.io/openshift-release-dev/ocp-release:4.11.0-0.nightly-multi-2022-07-06-015348-x86_64
Warning: the default reading order of registry auth file will be changed from "${HOME}/.docker/config.json" to podman registry config locations in the future version of oc. "${HOME}/.docker/config.json" is deprecated, but can still be used for storing credentials as a fallback. See https://github.com/containers/image/blob/main/docs/containers-auth.json.5.md for the order of podman registry config locations.
error: unable to read image icr.io/openshift-release-dev/ocp-release:4.11.0-0.nightly-multi-2022-07-06-015348-x86_64: Head "https://icr.io/v2/openshift-release-dev/ocp-release/manifests/4.11.0-0.nightly-multi-2022-07-06-015348-x86_64": unauthorized: The login credentials are not valid, or your IBM Cloud account is not active.
[root@mkumatag-workspace oc]#
```

after this fix:
```shell
$ ./oc adm release info icr.io/openshift-release-dev/ocp-release:4.11.0-0.nightly-multi-2022-07-06-015348-x86_64
Warning: the default reading order of registry auth file will be changed from "${HOME}/.docker/config.json" to podman registry config locations in the future version of oc. "${HOME}/.docker/config.json" is deprecated, but can still be used for storing credentials as a fallback. See https://github.com/containers/image/blob/main/docs/containers-auth.json.5.md for the order of podman registry config locations.
Name:           4.11.0-0.nightly-multi-2022-07-06-015348
Digest:
Created:        2022-07-06T01:59:05Z
OS/Arch:        linux/ppc64le
Manifests:      593
Metadata files: 1

Pull From: icr.io/openshift-release-dev/ocp-release

Release Metadata:
  Version:  4.11.0-0.nightly-multi-2022-07-06-015348
  Upgrades: <none>
  Metadata:
    release.openshift.io/architecture: multi

Component Versions:
  kubernetes 1.24.0
  machine-os 411.86.202207011902-0 Red Hat Enterprise Linux CoreOS

Images:
  NAME                                           DIGEST
........
........
```