### PR TITLE
[release-4.10] bug 2116526: oc adm inspect: check a resource exists before its inspection

### DIFF
--- a/pkg/cli/admin/inspect/resource.go
+++ b/pkg/cli/admin/inspect/resource.go
@@ -73,7 +73,7 @@ func InspectResource(info *resource.Info, context *resourceContext, o *InspectOp
 			if context.visited.Has(resourceToContextKey(resource, info.Name)) {
 				continue
 			}
-			resourceInfos, err := groupResourceToInfos(o.configFlags, resource, info.Name)
+			resourceInfos, err := groupResourceToInfos(o.configFlags, resource, info.Name, context.serverResources)
 			if err != nil {
 				errs = append(errs, err)
 				continue


### PR DESCRIPTION
Collect all resources served by the server through the discovery client and check whether an about-to-be-inspected resource exists to avoid getting an error when it does not.

```
$ ./oc adm inspect co/console
Gathering data for ns/openshift-console-operator...
W0729 16:26:09.139371 1931005 util.go:119] the server doesn't have a resource type egressfirewalls, skipping the inspection
Gathering data for ns/openshift-console...
W0729 16:26:15.981392 1931005 util.go:119] the server doesn't have a resource type egressfirewalls, skipping the inspection
Wrote inspect data to inspect.local.8870216383603463254.
```

Cherry-picking https://github.com/openshift/oc/pull/1215