### PR TITLE
OCPBUGS-2495: pkg/cli/login: Warn, but do not fail, on surprise project-list errors

### DIFF
--- a/pkg/cli/login/loginoptions.go
+++ b/pkg/cli/login/loginoptions.go
@@ -275,13 +275,13 @@ func (o *LoginOptions) gatherProjectInfo() error {
 
 	projectsList, err := projectClient.Projects().List(context.TODO(), metav1.ListOptions{})
 	// if we're running on kube (or likely kube), just set it to "default"
-	if kerrors.IsNotFound(err) || kerrors.IsForbidden(err) {
+	if err != nil {
+		if !kerrors.IsNotFound(err) && !kerrors.IsForbidden(err) {
+			fmt.Fprintf(o.Out, "WARNING: Failed to list projects: %v\n", err)
+		}
 		fmt.Fprintf(o.Out, "Using \"default\" namespace.  You can switch namespaces with:\n\n %s project <projectname>\n", o.CommandName)
 		o.Project = "default"
 		return nil
-	}
-	if err != nil {
-		return err
 	}
 
 	projectsItems := projectsList.Items


### PR DESCRIPTION
Initially, all project-listing errors were fatal.  bcf5470fe7 began tolerating `IsNotFound`.  40e76d093d began tolerating `IsForbidden`.  But sometimes the error can be on the service side, [like][1]:

```console
$ oc login --token=...

Logged into "https://api..." as "..." using the token provided.

Error from server (Timeout): the server was unable to return a response in the time allotted, but may still be processing the request (get projects.project.openshift.io)
```

With this commit, we log the error, so the caller is aware that we had problems, but we fall back to `default`, because it's hard to imagine a situation where the caller would rather not be logged in.  If they want to adjust their default project after logging in, they can always do that in follow-up work.

[1]: https://issues.redhat.com/browse/OCPBUGS-2495