### PR TITLE
Add must gather namespace annotation needed for performance profile controller

### DIFF
--- a/pkg/cli/admin/mustgather/mustgather.go
+++ b/pkg/cli/admin/mustgather/mustgather.go
@@ -662,8 +662,9 @@ func newNamespace() *corev1.Namespace {
 				"security.openshift.io/scc.podSecurityLabelSync": "false",
 			},
 			Annotations: map[string]string{
-				"oc.openshift.io/command":    "oc adm must-gather",
-				"openshift.io/node-selector": "",
+				"oc.openshift.io/command":       "oc adm must-gather",
+				"openshift.io/node-selector":    "",
+				"workload.openshift.io/allowed": "management",
 			},
 		},
 	}


### PR DESCRIPTION
# Context

Add "workload.openshift.io/allowed": "management", in order to must-gather performance profile controller daemonset works correctly.


# Why?
To fix this PR: https://github.com/openshift/must-gather/pull/341


Before this error is shown: 
Warning FailedCreate 33s (x15 over 115s) daemonset-controller Error creating: pods "perf-node-gather-daemonset-" is forbidden: [autoscaling.openshift.io/ManagementCPUsOverride](http://autoscaling.openshift.io/ManagementCPUsOverride) the pod namespace "openshift-must-gather-f2s49" does not allow the workload type management

Signed-off-by: Mario Fernandez <mariofer@redhat.com>