### PR TITLE
OCPBUGS-4906: oc process: Set original namespace if it differs

### DIFF
--- a/pkg/cli/process/process.go
+++ b/pkg/cli/process/process.go
@@ -350,6 +350,10 @@ func (o *ProcessOptions) RunProcess() error {
 			return err
 		}
 		templateObj.CreationTimestamp = metav1.Now()
+		if len(templateObj.Namespace) > 0 && templateObj.Namespace != o.namespace {
+			// if set, template namespace must match the namespace it will be processed in.
+			templateObj.Namespace = o.namespace
+		}
 		infos = append(infos, &resource.Info{Object: templateObj})
 	} else {
 		var err error


### PR DESCRIPTION
When template passed to `oc process` has namespace different from the `--namespace`. It returns an error;

```
the namespace of the provided object does not match the namespace sent on the request
``` 

This PR uses the same fix applied in https://github.com/openshift/oc/pull/1272