### PR TITLE
OCPBUGS-1115: Use linux/arch when user's OS isn't in manifests 

### DIFF
--- a/pkg/cli/image/manifest/errors.go
+++ b/pkg/cli/image/manifest/errors.go
@@ -1,9 +1,13 @@
 package manifest
 
 import (
+	"fmt"
+
 	"github.com/docker/distribution/registry/api/errcode"
 	registryapiv2 "github.com/docker/distribution/registry/api/v2"
 )
+
+var AllImageFilteredErr = fmt.Errorf("filtered all images from manifest list")
 
 type imageNotFound struct {
 	msg string

--- a/pkg/cli/image/manifest/manifest.go
+++ b/pkg/cli/image/manifest/manifest.go
@@ -296,7 +296,7 @@ func FirstManifest(ctx context.Context, from imagereference.DockerImageReference
 		return nil, ManifestLocation{}, err
 	}
 	if len(srcManifests) == 0 {
-		return nil, ManifestLocation{}, fmt.Errorf("filtered all images from manifest list")
+		return nil, ManifestLocation{}, AllImageFilteredErr
 	}
 
 	if srcDigest != originalSrcDigest {


### PR DESCRIPTION
Fixes [OCPBUGS-1115](https://issues.redhat.com/browse/OCPBUGS-1115).

When extracting 'oc' from a manifest listed image, if the --no-filter-by-os flag was not used and an image could not be found for the runtime OS/runtime arch combination, warn the user a manifest image could not be found for this combination and try searching for a linux/runtime arch combination again in the manifest listed image.