### PR TITLE
use correct namespace with sample templates

### DIFF
--- a/pkg/helpers/newapp/cmd/newapp.go
+++ b/pkg/helpers/newapp/cmd/newapp.go
@@ -567,7 +567,10 @@ func (c *AppConfig) buildTemplates(components app.ComponentReferences, parameter
 	name := ""
 	for _, ref := range components {
 		tpl := ref.Input().ResolvedMatch.Template
-
+		if len(tpl.Namespace) > 0 && tpl.Namespace != c.OriginNamespace {
+			// if set, template namespace must match the namespace it will be processed in.
+			tpl.Namespace = c.OriginNamespace
+		}
 		klog.V(4).Infof("processing template %s/%s", c.OriginNamespace, tpl.Name)
 		if len(c.ContextDir) > 0 {
 			return "", nil, fmt.Errorf("--context-dir is not supported when using a template")


### PR DESCRIPTION
Bumping openshift-apiserver brings with it stricter validation of namespace (obj vs. request). 