### PR TITLE
Bug 2078694: New-App Using Git via SSH

### DIFF
--- a/pkg/helpers/newapp/app/sourcelookup.go
+++ b/pkg/helpers/newapp/app/sourcelookup.go
@@ -275,11 +275,11 @@ func (r *SourceRepository) LocalPath() (string, error) {
 // DetectAuth returns an error if the source repository cannot be cloned
 // without the current user's environment. The following changes are made to the
 // environment:
-// 1) The HOME directory is set to a temporary dir to avoid loading any settings in .gitconfig
-// 2) The GIT_SSH variable is set to /dev/null so the regular SSH keys are not used
-//    (changing the HOME directory is not enough).
-// 3) GIT_CONFIG_NOSYSTEM prevents git from loading system-wide config
-// 4) GIT_ASKPASS to prevent git from prompting for a user/password
+//  1. The HOME directory is set to a temporary dir to avoid loading any settings in .gitconfig
+//  2. The GIT_SSH variable is set to /dev/null so the regular SSH keys are not used
+//     (changing the HOME directory is not enough).
+//  3. GIT_CONFIG_NOSYSTEM prevents git from loading system-wide config
+//  4. GIT_ASKPASS to prevent git from prompting for a user/password
 func (r *SourceRepository) DetectAuth() error {
 
 	url, ok, err := r.RemoteURL()
@@ -301,7 +301,6 @@ func (r *SourceRepository) DetectAuth() error {
 	defer os.RemoveAll(tempSrc)
 	env := []string{
 		fmt.Sprintf("HOME=%s", tempHome),
-		"GIT_SSH=/dev/null",
 		"GIT_CONFIG_NOSYSTEM=true",
 		"GIT_ASKPASS=true",
 	}


### PR DESCRIPTION
When a user tries to create a new-app with a SSH based repository, `oc` fails on not being able to `git ls-remote --heads` due authentication error, i.e.:

```
$ oc new-app --v=8 --source-secret=github-repo-key --name=test-app 'git@github.com:otaviof/nodejs-ex.git'
I1019 09:41:10.701737   24709 loader.go:374] Config loaded from file:  /home/otaviof/.kube/config
I1019 09:41:10.702768   24709 sourcelookup.go:316] Checking if git@github.com:otaviof/nodejs-ex.git requires authentication
I1019 09:41:10.702789   24709 repository.go:450] Executing git ls-remote --heads git@github.com:otaviof/nodejs-ex.git
I1019 09:41:10.702811   24709 repository.go:459] Environment:
I1019 09:41:10.702818   24709 repository.go:461] - HOME=/tmp/githome2802467764
I1019 09:41:10.702825   24709 repository.go:461] - GIT_SSH=/dev/null
I1019 09:41:10.702832   24709 repository.go:461] - GIT_CONFIG_NOSYSTEM=true
I1019 09:41:10.702837   24709 repository.go:461] - GIT_ASKPASS=true
I1019 09:41:10.704143   24709 repository.go:541] Error executing command: exit status 128
warning: Cannot check if git requires authentication.
[...]
See 'oc new-app -h' for examples.
exit status 1
``` 

This pull request removes the hardcoded `GIT_SSH=/dev/null` allowing Git to use the local SSH-Agent:

```
$ oc new-app --v=8 --source-secret=github-repo-key --name=test-app 'git@github.com:otaviof/nodejs-ex.git'
I1019 09:35:20.560638   23876 loader.go:374] Config loaded from file:  /home/otaviof/.kube/config
I1019 09:35:20.561705   23876 sourcelookup.go:315] Checking if git@github.com:otaviof/nodejs-ex.git requires authentication
I1019 09:35:20.561722   23876 repository.go:450] Executing git ls-remote --heads git@github.com:otaviof/nodejs-ex.git
I1019 09:35:20.561742   23876 repository.go:459] Environment:
I1019 09:35:20.561747   23876 repository.go:461] - HOME=/tmp/githome2424980829
I1019 09:35:20.561750   23876 repository.go:461] - GIT_CONFIG_NOSYSTEM=true
I1019 09:35:20.561753   23876 repository.go:461] - GIT_ASKPASS=true
I1019 09:35:21.892018   23876 sourcelookup.go:94] git@github.com:otaviof/nodejs-ex.git is a valid remote git repository
I1019 09:35:21.892044   23876 newapp.go:318] treating git@github.com:otaviof/nodejs-ex.git as possible source repo
[...]
--> Success
    Build scheduled, use 'oc logs -f buildconfig/test-app' to track its progress.
    Application is not exposed. You can expose services to the outside world by executing one or more of the commands below:
     'oc expose service/test-app'
    Run 'oc status' to view your app.
```