### PR TITLE
OCPBUGS-3526: Proceed archive if Lsetxattr gets unsupported error

### DIFF
--- a/pkg/cli/image/archive/archive.go
+++ b/pkg/cli/image/archive/archive.go
@@ -392,7 +392,6 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, L
 		}
 	}
 
-	var errors []string
 	for key, value := range hdr.Xattrs {
 		// exclude security.capability unless you're root, Lsetxattr only works
 		// for linux based systems so that's fine
@@ -405,7 +404,6 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, L
 				// xattrs *cough* old versions of AUFS *cough*. However only
 				// ENOTSUP should be emitted in that case, otherwise we still
 				// bail.
-				errors = append(errors, err.Error())
 				continue
 			}
 			return err

--- a/pkg/cli/image/archive/archive.go
+++ b/pkg/cli/image/archive/archive.go
@@ -399,6 +399,11 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, L
 			continue
 		}
 		if err := system.Lsetxattr(path, key, []byte(value), 0); err != nil {
+			if err == system.ErrNotSupportedPlatform {
+				// we ignore not supported platform errors
+				// to proceed archiving on platforms like darwin.
+				continue
+			}
 			if err == syscall.ENOTSUP {
 				// We ignore errors here because not all graphdrivers support
 				// xattrs *cough* old versions of AUFS *cough*. However only


### PR DESCRIPTION
Currently on darwin, archiving is failing by raising unsupported system error.
This PR handles that error and proceeds to archiving.

This is basically the same approach applied in here https://github.com/openshift/oc/blob/952066e54e7b9a487f321d3266161786ff8ab742/pkg/cli/image/archive/archive.go#L444