### PR TITLE
pkg/cli/admin/release/extract: Unify extraction cases

### DIFF
--- a/pkg/cli/admin/release/extract.go
+++ b/pkg/cli/admin/release/extract.go
@@ -262,6 +262,7 @@ func (o *ExtractOptions) Run() error {
 	opts.SecurityOptions = o.SecurityOptions
 	opts.FilterOptions = o.FilterOptions
 	opts.FileDir = o.FileDir
+	opts.OnlyFiles = true
 	opts.ICSPFile = o.ICSPFile
 
 	switch {
@@ -269,7 +270,6 @@ func (o *ExtractOptions) Run() error {
 		if o.ImageMetadataCallback != nil {
 			opts.ImageMetadataCallback = o.ImageMetadataCallback
 		}
-		opts.OnlyFiles = true
 		opts.Mappings = []extract.Mapping{
 			{
 				ImageRef: ref,
@@ -336,7 +336,6 @@ func (o *ExtractOptions) Run() error {
 		return nil
 
 	case o.CredentialsRequests:
-		opts.OnlyFiles = true
 		opts.Mappings = []extract.Mapping{
 			{
 				ImageRef: ref,
@@ -403,7 +402,6 @@ func (o *ExtractOptions) Run() error {
 		}
 		return opts.Run()
 	default:
-		opts.OnlyFiles = true
 		opts.Mappings = []extract.Mapping{
 			{
 				ImageRef: ref,

--- a/pkg/cli/admin/release/extract.go
+++ b/pkg/cli/admin/release/extract.go
@@ -173,7 +173,7 @@ type ExtractOptions struct {
 	ExtractManifests bool
 	Manifests        []manifest.Manifest
 
-	ImageMetadataCallback func(m *extract.Mapping, dgst, contentDigest digest.Digest, config *dockerv1client.DockerImageConfig, manifestListDigest digest.Digest)
+	ImageMetadataCallback extract.ImageMetadataFunc
 }
 
 func (o *ExtractOptions) Complete(f kcmdutil.Factory, cmd *cobra.Command, args []string) error {
@@ -273,11 +273,29 @@ func (o *ExtractOptions) Run() error {
 		},
 	}
 
+	imageMetadataCallbacks := []extract.ImageMetadataFunc{}
+	if o.ImageMetadataCallback != nil {
+		imageMetadataCallbacks = append(imageMetadataCallbacks, o.ImageMetadataCallback)
+	}
+
+	verifier := imagemanifest.NewVerifier()
+	imageMetadataCallbacks = append(imageMetadataCallbacks, func(m *extract.Mapping, dgst, contentDigest digest.Digest, config *dockerv1client.DockerImageConfig, manifestListDigest digest.Digest) {
+		verifier.Verify(dgst, contentDigest)
+		if len(ref.Ref.ID) > 0 {
+			fmt.Fprintf(o.Out, "Extracted release payload created at %s\n", config.Created.Format(time.RFC3339))
+		} else {
+			fmt.Fprintf(o.Out, "Extracted release payload from digest %s created at %s\n", dgst, config.Created.Format(time.RFC3339))
+		}
+	})
+
+	opts.ImageMetadataCallback = func(m *extract.Mapping, dgst, contentDigest digest.Digest, config *dockerv1client.DockerImageConfig, manifestListDigest digest.Digest) {
+		for _, callback := range imageMetadataCallbacks {
+			callback(m, dgst, contentDigest, config, manifestListDigest)
+		}
+	}
+
 	switch {
 	case len(o.File) > 0:
-		if o.ImageMetadataCallback != nil {
-			opts.ImageMetadataCallback = o.ImageMetadataCallback
-		}
 		var manifestErrs []error
 		found := false
 		opts.TarEntryCallback = func(hdr *tar.Header, _ extract.LayerInfo, r io.Reader) (bool, error) {
@@ -392,32 +410,24 @@ func (o *ExtractOptions) Run() error {
 			}
 			return true, nil
 		}
-		return opts.Run()
-	default:
-		verifier := imagemanifest.NewVerifier()
-		opts.ImageMetadataCallback = func(m *extract.Mapping, dgst, contentDigest digest.Digest, config *dockerv1client.DockerImageConfig, manifestListDigest digest.Digest) {
-			verifier.Verify(dgst, contentDigest)
-			if o.ImageMetadataCallback != nil {
-				o.ImageMetadataCallback(m, dgst, contentDigest, config, manifestListDigest)
-			}
-			if len(ref.Ref.ID) > 0 {
-				fmt.Fprintf(o.Out, "Extracted release payload created at %s\n", config.Created.Format(time.RFC3339))
-			} else {
-				fmt.Fprintf(o.Out, "Extracted release payload from digest %s created at %s\n", dgst, config.Created.Format(time.RFC3339))
-			}
-		}
 		if err := opts.Run(); err != nil {
 			return err
 		}
-		if !verifier.Verified() {
-			err := fmt.Errorf("the release image failed content verification and may have been tampered with")
-			if !o.SecurityOptions.SkipVerification {
-				return err
-			}
-			fmt.Fprintf(o.ErrOut, "warning: %v\n", err)
+	default:
+		if err := opts.Run(); err != nil {
+			return err
 		}
-		return nil
 	}
+
+	if !verifier.Verified() {
+		err := fmt.Errorf("the release image failed content verification and may have been tampered with")
+		if !o.SecurityOptions.SkipVerification {
+			return err
+		}
+		fmt.Fprintf(o.ErrOut, "warning: %v\n", err)
+	}
+	return nil
+
 }
 
 func (o *ExtractOptions) extractGit(dir string) error {

--- a/pkg/cli/admin/release/extract.go
+++ b/pkg/cli/admin/release/extract.go
@@ -264,19 +264,19 @@ func (o *ExtractOptions) Run() error {
 	opts.FileDir = o.FileDir
 	opts.OnlyFiles = true
 	opts.ICSPFile = o.ICSPFile
+	opts.Mappings = []extract.Mapping{
+		{
+			ImageRef: ref,
+
+			From: "release-manifests/",
+			To:   dir,
+		},
+	}
 
 	switch {
 	case len(o.File) > 0:
 		if o.ImageMetadataCallback != nil {
 			opts.ImageMetadataCallback = o.ImageMetadataCallback
-		}
-		opts.Mappings = []extract.Mapping{
-			{
-				ImageRef: ref,
-
-				From: "release-manifests/",
-				To:   dir,
-			},
 		}
 		var manifestErrs []error
 		found := false
@@ -336,14 +336,6 @@ func (o *ExtractOptions) Run() error {
 		return nil
 
 	case o.CredentialsRequests:
-		opts.Mappings = []extract.Mapping{
-			{
-				ImageRef: ref,
-
-				From: "release-manifests/",
-				To:   dir,
-			},
-		}
 		expectedProviderSpecKind := ""
 		if len(o.Cloud) > 0 {
 			expectedProviderSpecKind = credRequestCloudProviderSpecKindMapping[o.Cloud]
@@ -402,14 +394,6 @@ func (o *ExtractOptions) Run() error {
 		}
 		return opts.Run()
 	default:
-		opts.Mappings = []extract.Mapping{
-			{
-				ImageRef: ref,
-
-				From: "release-manifests/",
-				To:   dir,
-			},
-		}
 		verifier := imagemanifest.NewVerifier()
 		opts.ImageMetadataCallback = func(m *extract.Mapping, dgst, contentDigest digest.Digest, config *dockerv1client.DockerImageConfig, manifestListDigest digest.Digest) {
 			verifier.Verify(dgst, contentDigest)

--- a/pkg/cli/admin/release/mirror.go
+++ b/pkg/cli/admin/release/mirror.go
@@ -471,7 +471,6 @@ func (o *MirrorOptions) Run() error {
 
 	var releaseDigest string
 	var manifests []manifest.Manifest
-	verifier := imagemanifest.NewVerifier()
 	is := o.ImageStream
 	if is == nil {
 		o.ImageStream = &imagev1.ImageStream{}
@@ -493,7 +492,6 @@ func (o *MirrorOptions) Run() error {
 		}
 		extractOpts.ImageMetadataCallback = func(m *extract.Mapping, dgst, contentDigest digest.Digest, config *dockerv1client.DockerImageConfig, manifestListDigest digest.Digest) {
 			releaseDigest = contentDigest.String()
-			verifier.Verify(dgst, contentDigest)
 			if config != nil {
 				if val, ok := archMap[config.Architecture]; ok {
 					archExt = "-" + val
@@ -515,13 +513,6 @@ func (o *MirrorOptions) Run() error {
 		}
 		if is.Kind != "ImageStream" || is.APIVersion != "image.openshift.io/v1" {
 			return fmt.Errorf("unrecognized image-references in release payload")
-		}
-		if !verifier.Verified() {
-			err := fmt.Errorf("the release image failed content verification and may have been tampered with")
-			if !o.SecurityOptions.SkipVerification {
-				return err
-			}
-			fmt.Fprintf(o.ErrOut, "warning: %v\n", err)
 		}
 		manifests = extractOpts.Manifests
 	}

--- a/pkg/cli/image/extract/extract.go
+++ b/pkg/cli/image/extract/extract.go
@@ -111,6 +111,9 @@ type LayerInfo struct {
 	Mapping    *Mapping
 }
 
+// ImageMetadataFunc is called once per image retrieved.
+type ImageMetadataFunc func(m *Mapping, dgst, contentDigest digest.Digest, imageConfig *dockerv1client.DockerImageConfig, manifestListDigest digest.Digest)
+
 // TarEntryFunc is called once per entry in the tar file. It may return
 // an error, or false to stop processing.
 type TarEntryFunc func(*tar.Header, LayerInfo, io.Reader) (cont bool, err error)
@@ -138,7 +141,7 @@ type ExtractOptions struct {
 
 	// ImageMetadataCallback is invoked once per image retrieved, and may be called in parallel if
 	// MaxPerRegistry is set higher than 1.
-	ImageMetadataCallback func(m *Mapping, dgst, contentDigest digest.Digest, imageConfig *dockerv1client.DockerImageConfig, manifestListDigest digest.Digest)
+	ImageMetadataCallback ImageMetadataFunc
 	// TarEntryCallback, if set, is passed each entry in the viewed layers. Entries will be filtered
 	// by name and only the entry in the highest layer will be passed to the callback. Returning false
 	// will halt processing of the image.


### PR DESCRIPTION
There's no reason we can't do things like "extract manifests to a directory" and "extract a single thing to a file", etc. simultaneously.  This pull request is the first portion of changes to consolidate shared logic, and reduce the amount of case-specific code.  It should mostly be a no-op refactor for users, except for the extension of verification coverage to cases that previously lacked verification.