### PR TITLE
Bug 2105325: Add ManifestListDigest field to release info struct

### DIFF
--- a/pkg/cli/admin/release/extract.go
+++ b/pkg/cli/admin/release/extract.go
@@ -173,7 +173,7 @@ type ExtractOptions struct {
 	ExtractManifests bool
 	Manifests        []manifest.Manifest
 
-	ImageMetadataCallback func(m *extract.Mapping, dgst, contentDigest digest.Digest, config *dockerv1client.DockerImageConfig, isManifestList bool)
+	ImageMetadataCallback func(m *extract.Mapping, dgst, contentDigest digest.Digest, config *dockerv1client.DockerImageConfig, manifestListDigest digest.Digest)
 }
 
 func (o *ExtractOptions) Complete(f kcmdutil.Factory, cmd *cobra.Command, args []string) error {
@@ -413,10 +413,10 @@ func (o *ExtractOptions) Run() error {
 			},
 		}
 		verifier := imagemanifest.NewVerifier()
-		opts.ImageMetadataCallback = func(m *extract.Mapping, dgst, contentDigest digest.Digest, config *dockerv1client.DockerImageConfig, isManifestList bool) {
+		opts.ImageMetadataCallback = func(m *extract.Mapping, dgst, contentDigest digest.Digest, config *dockerv1client.DockerImageConfig, manifestListDigest digest.Digest) {
 			verifier.Verify(dgst, contentDigest)
 			if o.ImageMetadataCallback != nil {
-				o.ImageMetadataCallback(m, dgst, contentDigest, config, isManifestList)
+				o.ImageMetadataCallback(m, dgst, contentDigest, config, manifestListDigest)
 			}
 			if len(ref.Ref.ID) > 0 {
 				fmt.Fprintf(o.Out, "Extracted release payload created at %s\n", config.Created.Format(time.RFC3339))

--- a/pkg/cli/admin/release/extract_tools.go
+++ b/pkg/cli/admin/release/extract_tools.go
@@ -373,8 +373,11 @@ func (o *ExtractOptions) extractCommand(command string) error {
 	refExact.Ref.Tag = ""
 	// if the release image is manifestlist image, we'll not change digest with
 	// arch based sha. Because we want that the extracted tool can be used for all archs.
-	if !release.IsManifestList {
+	if len(release.ManifestListDigest) == 0 {
 		refExact.Ref.ID = release.Digest.String()
+	} else {
+		// if the image is manifestlisted, use the manifestlist digest.
+		refExact.Ref.ID = release.ManifestListDigest.String()
 	}
 	exactReleaseImage := refExact.String()
 

--- a/pkg/cli/admin/release/mirror.go
+++ b/pkg/cli/admin/release/mirror.go
@@ -491,7 +491,7 @@ func (o *MirrorOptions) Run() error {
 			}
 			extractOpts.FilterOptions.OSFilter = re
 		}
-		extractOpts.ImageMetadataCallback = func(m *extract.Mapping, dgst, contentDigest digest.Digest, config *dockerv1client.DockerImageConfig, isManifestList bool) {
+		extractOpts.ImageMetadataCallback = func(m *extract.Mapping, dgst, contentDigest digest.Digest, config *dockerv1client.DockerImageConfig, manifestListDigest digest.Digest) {
 			releaseDigest = contentDigest.String()
 			verifier.Verify(dgst, contentDigest)
 			if config != nil {

--- a/pkg/cli/admin/release/new.go
+++ b/pkg/cli/admin/release/new.go
@@ -384,7 +384,7 @@ func (o *NewOptions) Run() error {
 				From:     "release-manifests/",
 			},
 		}
-		extractOpts.ImageMetadataCallback = func(m *extract.Mapping, dgst, contentDigest digest.Digest, config *dockerv1client.DockerImageConfig, isManifestList bool) {
+		extractOpts.ImageMetadataCallback = func(m *extract.Mapping, dgst, contentDigest digest.Digest, config *dockerv1client.DockerImageConfig, manifestListDigest digest.Digest) {
 			verifier.Verify(dgst, contentDigest)
 			releaseDigest = contentDigest
 			if config.Config != nil {
@@ -947,7 +947,7 @@ func (o *NewOptions) extractManifests(is *imageapi.ImageStream, name string, met
 		opts.FilterOptions.OSFilter = re
 	}
 	opts.OnlyFiles = true
-	opts.ImageMetadataCallback = func(m *extract.Mapping, dgst, contentDigest digest.Digest, config *dockerv1client.DockerImageConfig, isManifestList bool) {
+	opts.ImageMetadataCallback = func(m *extract.Mapping, dgst, contentDigest digest.Digest, config *dockerv1client.DockerImageConfig, manifestListDigest digest.Digest) {
 		verifier.Verify(dgst, contentDigest)
 
 		lock.Lock()

--- a/pkg/cli/image/extract/extract.go
+++ b/pkg/cli/image/extract/extract.go
@@ -138,7 +138,7 @@ type ExtractOptions struct {
 
 	// ImageMetadataCallback is invoked once per image retrieved, and may be called in parallel if
 	// MaxPerRegistry is set higher than 1.
-	ImageMetadataCallback func(m *Mapping, dgst, contentDigest digest.Digest, imageConfig *dockerv1client.DockerImageConfig, isManifestList bool)
+	ImageMetadataCallback func(m *Mapping, dgst, contentDigest digest.Digest, imageConfig *dockerv1client.DockerImageConfig, manifestListDigest digest.Digest)
 	// TarEntryCallback, if set, is passed each entry in the viewed layers. Entries will be filtered
 	// by name and only the entry in the highest layer will be passed to the callback. Returning false
 	// will halt processing of the image.
@@ -518,7 +518,7 @@ func (o *ExtractOptions) Run() error {
 				}
 
 				if o.ImageMetadataCallback != nil {
-					o.ImageMetadataCallback(&mapping, location.Manifest, contentDigest, imageConfig, location.IsList())
+					o.ImageMetadataCallback(&mapping, location.Manifest, contentDigest, imageConfig, location.ManifestListDigest())
 				}
 				return nil
 			})

--- a/pkg/cli/image/manifest/manifest.go
+++ b/pkg/cli/image/manifest/manifest.go
@@ -253,6 +253,13 @@ func (m ManifestLocation) IsList() bool {
 	return len(m.ManifestList) > 0
 }
 
+func (m ManifestLocation) ManifestListDigest() digest.Digest {
+	if m.IsList() {
+		return m.ManifestList
+	}
+	return ""
+}
+
 func (m ManifestLocation) String() string {
 	if m.IsList() {
 		return fmt.Sprintf("manifest %s in manifest list %s", m.Manifest, m.ManifestList)


### PR DESCRIPTION
When performing oc adm release info or extract commands on heterogeneous images with tags, the release image reference is incorrect. infer the manifestlist digest and add that to the release image when referencing by tag