### PR TITLE
IR-266: Add image manifests to 'describe image'

### DIFF
--- a/pkg/helpers/describe/describer.go
+++ b/pkg/helpers/describe/describer.go
@@ -753,6 +753,14 @@ func DescribeImage(image *imagev1.Image, imageName string) (string, error) {
 		formatString(out, "Author", dockerImage.Author)
 		formatString(out, "Arch", dockerImage.Architecture)
 
+		if len(image.DockerImageManifests) > 0 {
+			var manifests []string
+			for _, m := range image.DockerImageManifests {
+				manifests = append(manifests, fmt.Sprintf("%s/%s\t%s", m.OS, m.Architecture, m.Digest))
+			}
+			formatString(out, "Manifests", strings.Join(manifests, "\n"))
+		}
+
 		dockerImageConfig := dockerImage.Config
 		// This field should always be populated, if it is not we should print empty fields.
 		if dockerImageConfig == nil {

--- a/pkg/helpers/describe/describer_test.go
+++ b/pkg/helpers/describe/describer_test.go
@@ -539,6 +539,22 @@ func TestDescribeImage(t *testing.T) {
 				"Image Size:.+4.43kB in 2 layers",
 			},
 		},
+		{
+			image: imagev1.Image{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				DockerImageManifests: []imagev1.ImageManifest{
+					{Architecture: "amd64", OS: "linux", Digest: "sha256:1234"},
+					{Architecture: "s390x", OS: "linux", Digest: "sha256:5678"},
+				},
+				DockerImageMetadata: runtime.RawExtension{Object: &dockerv10.DockerImage{}},
+			},
+			want: []string{
+				"Manifests:\\slinux/amd64\\ssha256:1234",
+				"linux/s390x\\ssha256:5678",
+			},
+		},
 	}
 	for i := range tests {
 		tt := tests[i]


### PR DESCRIPTION
If the image to describe contains image manifests, this adds both os/arch and digest of each manifest to the output.

The output looks like this (this is the output of the stripped down test case):
```
Image Name:     test
Docker Image:   <none>
Name:           test
Layer Size:     0B
Image Created:  292 years ago
Author:         <none>
Arch:           <none>
Manifests:      linux/amd64     sha256:1234
                linux/s390x     sha256:5678
Command:        <none>
Working Dir:    <none>
User:           <none>
Exposes Ports:  <none>
Docker Labels:  <none>
```

