### PR TITLE
bug 2095708: oc adm inspect: check a resource exists before its inspection

### DIFF
--- a/pkg/cli/admin/inspect/inspect.go
+++ b/pkg/cli/admin/inspect/inspect.go
@@ -236,8 +236,28 @@ func (o *InspectOptions) Run() error {
 	}
 	defer o.logTimestamp()
 
+	// Collect all resources served by the server
+	discoveryClient, err := o.configFlags.ToDiscoveryClient()
+	if err != nil {
+		return err
+	}
+
+	// Check if the resource is served by the server
+	_, rList, err := discoveryClient.ServerGroupsAndResources()
+	if err != nil {
+		return fmt.Errorf("unable to retrieve served resources: %v", err)
+	}
+	serverResources := sets.NewString()
+	for _, rItem := range rList {
+		for _, item := range rItem.APIResources {
+			// The inspection checks whether a resource of a given name exist
+			// independent of the version/group.
+			serverResources.Insert(item.Name)
+		}
+	}
+
 	// finally, gather polymorphic resources specified by the user
-	ctx := NewResourceContext()
+	ctx := NewResourceContext(serverResources)
 	for _, info := range infos {
 		err := InspectResource(info, ctx, o)
 		if err != nil {

--- a/pkg/cli/admin/inspect/resource.go
+++ b/pkg/cli/admin/inspect/resource.go
@@ -73,7 +73,7 @@ func InspectResource(info *resource.Info, context *resourceContext, o *InspectOp
 			if context.visited.Has(resourceToContextKey(resource, info.Name)) {
 				continue
 			}
-			resourceInfos, err := groupResourceToInfos(o.configFlags, resource, info.Name)
+			resourceInfos, err := groupResourceToInfos(o.configFlags, resource, info.Name, context.serverResources)
 			if err != nil {
 				errs = append(errs, err)
 				continue


### PR DESCRIPTION
Collect all resources served by the server through the discovery client and check whether an about-to-be-inspected resource exists to avoid getting an error when it does not.

```
$ ./oc adm inspect co/console
Gathering data for ns/openshift-console-operator...
W0729 16:26:09.139371 1931005 util.go:119] the server doesn't have a resource type egressfirewalls, skipping the inspection
Gathering data for ns/openshift-console...
W0729 16:26:15.981392 1931005 util.go:119] the server doesn't have a resource type egressfirewalls, skipping the inspection
Wrote inspect data to inspect.local.8870216383603463254.
```