### PR TITLE
oc debug,version: minor todo improvements

### DIFF
--- a/pkg/cli/debug/debug.go
+++ b/pkg/cli/debug/debug.go
@@ -326,17 +326,8 @@ func (o *DebugOptions) Complete(cmd *cobra.Command, f kcmdutil.Factory, args []s
 	}
 	o.AsNonRoot = !o.AsRoot && cmd.Flag("as-root").Changed
 
-	templateArgSpecified := o.PrintFlags.TemplatePrinterFlags != nil &&
-		o.PrintFlags.TemplatePrinterFlags.TemplateArgument != nil &&
-		len(*o.PrintFlags.TemplatePrinterFlags.TemplateArgument) > 0
-
-	outputFormatSpecified := o.PrintFlags.OutputFormat != nil && len(*o.PrintFlags.OutputFormat) > 0
-
-	// TODO: below should be turned into a method on PrintFlags
-	if outputFormatSpecified || templateArgSpecified {
-		if o.DryRun {
-			o.PrintFlags.Complete("%s (dry run)")
-		}
+	if o.PrintFlags.OutputFlagSpecified() {
+		kcmdutil.PrintFlagsWithDryRunStrategy(o.PrintFlags, strategy)
 		o.Printer, err = o.PrintFlags.ToPrinter()
 		if err != nil {
 			return err

--- a/pkg/cli/debug/debug.go
+++ b/pkg/cli/debug/debug.go
@@ -1195,7 +1195,7 @@ func (o *DebugOptions) getNamespace(infoNs string) (string, func(), error) {
 		return infoNs, func() {}, nil
 	}
 
-	if !o.IsNode {
+	if !o.IsNode || o.DryRun {
 		return infoNs, func() {}, nil
 	}
 

--- a/pkg/cli/version/version.go
+++ b/pkg/cli/version/version.go
@@ -122,9 +122,7 @@ func (o *VersionOptions) Run() error {
 		versionInfo.ReleaseClientVersion = reportedVersion
 	}
 	versionInfo.ClientVersion = &clientVersion
-	// TODO: fix this to use kversion.GetKustomizeVersion after
-	// https://github.com/kubernetes/kubernetes/pull/109430 lands
-	versionInfo.KustomizeVersion = "v4.5.4"
+	versionInfo.KustomizeVersion, _ = kversion.GetKustomizeModVersion()
 
 	var serverErr error
 	var serverVersion *apimachineryversion.Info


### PR DESCRIPTION
This PR;

- uses `GetKustomizeModVersion()` function to get kustomize version instead using static one. Because https://github.com/kubernetes/kubernetes/pull/109430 patch was merged and landed on o/k
- adds check to not create temporary namespace if `dry-run` flag is passed to `oc debug node`. It is redundant operation for dry-run.
- relies on `printFlags` functions instead manual output calculations. `printFlags` already supports required functionality.