### PR TITLE
OCPBUGS-843: Add limitranges into common namespaces for inspection

### DIFF
--- a/pkg/cli/admin/inspect/namespace.go
+++ b/pkg/cli/admin/inspect/namespace.go
@@ -31,6 +31,7 @@ func namespaceResourcesToCollect() []schema.GroupResource {
 		{Resource: "poddisruptionbudgets"},
 		{Resource: "secrets"},
 		{Resource: "servicemonitors"},
+		{Resource: "limitranges"},
 	}
 }
 


### PR DESCRIPTION
This PR adds `limitrages` resource into common namespaces for `oc adm inspect`.
`limitranges` is a useful resource as stated in referenced bug
and it takes a few kilobytes storage.