### PR TITLE
pkg/cli/admin/upgrade: Drop "force" from "No updates available"

### DIFF
--- a/pkg/cli/admin/upgrade/upgrade.go
+++ b/pkg/cli/admin/upgrade/upgrade.go
@@ -405,7 +405,7 @@ func (o *Options) Run() error {
 			if c := findClusterOperatorStatusCondition(cv.Status.Conditions, configv1.RetrievedUpdates); c != nil && c.Status == configv1.ConditionFalse {
 				fmt.Fprintf(o.ErrOut, "warning: Cannot display available updates:\n  Reason: %s\n  Message: %s\n\n", c.Reason, strings.ReplaceAll(c.Message, "\n", "\n  "))
 			} else {
-				fmt.Fprintf(o.Out, "No updates available. You may force an upgrade to a specific release image, but doing so may not be supported and may result in downtime or data loss.\n")
+				fmt.Fprintf(o.Out, "No updates available. You may still upgrade to a specific release image with --to-image or wait for new updates to be available.\n")
 			}
 		}
 


### PR DESCRIPTION
The outgoing wording dates back to the initial subcommand implementation in openshift/origin@65cce8c37d (openshift/origin#21605).  But "force" is easy to conflate with the `--force` option, and we occasionally hear of users who set `--force` under the mistaken impression that it is related to the recommended-ness of the target release image.  There's already a paragraph in the generic `--help` text discussing the risks of `--allow-explicit-upgrade`, and folks who use `--to-image` in the absence of recommended updates will hear about `--allow-explicit-upgrade` when a bare `--to-image` fails to turn up the requested pullspec in `availableUpdates`.