### PR TITLE
OCPBUGS-3473: oc adm release new: allow specifying crio and kernel versions

### DIFF
--- a/pkg/cli/admin/release/new.go
+++ b/pkg/cli/admin/release/new.go
@@ -55,7 +55,7 @@ func NewNewOptions(streams genericclioptions.IOStreams) *NewOptions {
 		// We strongly control the set of allowed component versions to prevent confusion
 		// about what component versions may be used for. Changing this list requires
 		// approval from the release architects.
-		AllowedComponents: []string{"kubernetes", "machine-os"},
+		AllowedComponents: []string{"kubernetes", "machine-os", "kernel", "crio"},
 	}
 }
 


### PR DESCRIPTION
For OKD payloads it would be useful to display kernel (if its overriden) and CRI-O versions used