### PR TITLE
Rename registry.svc.ci.openshift.org to registry.ci.openshift.org

### DIFF
--- a/pkg/cli/admin/release/extract.go
+++ b/pkg/cli/admin/release/extract.go
@@ -105,7 +105,7 @@ func NewExtract(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.
 
 			# Use git to check out the source code for the current cluster release to DIR from linux/s390x image
 			# Note: Wildcard filter is not supported. Pass a single os/arch to extract
-			oc adm release extract --git=DIR quay.io/openshift-release-dev/ocp-release:4.2.2 --filter-by-os=linux/s390x
+			oc adm release extract --git=DIR quay.io/openshift-release-dev/ocp-release:4.11.2 --filter-by-os=linux/s390x
 		`),
 		Run: func(cmd *cobra.Command, args []string) {
 			kcmdutil.CheckErr(o.Complete(f, cmd, args))

--- a/pkg/cli/admin/release/info.go
+++ b/pkg/cli/admin/release/info.go
@@ -74,7 +74,7 @@ func NewInfo(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Com
 
 			If no arguments are specified the release of the currently connected cluster is displayed.
 			Specify one or more images via pull spec to see details of each release image. You may also
-			pass a semantic version (4.2.2) as an argument, and if cluster version object has seen such a
+			pass a semantic version (4.11.2) as an argument, and if cluster version object has seen such a
 			version in the upgrades channel it will find the release info for that version.
 
 			The --commits flag will display the Git commit IDs and repository URLs for the source of each
@@ -104,17 +104,17 @@ func NewInfo(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Com
 			oc adm release info
 
 			# Show the source code that comprises a release
-			oc adm release info 4.2.2 --commit-urls
+			oc adm release info 4.11.2 --commit-urls
 
 			# Show the source code difference between two releases
-			oc adm release info 4.2.0 4.2.2 --commits
+			oc adm release info 4.11.0 4.11.2 --commits
 
 			# Show where the images referenced by the release are located
-			oc adm release info quay.io/openshift-release-dev/ocp-release:4.2.2 --pullspecs
+			oc adm release info quay.io/openshift-release-dev/ocp-release:4.11.2 --pullspecs
 
 			# Show information about linux/s390x image
 			# Note: Wildcard filter is not supported. Pass a single os/arch to extract
-			oc adm release info quay.io/openshift-release-dev/ocp-release:4.2.2 --filter-by-os=linux/s390x
+			oc adm release info quay.io/openshift-release-dev/ocp-release:4.11.2 --filter-by-os=linux/s390x
 
 		`),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cli/admin/release/mirror.go
+++ b/pkg/cli/admin/release/mirror.go
@@ -81,7 +81,7 @@ func NewMirrorOptions(streams genericclioptions.IOStreams) *MirrorOptions {
 // # Example command to mirror a release to a local repository to work offline
 //
 //	$ oc adm release mirror \
-//	    --from=registry.svc.ci.openshift.org/openshift/v4.0 \
+//	    --from=registry.ci.openshift.org/openshift/v4.11 \
 //	    --to=mycompany.com/myrepository/repo
 func NewMirror(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
 	o := NewMirrorOptions(streams)
@@ -123,22 +123,22 @@ func NewMirror(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.C
 		`),
 		Example: templates.Examples(`
 			# Perform a dry run showing what would be mirrored, including the mirror objects
-			oc adm release mirror 4.3.0 --to myregistry.local/openshift/release \
+			oc adm release mirror 4.11.0 --to myregistry.local/openshift/release \
 				--release-image-signature-to-dir /tmp/releases --dry-run
 
 			# Mirror a release into the current directory
-			oc adm release mirror 4.3.0 --to file://openshift/release \
+			oc adm release mirror 4.11.0 --to file://openshift/release \
 				--release-image-signature-to-dir /tmp/releases
 
 			# Mirror a release to another directory in the default location
-			oc adm release mirror 4.3.0 --to-dir /tmp/releases
+			oc adm release mirror 4.11.0 --to-dir /tmp/releases
 
 			# Upload a release from the current directory to another server
 			oc adm release mirror --from file://openshift/release --to myregistry.com/openshift/release \
 				--release-image-signature-to-dir /tmp/releases
 
-			# Mirror the 4.3.0 release to repository registry.example.com and apply signatures to connected cluster
-			oc adm release mirror --from=quay.io/openshift-release-dev/ocp-release:4.3.0-x86_64 \
+			# Mirror the 4.11.0 release to repository registry.example.com and apply signatures to connected cluster
+			oc adm release mirror --from=quay.io/openshift-release-dev/ocp-release:4.11.0-x86_64 \
 				--to=registry.example.com/your/repository --apply-release-image-signature
 		`),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cli/admin/release/new.go
+++ b/pkg/cli/admin/release/new.go
@@ -97,18 +97,18 @@ func NewRelease(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.
 		`),
 		Example: templates.Examples(`
 			# Create a release from the latest origin images and push to a DockerHub repo
-			oc adm release new --from-image-stream=4.1 -n origin --to-image docker.io/mycompany/myrepo:latest
+			oc adm release new --from-image-stream=4.11 -n origin --to-image docker.io/mycompany/myrepo:latest
 
 			# Create a new release with updated metadata from a previous release
-			oc adm release new --from-release registry.svc.ci.openshift.org/origin/release:v4.1 --name 4.1.1 \
-				--previous 4.1.0 --metadata ... --to-image docker.io/mycompany/myrepo:latest
+			oc adm release new --from-release registry.ci.openshift.org/origin/release:v4.11 --name 4.11.1 \
+				--previous 4.11.0 --metadata ... --to-image docker.io/mycompany/myrepo:latest
 
 			# Create a new release and override a single image
-			oc adm release new --from-release registry.svc.ci.openshift.org/origin/release:v4.1 \
+			oc adm release new --from-release registry.ci.openshift.org/origin/release:v4.11 \
 				cli=docker.io/mycompany/cli:latest --to-image docker.io/mycompany/myrepo:latest
 
 			# Run a verification pass to ensure the release can be reproduced
-			oc adm release new --from-release registry.svc.ci.openshift.org/origin/release:v4.1
+			oc adm release new --from-release registry.ci.openshift.org/origin/release:v4.11
 		`),
 		Run: func(cmd *cobra.Command, args []string) {
 			kcmdutil.CheckErr(o.Complete(f, cmd, args))


### PR DESCRIPTION
Align OCP versions with the new CI registry