### PR TITLE
OCPBUGS-8004: Fix bug when recreating an index with fewer images

### DIFF
--- a/pkg/cli/image/manifest/manifest.go
+++ b/pkg/cli/image/manifest/manifest.go
@@ -427,7 +427,7 @@ func ProcessManifestList(ctx context.Context, srcDigest digest.Digest, srcManife
 				return nil, nil, "", fmt.Errorf("unable to filter source image %s manifest list (bad payload): %v", ref, err)
 			}
 			manifestList = t
-			manifestDigest, err := registryclient.ContentDigestForManifest(t, srcDigest.Algorithm())
+			manifestDigest, err = registryclient.ContentDigestForManifest(t, srcDigest.Algorithm())
 			if err != nil {
 				return nil, nil, "", err
 			}


### PR DESCRIPTION
Currently, the original index digest is maintained because the variable containing the digest is incorrectly scoped instead of being overwritten.