### PR TITLE
OCPBUGS-5949: Add subrepository support for ICSP

### DIFF
--- a/pkg/cli/image/strategy/onerror_test.go
+++ b/pkg/cli/image/strategy/onerror_test.go
@@ -100,6 +100,25 @@ func TestOnErrorStrategy(t *testing.T) {
 			imageSourcesExpected: []string{"quay.io/ocp-test/release", "someregistry/mirrors/match"},
 		},
 		{
+			name: "single mirror and match with subrepository",
+			icspList: []operatorv1alpha1.ImageContentSourcePolicy{
+				{
+					Spec: operatorv1alpha1.ImageContentSourcePolicySpec{
+						RepositoryDigestMirrors: []operatorv1alpha1.RepositoryDigestMirrors{
+							{
+								Source: "quay.io/ocp-test",
+								Mirrors: []string{
+									"someregistry/mirrors",
+								},
+							},
+						},
+					},
+				},
+			},
+			image:                "quay.io/ocp-test/release:4.5",
+			imageSourcesExpected: []string{"quay.io/ocp-test/release", "someregistry/mirrors/release"},
+		},
+		{
 			name: "no source match",
 			icspList: []operatorv1alpha1.ImageContentSourcePolicy{
 				{


### PR DESCRIPTION
Currently, when icsp file is passed, oc does not search in subrepositories. This PR adds ability that is searching also in subrepositories.

This PR basically applies the same mechanism used in here https://github.com/openshift/image-registry/blob/master/pkg/dockerregistry/server/simplelookupicsp.go for the same purpose.