### PR TITLE
Bug 2112934: Add servicemonitors into common namespaces for inspection

### DIFF
--- a/pkg/cli/admin/inspect/namespace.go
+++ b/pkg/cli/admin/inspect/namespace.go
@@ -29,6 +29,7 @@ func namespaceResourcesToCollect() []schema.GroupResource {
 		{Resource: "persistentvolumeclaims"},
 		{Resource: "poddisruptionbudgets"},
 		{Resource: "secrets"},
+		{Resource: "servicemonitors"},
 	}
 }
 


### PR DESCRIPTION
This PR adds `servicemonitors` resource into common namespaces for `oc adm inspect`. 
`servicemonitors` is a useful resource as stated in referenced bug and it takes a few kilobytes storage.