### PR TITLE
Add --overwrite flag into pod security violation error message

### DIFF
--- a/pkg/helpers/cmd/errors.go
+++ b/pkg/helpers/cmd/errors.go
@@ -25,7 +25,7 @@ func CheckPodSecurityErr(err error) {
 		err = fmt.Errorf("PodSecurity violation error:\n"+
 			"Ensure the target namespace has the appropriate security level set "+
 			"or consider creating a dedicated privileged namespace using:\n"+
-			"\t\"oc create ns <namespace> -o yaml | oc label -f - security.openshift.io/scc.podSecurityLabelSync=false pod-security.kubernetes.io/enforce=privileged pod-security.kubernetes.io/audit=privileged pod-security.kubernetes.io/warn=privileged\".\n\nOriginal error:\n%w", err)
+			"\t\"oc create ns <namespace> -o yaml | oc label -f - security.openshift.io/scc.podSecurityLabelSync=false pod-security.kubernetes.io/enforce=privileged pod-security.kubernetes.io/audit=privileged pod-security.kubernetes.io/warn=privileged --overwrite\".\n\nOriginal error:\n%w", err)
 	}
 
 	kcmdutil.CheckErr(err)


### PR DESCRIPTION
If user gets a pod security violation error, `oc` suggests a command how to overcome that. However, newly created namespaces already have `pod-security.kubernetes.io/enforce: restricted` this label and suggested command is failing by
`error: 'pod-security.kubernetes.io/enforce' already has a value (restricted), and --overwrite is false`.

This PR adds `--overwrite` flag into suggested commands in case new namespace might already contain such labels.