### PR TITLE
Bug 2093046: oc debug: Add priorityClassName into node debugging pod template

### DIFF
--- a/pkg/cli/debug/debug.go
+++ b/pkg/cli/debug/debug.go
@@ -1026,7 +1026,8 @@ func (o *DebugOptions) approximatePodTemplateForObject(object runtime.Object) (*
 						},
 					},
 				},
-				RestartPolicy: corev1.RestartPolicyNever,
+				PriorityClassName: "openshift-user-critical",
+				RestartPolicy:     corev1.RestartPolicyNever,
 				Containers: []corev1.Container{
 					{
 						Name:  "container-00",


### PR DESCRIPTION
When user tries to debug a pod, priorityClassName is automatically copied to this debug pod. However, there is no such information for node debugging.

This PR adds "openshift-user-critical" priorityClassName into node debugging pod which means that "it is fine node debugging pod to be preempted by user-workload and OOMKilled."[1]

[1] https://github.com/openshift/enhancements/blob/master/CONVENTIONS.md#priority-classes