### PR TITLE
[OCPNODE-521] Add icsp file convert command

### DIFF
--- a/pkg/cli/admin/admin.go
+++ b/pkg/cli/admin/admin.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openshift/oc/pkg/cli/admin/groups"
 	"github.com/openshift/oc/pkg/cli/admin/inspect"
 	"github.com/openshift/oc/pkg/cli/admin/migrate"
+	migrateteicsp "github.com/openshift/oc/pkg/cli/admin/migrate/icsp"
 	migratetemplateinstances "github.com/openshift/oc/pkg/cli/admin/migrate/templateinstances"
 	"github.com/openshift/oc/pkg/cli/admin/mustgather"
 	"github.com/openshift/oc/pkg/cli/admin/network"
@@ -88,6 +89,7 @@ func NewCommandAdmin(f kcmdutil.Factory, streams genericclioptions.IOStreams) *c
 				migrate.NewCommandMigrate(f, streams,
 					// Migration commands
 					migratetemplateinstances.NewCmdMigrateTemplateInstances(f, streams),
+					migrateteicsp.NewCmdMigrateICSP(f, streams),
 				),
 			},
 		},

--- a/pkg/cli/admin/migrate/icsp/icsp.go
+++ b/pkg/cli/admin/migrate/icsp/icsp.go
@@ -1,0 +1,196 @@
+package icsp
+
+import (
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"path/filepath"
+
+	apicfgv1 "github.com/openshift/api/config/v1"
+	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
+	operatorv1alpha1scheme "github.com/openshift/client-go/operator/clientset/versioned/scheme"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+var (
+	internalMigrateICSPLong = templates.LongDesc(`
+	Update imagecontentsourcepolicy file(s) to imagedigestmirrorset file(s). If --dest-dir is unset, the imagedigestmirrorset file(s) that can be added to a cluster will be written to file(s) under the current directory.
+	`)
+
+	internalMigrateICSPExample = templates.Examples(`
+	# update the imagecontentsourcepolicy.yaml to new imagedigestmirrorset file under directory mydir
+	oc adm migrate icsp imagecontentsourcepolicy.yaml --dest-dir mydir
+`)
+)
+
+type MigrateICSPOptions struct {
+	genericclioptions.IOStreams
+
+	ICSPFiles []string
+	DestDir   string
+}
+
+func NewCmdMigrateICSP(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewMigrateICSPOptions(streams)
+	cmd := &cobra.Command{
+		Use:     "icsp",
+		Short:   "Update imagecontentsourcepolicy file(s) to imagedigestmirrorset file(s).",
+		Long:    internalMigrateICSPLong,
+		Example: internalMigrateICSPExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			kcmdutil.CheckErr(o.Complete(f, cmd, args))
+			kcmdutil.CheckErr(o.Run())
+		},
+	}
+	cmd.Flags().StringVar(&o.DestDir, "dest-dir", o.DestDir, "Set a specific directory on the local machine to write imagedigestmirrorset file(s) to.")
+
+	return cmd
+}
+
+func NewMigrateICSPOptions(streams genericclioptions.IOStreams) *MigrateICSPOptions {
+	return &MigrateICSPOptions{
+		IOStreams: streams,
+	}
+}
+
+func (o *MigrateICSPOptions) Complete(f kcmdutil.Factory, cmd *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("convert expects at least one argument, path to an imagecontentsourcepolicy file")
+	}
+	o.ICSPFiles = args
+	return nil
+}
+
+func (o *MigrateICSPOptions) Run() error {
+	if o.DestDir == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+		o.DestDir = cwd
+	}
+	if err := o.ensureDirectoryViable(); err != nil {
+		return err
+	}
+	// ensure destination path exists
+	if err := os.MkdirAll(o.DestDir, os.ModePerm); err != nil {
+		return err
+	}
+
+	var multiErr []error
+	for _, file := range o.ICSPFiles {
+		if err := func() error {
+			icsp, name, err := readICSPsFromFile(file)
+			if err != nil {
+				return err
+			}
+			idmsYml, err := generateIDMS(icsp)
+			if err != nil {
+				return err
+			}
+
+			fname := filepath.Join(o.DestDir, fmt.Sprintf("imagedigestmirrorset_%s.%06d.yaml", name, rand.Int63()))
+			if err = os.WriteFile(fname, idmsYml, os.ModePerm); err != nil {
+				defer func() {
+					os.Remove(fname)
+				}()
+				return fmt.Errorf("error writing ImageDigestMirrorSet: %v", err)
+			}
+			fmt.Fprintf(o.Out, "wrote ImageDigestMirrorSet to %s\n", fname)
+			return nil
+		}(); err != nil {
+			multiErr = append(multiErr, err)
+			continue
+		}
+	}
+	return errors.NewAggregate(multiErr)
+}
+
+// ensureDirectoryViable returns an error if DestDir:
+// 1. already exists AND is a file (not a directory)
+// 2. an IO error occurs
+func (o *MigrateICSPOptions) ensureDirectoryViable() error {
+	baseDirInfo, err := os.Stat(o.DestDir)
+	if err != nil && os.IsNotExist(err) {
+		// no error, directory simply does not exist yet
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if !baseDirInfo.IsDir() {
+		return fmt.Errorf("%q exists and is a file", o.DestDir)
+	}
+	if _, err = ioutil.ReadDir(o.DestDir); err != nil {
+		return err
+	}
+	return nil
+}
+
+func generateIDMS(icsp operatorv1alpha1.ImageContentSourcePolicy) ([]byte, error) {
+	imgDigestMirrors := []apicfgv1.ImageDigestMirrors{}
+	for _, rdm := range icsp.Spec.RepositoryDigestMirrors {
+		idm := apicfgv1.ImageDigestMirrors{}
+		idm.Source = rdm.Source
+		mirrors := []apicfgv1.ImageMirror{}
+		for _, m := range rdm.Mirrors {
+			mirrors = append(mirrors, apicfgv1.ImageMirror(m))
+		}
+		idm.Mirrors = mirrors
+		imgDigestMirrors = append(imgDigestMirrors, idm)
+	}
+	idms := apicfgv1.ImageDigestMirrorSet{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: apicfgv1.GroupVersion.String(),
+			Kind:       "ImageDigestMirrorSet",
+		},
+		ObjectMeta: icsp.ObjectMeta,
+		Spec:       apicfgv1.ImageDigestMirrorSetSpec{ImageDigestMirrors: imgDigestMirrors},
+	}
+
+	// Create an unstructured object for removing creationTimestamp, status
+	unstructuredObj := unstructured.Unstructured{}
+	var err error
+	unstructuredObj.Object, err = runtime.DefaultUnstructuredConverter.ToUnstructured(&idms)
+	if err != nil {
+		return nil, fmt.Errorf("error converting to unstructured: %v", err)
+	}
+	delete(unstructuredObj.Object["metadata"].(map[string]interface{}), "creationTimestamp")
+	delete(unstructuredObj.Object, "status")
+	idmsYml, err := yaml.Marshal(unstructuredObj.Object)
+	if err != nil {
+		return nil, fmt.Errorf("unable to marshal ImageDigestMirrorSet yaml: %v", err)
+	}
+	return idmsYml, nil
+}
+
+// readICSPsFromFile appends to list of alternative image sources from ICSP file
+// returns error if no icsp object decoded from file data
+func readICSPsFromFile(icspFile string) (operatorv1alpha1.ImageContentSourcePolicy, string, error) {
+	icspData, err := os.ReadFile(icspFile)
+	if err != nil {
+		return operatorv1alpha1.ImageContentSourcePolicy{}, "", fmt.Errorf("unable to read ImageContentSourceFile %s: %v", icspFile, err)
+	}
+	if len(icspData) == 0 {
+		return operatorv1alpha1.ImageContentSourcePolicy{}, "", fmt.Errorf("no data found in ImageContentSourceFile %s", icspFile)
+	}
+	icspObj, err := runtime.Decode(operatorv1alpha1scheme.Codecs.UniversalDeserializer(), icspData)
+	if err != nil {
+		return operatorv1alpha1.ImageContentSourcePolicy{}, "", fmt.Errorf("error decoding ImageContentSourcePolicy from %s: %v", icspFile, err)
+	}
+	icsp, ok := icspObj.(*operatorv1alpha1.ImageContentSourcePolicy)
+	if !ok {
+		return operatorv1alpha1.ImageContentSourcePolicy{}, "", fmt.Errorf("could not decode ImageContentSourcePolicy from %s", icspFile)
+	}
+	return *icsp, icsp.Name, nil
+}

--- a/pkg/cli/admin/migrate/icsp/icsp_test.go
+++ b/pkg/cli/admin/migrate/icsp/icsp_test.go
@@ -1,0 +1,69 @@
+package icsp
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGenerateIDMS(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		icsp operatorv1alpha1.ImageContentSourcePolicy
+		want []byte
+	}{
+		{
+
+			name: "convert icsp to idms",
+			icsp: operatorv1alpha1.ImageContentSourcePolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "convert",
+					Labels:      map[string]string{"icspIdx": "1"},
+					Annotations: map[string]string{"icspCon": "idms"},
+				},
+				Spec: operatorv1alpha1.ImageContentSourcePolicySpec{
+					RepositoryDigestMirrors: []operatorv1alpha1.RepositoryDigestMirrors{
+						{Source: "source.example.com", Mirrors: []string{"z1.example.com", "y2.example.com", "x3.example.com"}},
+						{Source: "source.example.net", Mirrors: []string{"z1.example.net", "y2.example.net", "x3.example.net"}},
+					},
+				},
+			},
+			want: []byte(
+				`apiVersion: config.openshift.io/v1
+kind: ImageDigestMirrorSet
+metadata:
+    annotations:
+        icspCon: idms
+    labels:
+        icspIdx: "1"
+    name: convert
+spec:
+    imageDigestMirrors:
+        - mirrors:
+            - z1.example.com
+            - y2.example.com
+            - x3.example.com
+          source: source.example.com
+        - mirrors:
+            - z1.example.net
+            - y2.example.net
+            - x3.example.net
+          source: source.example.net
+`,
+			),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := generateIDMS(tc.icsp)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(result, tc.want) {
+				t.Errorf("generateIDMS() got = %v, want %v, diff = %v", string(result), string(tc.want), cmp.Diff(result, tc.want))
+			}
+		})
+	}
+}


### PR DESCRIPTION
According to the discuusion [resolution](https://docs.google.com/document/d/13h6IJn8wlzXdiPMvCWlMEHOXXqEZ9_GYOl02Wldb3z8/edit?usp=sharing), having a tool in oc to convert icsp file is helpul to land new CRD imagedigestmirrorset. This pr propose command `oc image convert` to convert passed in icsp file to idms file.

```
$ ./oc adm migrate icsp --help
Update imagecontentsourcepolicy file(s) to imagedigestmirrorset file(s). If --dest-dir is unset, the
imagedigestmirrorset file(s) that can be added to a cluster will be written to file(s) under the current directory.

Examples:
  # update the imagecontentsourcepolicy.yaml to new imagedigestmirrorset file under directory mydir
  oc adm migrate icsp imagecontentsourcepolicy.yaml --dest-dir mydir

Options:
    --dest-dir='':
        Set a specific directory on the local machine to write imagedigestmirrorset file(s) to.

Usage:
  oc adm migrate icsp [flags] [options]

Use "oc options" for a list of global command-line options (applies to all commands).

$ ./oc adm migrate icsp icsp.yml icsp1.yml --dest-dir mydir
wrote ImageDigestMirrorSet to mydir/imagedigestmirrorset_ubi8repo.1498535234348096290.yaml
wrote ImageDigestMirrorSet tomydir/imagedigestmirrorset_ubi8repo-1.2106923056265733512.yaml

// example error output
$ ./oc adm migrate icsp icsp.yml icsp-1.yml icsp-2.yml
wrote ImageDigestMirrorSet to /home/qiwan/go/src/github.com/openshift/oc/imagedigestmirrorset_ubi8repo.748345346019788996.yaml
unable to read ImageContentSourceFile icsp-1.yml: open icsp-1.yml: no such file or directory
unable to read ImageContentSourceFile icsp-2.yml: open icsp-2.yml: no such file or directory
```

- ImageDigestMirrorSet implemented: https://github.com/openshift/machine-config-operator/pull/3037
- ImageDigestMirrorSet epic: https://issues.redhat.com/browse/OCPNODE-521
Signed-off-by: Qi Wang <qiwan@redhat.com>