### PR TITLE
IR-261: Add --import-mode to 'tag'

### DIFF
--- a/pkg/cli/tag/tag.go
+++ b/pkg/cli/tag/tag.go
@@ -37,6 +37,7 @@ type TagOptions struct {
 	namespace    string
 
 	referencePolicy string
+	importMode      string
 
 	ref            imagev1.DockerImageReference
 	sourceKind     string
@@ -44,8 +45,6 @@ type TagOptions struct {
 	destNameAndTag []string
 
 	genericclioptions.IOStreams
-
-	importMode string
 }
 
 var (

--- a/pkg/cli/tag/tag.go
+++ b/pkg/cli/tag/tag.go
@@ -305,7 +305,7 @@ func isCrossImageStream(namespace string, srcRef imagev1.DockerImageReference, d
 }
 
 // Validate validates all the required options for the tag command.
-func (o TagOptions) Validate() error {
+func (o *TagOptions) Validate() error {
 	if o.deleteTag && o.aliasTag {
 		return errors.New("--alias and --delete may not be both specified")
 	}
@@ -358,6 +358,15 @@ func (o TagOptions) Validate() error {
 		if cross {
 			return errors.New("cannot set alias across different Image Streams")
 		}
+	}
+
+	switch o.importMode {
+	case string(imagev1.ImportModeLegacy):
+	case string(imagev1.ImportModePreserveOriginal):
+	case "":
+		o.importMode = string(imagev1.ImportModeLegacy)
+	default:
+		return fmt.Errorf("valid ImportMode values are %s or %s", imagev1.ImportModeLegacy, imagev1.ImportModePreserveOriginal)
 	}
 
 	return nil

--- a/pkg/cli/tag/tag.go
+++ b/pkg/cli/tag/tag.go
@@ -76,6 +76,9 @@ var (
 		# Tag an external container image and request pullthrough for it
 		oc tag --source=docker openshift/origin-control-plane:latest yourproject/ruby:tip --reference-policy=local
 
+		# Tag an external container image and include the full manifest list
+		oc tag --source=docker openshift/origin-control-plane:latest yourproject/ruby:tip --import-mode=PreserveOriginal
+
 		# Remove the specified spec tag from an image stream
 		oc tag openshift/origin-control-plane:latest -d`)
 )


### PR DESCRIPTION
Adds the given value (one of "PreserveOriginal", "Legacy", "") to the resulting ImageStreamTag. Invalid values result in an error by the API server.

https://issues.redhat.com/browse/IR-261
See also: https://github.com/openshift/oc/pull/1289/