### PR TITLE
OCPBUGS-4280: oc import-image: reflect import image error

### DIFF
--- a/pkg/cli/importimage/importimage.go
+++ b/pkg/cli/importimage/importimage.go
@@ -222,8 +222,10 @@ func (o *ImportImageOptions) Run() error {
 		return err
 	}
 
+	var importErr error
 	message := "imported"
 	if wasError(result) {
+		importErr = fmt.Errorf("imported completed with errors")
 		message = "imported with errors"
 	}
 
@@ -279,7 +281,12 @@ func (o *ImportImageOptions) Run() error {
 		return err
 	}
 
-	return printer.PrintObj(stream, o.Out)
+	err = printer.PrintObj(stream, o.Out)
+	if err != nil {
+		return err
+	}
+
+	return importErr
 }
 
 func wasError(isi *imagev1.ImageStreamImport) bool {


### PR DESCRIPTION
This PR returns import image error retrieved from server to return correct exit code. 