### PR TITLE
release info bug printing: enable `--skip-bug-check` for `--output=json` 

### DIFF
--- a/pkg/cli/admin/release/info.go
+++ b/pkg/cli/admin/release/info.go
@@ -416,8 +416,8 @@ func (o *InfoOptions) Validate() error {
 	if o.SkipBugCheck && len(o.BugsDir) == 0 {
 		return fmt.Errorf("--skip-bug-check requires --bugs")
 	}
-	if o.SkipBugCheck && o.Output != "name" {
-		return fmt.Errorf("--skip-bug-check requires --output to be set to 'name'")
+	if o.SkipBugCheck && o.Output != "name" && o.Output != "json" {
+		return fmt.Errorf("--skip-bug-check requires --output to be set to 'name' or 'json'")
 	}
 	if len(o.ChangelogDir) > 0 || len(o.BugsDir) > 0 {
 		if len(o.From) == 0 {
@@ -1658,8 +1658,12 @@ func describeBugs(out, errOut io.Writer, diff *ReleaseDiff, dir string, format s
 		case "json":
 			var printedBugs []BugRemoteInfo
 			for _, v := range valid {
-				if bug, ok := bugs[generateBugKey(v.Source, v.ID)]; ok {
-					printedBugs = append(printedBugs, bug)
+				if skipBugCheck {
+					printedBugs = append(printedBugs, BugRemoteInfo{ID: v.ID, Source: v.Source})
+				} else {
+					if bug, ok := bugs[generateBugKey(v.Source, v.ID)]; ok {
+						printedBugs = append(printedBugs, bug)
+					}
 				}
 			}
 			data, err := json.MarshalIndent(printedBugs, "", "  ")


### PR DESCRIPTION
The `--output=json` option is used on the `Openshift Release Controller` Jira and Bugzilla verifier. 
This option was added to be able to distinguish between Jira and Bugzilla bugs ([PR](https://github.com/openshift/oc/pull/1177)).

We use:
`oc adm release info --bugs=/tmp/git/ --output=json <from> <to>` to get the bug list for a given input.

When `oc` fails to retrieve a certain bug, it returns: 
`error: Bug XXXXX was not retrieved` 
This breaks our use case, and the `--skip-bug-check` option is required (at the moment this option is enabled for `--output=name` only)

This (`--output=json --skip-bug-check`) will return something like:
```json
[
  {
    "id": 2088606,
    "status": "",
    "priority": "",
    "summary": "",
    "source": 0
  }
]
```
