### PR TITLE
OWNERS_ALIASES: Freshen update-approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -7,12 +7,8 @@ aliases:
     - smarterclayton
     - soltysh
   update-approvers:
-    - abhinavdahiya
     - jottofar
     - LalatenduMohanty
-    - sdodson
-    - smarterclayton
-    - vrutkovs
     - wking
   catalog-approvers:
     - awgreene


### PR DESCRIPTION
Catching up with [this CVO config][1].  Abhinav and Clayton are no longer with Red Hat. Vadim has [moved to the assisted-installer][2], and Scott dropped himself [here][3].

[1]: https://github.com/openshift/cluster-version-operator/blob/bce1e9fb73467152ef38b11746b616038ff939f7/OWNERS
[2]: https://github.com/openshift/cluster-version-operator/commit/799b668d25b388808410a09ab3857446adca85f1
[3]: https://github.com/openshift/cluster-version-operator/commit/7c5dbf6d62b1108c1ee9c4493ce5898f8b0faa6a