### PR TITLE
Bug 2108307: Set HostIPC to true when debugging node

### DIFF
--- a/pkg/cli/debug/debug.go
+++ b/pkg/cli/debug/debug.go
@@ -1013,6 +1013,7 @@ func (o *DebugOptions) approximatePodTemplateForObject(object runtime.Object) (*
 				NodeName:    t.Name,
 				HostNetwork: true,
 				HostPID:     true,
+				HostIPC:     true,
 				Volumes: []corev1.Volume{
 					{
 						Name: "host",


### PR DESCRIPTION
To be compatible with the upstream [debug](https://github.com/kubernetes/kubernetes/blob/fd0c15cce3d66bc2b32fc6943688425ec269d97d/staging/src/k8s.io/kubectl/pkg/cmd/debug/profiles.go#L52) command, this PR sets
`HostIPC` to true when debugging a node for `oc`. 

In addition to that this PR fixes the referenced issue.