### PR TITLE
pkg/cli/admin/release/mirror: Reject by-digest --to-release-image pullspecs

### DIFF
--- a/pkg/cli/admin/release/mirror.go
+++ b/pkg/cli/admin/release/mirror.go
@@ -586,6 +586,9 @@ func (o *MirrorOptions) Run() error {
 			if err != nil {
 				return fmt.Errorf("invalid --to-release-image: %v", err)
 			}
+			if len(dstRef.Ref.Tag) == 0 {
+				return fmt.Errorf("invalid --to-release-image must include a tag name: %s", o.ToRelease)
+			}
 			mappings = append(mappings, mirror.Mapping{
 				Source:      srcRef,
 				Destination: dstRef,


### PR DESCRIPTION
`oc adm release mirror ...` should tag both the main release image and all the referenced component images when it pushes to the registry. Ideally all downstream consumers are using by-digest pullspecs, because those are immutable, and therefore safer, as described in 43cb3c8598 (#390).  But many image registries garbage-collect untagged images, so when we push into a registry we need to push into a tag to avoid that garbage collection.