### PR TITLE
FDN-112: Parse any jira reference from commit text, not just OCPBUGS

### DIFF
--- a/pkg/cli/admin/release/bug_test.go
+++ b/pkg/cli/admin/release/bug_test.go
@@ -9,75 +9,75 @@ import (
 func TestExtractBugs(t *testing.T) {
 	tests := []struct {
 		input string
-		bugs  BugList
+		bugs  RefList
 		msg   string
 	}{
 		{
 			input: " [release-4.1] Bugs , 17 43,564,: test",
-			bugs: BugList{
-				Bugs: []Bug{{17, Bugzilla}, {43, Bugzilla}, {564, Bugzilla}},
+			bugs: RefList{
+				Refs: []Ref{{"17", Bugzilla}, {"43", Bugzilla}, {"564", Bugzilla}},
 			},
 			msg: "test",
 		},
 		{
 			input: " [release-4.1] Bugs , 564,17 43,: test",
-			bugs: BugList{
-				Bugs: []Bug{{17, Bugzilla}, {43, Bugzilla}, {564, Bugzilla}},
+			bugs: RefList{
+				Refs: []Ref{{"17", Bugzilla}, {"43", Bugzilla}, {"564", Bugzilla}},
 			},
 			msg: "test",
 		},
 		{
 			input: " [release-4.1] Bug 1743564,: test",
-			bugs: BugList{
-				Bugs: []Bug{{1743564, Bugzilla}},
+			bugs: RefList{
+				Refs: []Ref{{"1743564", Bugzilla}},
 			},
 			msg: "test",
 		},
 		{
 			input: "[release-4.1] OCPBUGS-1743564: test",
-			bugs: BugList{
-				Bugs: []Bug{{1743564, Jira}},
+			bugs: RefList{
+				Refs: []Ref{{"OCPBUGS-1743564", Jira}},
 			},
 			msg: "test",
 		},
 		{
-			input: " [release-4.1] OCPBUGS-17,43,564: test",
-			bugs: BugList{
-				Bugs: []Bug{{17, Jira}, {43, Jira}, {564, Jira}},
+			input: " [release-4.1] OCPBUGS-17,OCPBUGS-43,OCPBUGS-564: test",
+			bugs: RefList{
+				Refs: []Ref{{"OCPBUGS-17", Jira}, {"OCPBUGS-43", Jira}, {"OCPBUGS-564", Jira}},
 			},
 			msg: "test",
 		},
 		{
-			input: " [release-4.1] OCPBUGS-17,43,564,: test",
-			bugs: BugList{
-				Bugs: []Bug{{17, Jira}, {43, Jira}, {564, Jira}},
+			input: " [release-4.1] OCPBUGS-17,OCPBUGS-43,OCPBUGS-564,: test",
+			bugs: RefList{
+				Refs: []Ref{{"OCPBUGS-17", Jira}, {"OCPBUGS-43", Jira}, {"OCPBUGS-564", Jira}},
 			},
 			msg: "test",
 		},
 		{
-			input: " [release-4.1] OCPBUGS-564,43,17,: test",
-			bugs: BugList{
-				Bugs: []Bug{{17, Jira}, {43, Jira}, {564, Jira}},
+			input: " [release-4.1] OCPBUGS-564,OCPBUGS-43,OCPBUGS-17,: test",
+			bugs: RefList{
+				Refs: []Ref{{"OCPBUGS-17", Jira}, {"OCPBUGS-43", Jira}, {"OCPBUGS-564", Jira}},
 			},
 			msg: "test",
 		},
 		{
-			input: "OCPBUGS-17,43,564 : test",
-			bugs: BugList{
-				Bugs: []Bug{{17, Jira}, {43, Jira}, {564, Jira}},
+			input: "OCPBUGS-17,OCPBUGS-43,OCPBUGS-564 : test",
+			bugs: RefList{
+				Refs: []Ref{{"OCPBUGS-17", Jira}, {"OCPBUGS-43", Jira}, {"OCPBUGS-564", Jira}},
 			},
 			msg: "test",
 		},
 		{
 			input: "test",
-			bugs:  BugList{},
+			bugs:  RefList{},
 			msg:   "test",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run("", func(t *testing.T) {
-			actualBugs, actualMsg := extractBugs(tt.input)
+			actualBugs, actualMsg := extractRefs(tt.input)
 			if tt.msg != actualMsg {
 				t.Errorf("extractBugs() actual message = %s, wanted message %s", actualMsg, tt.msg)
 			}
@@ -88,37 +88,37 @@ func TestExtractBugs(t *testing.T) {
 	}
 }
 
-func TestGetBugList(t *testing.T) {
+func TestGetRefList(t *testing.T) {
 	tests := []struct {
-		input  map[string]Bug
-		wanted []Bug
+		input  map[string]Ref
+		wanted []Ref
 	}{
 		{
-			input: map[string]Bug{
+			input: map[string]Ref{
 				"jira-511": {
-					ID:     511,
+					ID:     "511",
 					Source: Jira,
 				},
 				"bugzilla-12": {
-					ID:     12,
+					ID:     "12",
 					Source: Bugzilla,
 				},
 				"jira-1": {
-					ID:     1,
+					ID:     "1",
 					Source: Jira,
 				},
 			},
-			wanted: []Bug{
+			wanted: []Ref{
 				{
-					ID:     1,
+					ID:     "1",
 					Source: Jira,
 				},
 				{
-					ID:     12,
+					ID:     "12",
 					Source: Bugzilla,
 				},
 				{
-					ID:     511,
+					ID:     "511",
 					Source: Jira,
 				},
 			},
@@ -126,20 +126,20 @@ func TestGetBugList(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		actual := GetBugList(tt.input)
+		actual := GetRefList(tt.input)
 		if !reflect.DeepEqual(actual, tt.wanted) {
 			t.Errorf("getbuglist actual %v wanted %v", actual, tt.wanted)
 		}
 	}
 }
 
-func TestConvertJiraToBugRemoteInfo(t *testing.T) {
+func TestConvertJiraToRefRemoteInfo(t *testing.T) {
 	tests := []struct {
-		input  JiraRemoteBug
-		wanted BugRemoteInfo
+		input  JiraRemoteRef
+		wanted RefRemoteInfo
 	}{
 		{
-			input: JiraRemoteBug{
+			input: JiraRemoteRef{
 				Key: "OCPBUGS-11",
 				Fields: JiraRemoteFields{
 					Summary: "test bug",
@@ -151,8 +151,8 @@ func TestConvertJiraToBugRemoteInfo(t *testing.T) {
 					},
 				},
 			},
-			wanted: BugRemoteInfo{
-				ID:       11,
+			wanted: RefRemoteInfo{
+				ID:       "OCPBUGS-11",
 				Status:   "Closed",
 				Priority: "Blocker",
 				Summary:  "test bug",
@@ -162,42 +162,42 @@ func TestConvertJiraToBugRemoteInfo(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		actual := convertJiraToBugRemoteInfo(tt.input)
+		actual := convertJiraToRefRemoteInfo(tt.input)
 		if !reflect.DeepEqual(actual, tt.wanted) {
 			t.Errorf("convertjiratobugremoteinfo actual %v wanted %v", actual, tt.wanted)
 		}
 	}
 }
 
-func TestPrintBugs(t *testing.T) {
+func TestPrintRefs(t *testing.T) {
 	tests := []struct {
-		input  BugList
+		input  RefList
 		wanted string
 	}{
 		{
-			input: BugList{
-				Bugs: []Bug{{1212, Bugzilla}}},
+			input: RefList{
+				Refs: []Ref{{"1212", Bugzilla}}},
 			wanted: " [Bug 1212](https://bugzilla.redhat.com/show_bug.cgi?id=1212):",
 		},
 		{
-			input: BugList{
-				Bugs: []Bug{{1212, Jira}}},
+			input: RefList{
+				Refs: []Ref{{"OCPBUGS-1212", Jira}}},
 			wanted: " [OCPBUGS-1212](https://issues.redhat.com/browse/OCPBUGS-1212):",
 		},
 		{
-			input:  BugList{[]Bug{{1212, Bugzilla}, {22, Bugzilla}}},
+			input:  RefList{[]Ref{{"1212", Bugzilla}, {"22", Bugzilla}}},
 			wanted: " [Bug 1212](https://bugzilla.redhat.com/show_bug.cgi?id=1212), [22](https://bugzilla.redhat.com/show_bug.cgi?id=22):",
 		},
 		{
-			input:  BugList{[]Bug{{1212, Jira}, {22, Jira}}},
-			wanted: " [OCPBUGS-1212](https://issues.redhat.com/browse/OCPBUGS-1212), [22](https://issues.redhat.com/browse/OCPBUGS-22):",
+			input:  RefList{[]Ref{{"OCPBUGS-1212", Jira}, {"OCPBUGS-22", Jira}}},
+			wanted: " [OCPBUGS-1212](https://issues.redhat.com/browse/OCPBUGS-1212), [OCPBUGS-22](https://issues.redhat.com/browse/OCPBUGS-22):",
 		},
 		{
-			input:  BugList{[]Bug{{1212, Jira}, {22, Bugzilla}}},
-			wanted: " [OCPBUGS-1212](https://issues.redhat.com/browse/OCPBUGS-1212), [22](https://bugzilla.redhat.com/show_bug.cgi?id=22):",
+			input:  RefList{[]Ref{{"ABC-1212", Jira}, {"22", Bugzilla}}},
+			wanted: " [ABC-1212](https://issues.redhat.com/browse/ABC-1212), [22](https://bugzilla.redhat.com/show_bug.cgi?id=22):",
 		},
 		{
-			input:  BugList{},
+			input:  RefList{},
 			wanted: "",
 		},
 	}
@@ -205,10 +205,10 @@ func TestPrintBugs(t *testing.T) {
 	for _, tt := range tests {
 		var b bytes.Buffer
 		t.Run("", func(t *testing.T) {
-			tt.input.PrintBugs(&b)
+			tt.input.PrintRefs(&b)
 			actual := b.String()
 			if actual != tt.wanted {
-				t.Errorf("printBugs() actual print %s wanted %s", actual, tt.wanted)
+				t.Errorf("printBugs() actual print:\n|%s|\nwanted:\n|%s|", actual, tt.wanted)
 			}
 		})
 	}

--- a/pkg/cli/admin/release/git.go
+++ b/pkg/cli/admin/release/git.go
@@ -146,7 +146,7 @@ type MergeCommit struct {
 	ParentCommits []string
 
 	PullRequest int
-	Bugs        BugList
+	Refs        RefList
 
 	Subject string
 }
@@ -239,7 +239,7 @@ func mergeLogForRepo(g gitInterface, repo string, from, to string) ([]MergeCommi
 			msg = records[2]
 		}
 
-		mergeCommit.Bugs, msg = extractBugs(msg)
+		mergeCommit.Refs, msg = extractRefs(msg)
 		msg = strings.TrimSpace(msg)
 		msg = strings.SplitN(msg, "\n", 2)[0]
 

--- a/pkg/cli/admin/release/git_test.go
+++ b/pkg/cli/admin/release/git_test.go
@@ -36,10 +36,10 @@ func Test_mergeLogForRepo(t *testing.T) {
 			want: []MergeCommit{
 				{
 					ParentCommits: []string{}, Commit: "abc", PullRequest: 145, CommitDate: time.Unix(1, 0).UTC(),
-					Bugs: BugList{
-						Bugs: []Bug{
+					Refs: RefList{
+						Refs: []Ref{
 							{
-								ID:     1743564,
+								ID:     "1743564",
 								Source: Bugzilla,
 							},
 						},
@@ -53,10 +53,10 @@ func Test_mergeLogForRepo(t *testing.T) {
 			want: []MergeCommit{
 				{
 					ParentCommits: []string{}, Commit: "abc", PullRequest: 145, CommitDate: time.Unix(1, 0).UTC(),
-					Bugs: BugList{
-						Bugs: []Bug{
+					Refs: RefList{
+						Refs: []Ref{
 							{
-								ID:     1743564,
+								ID:     "1743564",
 								Source: Bugzilla,
 							},
 						},
@@ -70,10 +70,10 @@ func Test_mergeLogForRepo(t *testing.T) {
 			want: []MergeCommit{
 				{
 					ParentCommits: []string{}, Commit: "abc", PullRequest: 145, CommitDate: time.Unix(1, 0).UTC(),
-					Bugs: BugList{
-						Bugs: []Bug{
+					Refs: RefList{
+						Refs: []Ref{
 							{
-								ID:     1743564,
+								ID:     "1743564",
 								Source: Bugzilla,
 							},
 						},
@@ -87,10 +87,10 @@ func Test_mergeLogForRepo(t *testing.T) {
 			want: []MergeCommit{
 				{
 					ParentCommits: []string{}, Commit: "abc", PullRequest: 145, CommitDate: time.Unix(1, 0).UTC(),
-					Bugs: BugList{
-						Bugs: []Bug{
+					Refs: RefList{
+						Refs: []Ref{
 							{
-								ID:     1743564,
+								ID:     "1743564",
 								Source: Bugzilla,
 							},
 						},
@@ -104,10 +104,10 @@ func Test_mergeLogForRepo(t *testing.T) {
 			want: []MergeCommit{
 				{
 					ParentCommits: []string{}, Commit: "abc", PullRequest: 145, CommitDate: time.Unix(1, 0).UTC(),
-					Bugs: BugList{
-						Bugs: []Bug{
+					Refs: RefList{
+						Refs: []Ref{
 							{
-								ID:     1743564,
+								ID:     "1743564",
 								Source: Bugzilla,
 							},
 						},
@@ -121,10 +121,10 @@ func Test_mergeLogForRepo(t *testing.T) {
 			want: []MergeCommit{
 				{
 					ParentCommits: []string{}, Commit: "abc", PullRequest: 145, CommitDate: time.Unix(1, 0).UTC(),
-					Bugs: BugList{
-						Bugs: []Bug{
+					Refs: RefList{
+						Refs: []Ref{
 							{
-								ID:     1743564,
+								ID:     "1743564",
 								Source: Bugzilla,
 							},
 						},
@@ -138,10 +138,10 @@ func Test_mergeLogForRepo(t *testing.T) {
 			want: []MergeCommit{
 				{
 					ParentCommits: []string{}, Commit: "abc", PullRequest: 145, CommitDate: time.Unix(1, 0).UTC(),
-					Bugs: BugList{
-						Bugs: []Bug{
+					Refs: RefList{
+						Refs: []Ref{
 							{
-								ID:     1743564,
+								ID:     "1743564",
 								Source: Bugzilla,
 							},
 						},
@@ -155,18 +155,18 @@ func Test_mergeLogForRepo(t *testing.T) {
 			want: []MergeCommit{
 				{
 					ParentCommits: []string{}, Commit: "abc", PullRequest: 145, CommitDate: time.Unix(1, 0).UTC(),
-					Bugs: BugList{
-						Bugs: []Bug{
+					Refs: RefList{
+						Refs: []Ref{
 							{
-								ID:     17,
+								ID:     "17",
 								Source: Bugzilla,
 							},
 							{
-								ID:     43,
+								ID:     "43",
 								Source: Bugzilla,
 							},
 							{
-								ID:     564,
+								ID:     "564",
 								Source: Bugzilla,
 							},
 						},
@@ -180,18 +180,18 @@ func Test_mergeLogForRepo(t *testing.T) {
 			want: []MergeCommit{
 				{
 					ParentCommits: []string{}, Commit: "abc", PullRequest: 145, CommitDate: time.Unix(1, 0).UTC(),
-					Bugs: BugList{
-						Bugs: []Bug{
+					Refs: RefList{
+						Refs: []Ref{
 							{
-								ID:     17,
+								ID:     "17",
 								Source: Bugzilla,
 							},
 							{
-								ID:     43,
+								ID:     "43",
 								Source: Bugzilla,
 							},
 							{
-								ID:     564,
+								ID:     "564",
 								Source: Bugzilla,
 							},
 						},
@@ -205,7 +205,7 @@ func Test_mergeLogForRepo(t *testing.T) {
 			want: []MergeCommit{
 				{
 					ParentCommits: []string{}, Commit: "abc", PullRequest: 145, CommitDate: time.Unix(1, 0).UTC(),
-					Bugs:    BugList{},
+					Refs:    RefList{},
 					Subject: "[release 4.1] bugs , 17 43,564,: test",
 				},
 			},
@@ -216,10 +216,10 @@ func Test_mergeLogForRepo(t *testing.T) {
 			want: []MergeCommit{
 				{
 					ParentCommits: []string{}, Commit: "abc", PullRequest: 145, CommitDate: time.Unix(1, 0).UTC(),
-					Bugs: BugList{
-						Bugs: []Bug{
+					Refs: RefList{
+						Refs: []Ref{
 							{
-								ID:     1743564,
+								ID:     "1743564",
 								Source: Bugzilla,
 							},
 						},
@@ -234,10 +234,10 @@ func Test_mergeLogForRepo(t *testing.T) {
 			want: []MergeCommit{
 				{
 					ParentCommits: []string{}, Commit: "abc", PullRequest: 145, CommitDate: time.Unix(1, 0).UTC(),
-					Bugs: BugList{
-						Bugs: []Bug{
+					Refs: RefList{
+						Refs: []Ref{
 							{
-								ID:     1743564,
+								ID:     "OCPBUGS-1743564",
 								Source: Jira,
 							},
 						},
@@ -252,8 +252,38 @@ func Test_mergeLogForRepo(t *testing.T) {
 			want: []MergeCommit{
 				{
 					ParentCommits: []string{}, Commit: "abc", PullRequest: 145, CommitDate: time.Unix(1, 0).UTC(),
-					Bugs:    BugList{},
+					Refs:    RefList{},
 					Subject: "fix vendoring from #123 (#145)",
+				},
+			},
+		},
+		{
+			input:  "abc\x1e1\x1eOCPBUGS-1743564, NE-123 ABC-789,,, XYZ-123: fix typo (#145)\x1e * fix typo",
+			squash: true,
+			want: []MergeCommit{
+				{
+					ParentCommits: []string{}, Commit: "abc", PullRequest: 145, CommitDate: time.Unix(1, 0).UTC(),
+					Refs: RefList{
+						Refs: []Ref{
+							{
+								ID:     "ABC-789",
+								Source: Jira,
+							},
+							{
+								ID:     "NE-123",
+								Source: Jira,
+							},
+							{
+								ID:     "OCPBUGS-1743564",
+								Source: Jira,
+							},
+							{
+								ID:     "XYZ-123",
+								Source: Jira,
+							},
+						},
+					},
+					Subject: "fix typo (#145)",
 				},
 			},
 		},


### PR DESCRIPTION
for discussion on workloads call.

This allows the changelog to link to all the jira tickets(i.e. also stories/epics) referenced in commits, not just OCPBUGS tickets.