### PR TITLE
Expose events command to land k8s 1.26

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -237,6 +237,7 @@ func NewOcCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 				kubectlwrappers.NewCmdRun(f, ioStreams),
 				kubectlwrappers.NewCmdCp(f, ioStreams),
 				kubectlwrappers.NewCmdWait(f, ioStreams),
+				kubectlwrappers.NewCmdEvents(f, ioStreams),
 			},
 		},
 		{

--- a/pkg/cli/kubectlwrappers/wrappers.go
+++ b/pkg/cli/kubectlwrappers/wrappers.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/kubectl/pkg/cmd/describe"
 	"k8s.io/kubectl/pkg/cmd/diff"
 	"k8s.io/kubectl/pkg/cmd/edit"
+	"k8s.io/kubectl/pkg/cmd/events"
 	"k8s.io/kubectl/pkg/cmd/exec"
 	"k8s.io/kubectl/pkg/cmd/explain"
 	kget "k8s.io/kubectl/pkg/cmd/get"
@@ -206,6 +207,10 @@ func NewCmdCp(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Co
 
 func NewCmdWait(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
 	return cmdutil.ReplaceCommandName("kubectl", "oc", templates.Normalize(kwait.NewCmdWait(f, streams)))
+}
+
+func NewCmdEvents(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+	return cmdutil.ReplaceCommandName("kubectl", "oc", templates.Normalize(events.NewCmdEvents(f, streams)))
 }
 
 func NewCmdAuth(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {


### PR DESCRIPTION
/assign @sanchezl @ardaguclu

This will unblock the rebase PR, we will need to expose this either way, but this should be enough to get the e2e passing. 

1.26 PR: https://github.com/openshift/kubernetes/pull/1432