### PR TITLE
Remove version patching for mac arm64 archs

### DIFF
--- a/pkg/cli/admin/release/extract_tools.go
+++ b/pkg/cli/admin/release/extract_tools.go
@@ -189,10 +189,9 @@ func (o *ExtractOptions) extractCommand(command string) error {
 			NewArch: true,
 			Mapping: extract.Mapping{Image: "cli-artifacts", From: "usr/share/openshift/mac_arm64/oc"},
 
-			LinkTo:               []string{"kubectl"},
-			Readme:               readmeCLIUnix,
-			InjectReleaseVersion: true,
-			ArchiveFormat:        "openshift-client-mac-arm64-%s.tar.gz",
+			LinkTo:        []string{"kubectl"},
+			Readme:        readmeCLIUnix,
+			ArchiveFormat: "openshift-client-mac-arm64-%s.tar.gz",
 		},
 		{
 			OS:      "linux",
@@ -245,10 +244,8 @@ func (o *ExtractOptions) extractCommand(command string) error {
 			NewArch: true,
 			Mapping: extract.Mapping{Image: "installer-artifacts", From: "usr/share/openshift/mac_arm64/openshift-install"},
 
-			Readme:               readmeInstallUnix,
-			InjectReleaseImage:   true,
-			InjectReleaseVersion: true,
-			ArchiveFormat:        "openshift-install-mac-arm64-%s.tar.gz",
+			Readme:        readmeInstallUnix,
+			ArchiveFormat: "openshift-install-mac-arm64-%s.tar.gz",
 		},
 		{
 			OS:      "linux",


### PR DESCRIPTION
When binary versions are patched, mac os arm64 architectures does not allow binaries to be run by warning that binary is changed. To let `oc` and `openshift-install` working on mac os arm64, this PR removes version injection for these architectures.

Drawback of this PR is for that specific architectures, `oc version` and `openshift-install version` commands will not return correct data.