### PR TITLE
Give a complete oc label command in pod security error message

### DIFF
--- a/pkg/helpers/cmd/errors.go
+++ b/pkg/helpers/cmd/errors.go
@@ -25,7 +25,7 @@ func CheckPodSecurityErr(err error) {
 		err = fmt.Errorf("PodSecurity violation error:\n"+
 			"Ensure the target namespace has the appropriate security level set "+
 			"or consider creating a dedicated privileged namespace using:\n"+
-			"\t\"oc create ns <namespace> -o yaml | oc label -f - pod-security.kubernetes.io/enforce=privileged pod-security.kubernetes.io/audit=privileged pod-security.kubernetes.io/warn=privileged\".\n\nOriginal error:\n%w", err)
+			"\t\"oc create ns <namespace> -o yaml | oc label -f - security.openshift.io/scc.podSecurityLabelSync=false pod-security.kubernetes.io/enforce=privileged pod-security.kubernetes.io/audit=privileged pod-security.kubernetes.io/warn=privileged\".\n\nOriginal error:\n%w", err)
 	}
 
 	kcmdutil.CheckErr(err)


### PR DESCRIPTION
The original message's command can't let readers successfully add pod security labels due to the automatic sync mechanism. This confuses them. As talked in Slack with @stlaz , this needs modification. To make messages simplified, just adding security.openshift.io/scc.podSecurityLabelSync=false, not trying to complicatedly explain that only non-installer-created namespaces with no openshift- prefix require this label and non-installer-created openshift- prefixed namespaces don't require it.
/assign @stlaz 