### PR TITLE
WRKLDS-629: release run-namspace functionality

### DIFF
--- a/pkg/cli/admin/mustgather/mustgather.go
+++ b/pkg/cli/admin/mustgather/mustgather.go
@@ -154,9 +154,6 @@ func (o *MustGatherOptions) Complete(f kcmdutil.Factory, cmd *cobra.Command, arg
 	if len(o.DestDir) == 0 {
 		o.DestDir = fmt.Sprintf("must-gather.local.%06d", rand.Int63())
 	}
-	if len(o.RunNamespace) > 0 {
-		fmt.Fprintln(o.ErrOut, `"--run-namespace" is an experimental flag, using it is not supported`)
-	}
 	if err := o.completeImages(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Commit dc5504ff0383bde3c5fa86d4cbc4c3d6c878f703 adds the ability to run must-gather in a namespace skipping rope binding operations. With [WRKLDS-629](https://issues.redhat.com//browse/WRKLDS-629) or PR #1313 in 4.13 we no long consider this experimental, so this log/error is incorrect