### PR TITLE
IR-300,IR-301: generates ImageStreamTags with import-mode when using oc new-build and oc-new-app

### DIFF
--- a/pkg/cli/newapp/newapp.go
+++ b/pkg/cli/newapp/newapp.go
@@ -99,6 +99,9 @@ var (
 		# Use a MySQL image in a private registry to create an app and override application artifacts' names
 		oc new-app --image=myregistry.com/mycompany/mysql --name=private
 
+		# Use an image with the full manifest list to create an app and override application artifacts' names
+		oc new-app --image=myregistry.com/mycompany/image --name=private --import-mode=PreserveOriginal
+
 		# Create an application from a remote repository using its beta4 branch
 		oc new-app https://github.com/openshift/ruby-hello-world#beta4
 
@@ -298,6 +301,7 @@ func NewCmdNewApplication(f kcmdutil.Factory, streams genericclioptions.IOStream
 	cmd.Flags().StringVar(&o.Config.SourceSecret, "source-secret", o.Config.SourceSecret, "The name of an existing secret that should be used for cloning a private git repository.")
 	cmd.Flags().BoolVar(&o.Config.SkipGeneration, "no-install", o.Config.SkipGeneration, "Do not attempt to run images that describe themselves as being installable")
 	cmd.Flags().BoolVar(&o.Config.BinaryBuild, "binary", o.Config.BinaryBuild, "Instead of expecting a source URL, set the build to expect binary contents. Will disable triggers.")
+	cmd.Flags().StringVar(&o.Config.ImportMode, "import-mode", o.Config.ImportMode, "Imports the full manifest list of a tag when set to 'PreserveOriginal'. Defaults to 'Legacy'.")
 
 	o.Action.BindForOutput(cmd.Flags(), "output", "template")
 	cmd.Flags().String("output-version", "", "The preferred API versions of the output objects")

--- a/pkg/cli/newbuild/newbuild.go
+++ b/pkg/cli/newbuild/newbuild.go
@@ -59,6 +59,9 @@ var (
 		# Create a build config from a remote private repository and specify which existing secret to use
 		oc new-build https://github.com/youruser/yourgitrepo --source-secret=yoursecret
 
+		# Create a build config using  an image with the full manifest list to create an app and override application artifacts' names
+		oc new-build --image=myregistry.com/mycompany/image --name=private --import-mode=PreserveOriginal
+
 		# Create a build config from a remote repository and inject the npmrc into a build
 		oc new-build https://github.com/openshift/ruby-hello-world --build-secret npmrc:.npmrc
 
@@ -154,6 +157,7 @@ func NewCmdNewBuild(f kcmdutil.Factory, streams genericclioptions.IOStreams) *co
 	cmd.Flags().BoolVar(&o.Config.NoOutput, "no-output", o.Config.NoOutput, "If true, the build output will not be pushed anywhere.")
 	cmd.Flags().StringVar(&o.Config.SourceImage, "source-image", o.Config.SourceImage, "Specify an image to use as source for the build.  You must also specify --source-image-path.")
 	cmd.Flags().StringVar(&o.Config.SourceImagePath, "source-image-path", o.Config.SourceImagePath, "Specify the file or directory to copy from the source image and its destination in the build directory. Format: [source]:[destination-dir].")
+	cmd.Flags().StringVar(&o.Config.ImportMode, "import-mode", o.Config.ImportMode, "Imports the full manifest list of a tag when set to 'PreserveOriginal'. Defaults to 'Legacy'.")
 
 	o.Action.BindForOutput(cmd.Flags(), "output", "template", "sort-by")
 	cmd.Flags().String("output-version", "", "The preferred API versions of the output objects")

--- a/pkg/helpers/newapp/app/builder.go
+++ b/pkg/helpers/newapp/app/builder.go
@@ -60,6 +60,12 @@ func IsBuilderMatch(match *ComponentMatch) bool {
 	if match.ImageStream != nil && IsBuilderStreamTag(match.ImageStream, match.ImageTag) {
 		return true
 	}
+
+	// PreserveOriginal indicates the referenced Image is to be treated as manifest-listed
+	// and the match is an Image.
+	if match.ImageStream == nil && match.ImportMode == imagev1.ImportModePreserveOriginal && match.IsImage() {
+		return true
+	}
 	return false
 }
 

--- a/pkg/helpers/newapp/app/componentmatch.go
+++ b/pkg/helpers/newapp/app/componentmatch.go
@@ -27,6 +27,7 @@ type ComponentMatch struct {
 	// available.
 	DockerImage *dockerv10.DockerImage
 	ImageStream *imagev1.ImageStream
+	ImportMode  imagev1.ImportModeType
 	ImageTag    string
 	Template    *templatev1.Template
 

--- a/pkg/helpers/newapp/app/dockerimagelookup.go
+++ b/pkg/helpers/newapp/app/dockerimagelookup.go
@@ -43,6 +43,9 @@ type DockerClientSearcher struct {
 	// AllowingMissingImages will allow images that could not be found in the local or
 	// remote registry to be used anyway.
 	AllowMissingImages bool
+
+	// The ImportMode for the image
+	ImportMode string
 }
 
 func (r DockerClientSearcher) Type() string {
@@ -149,6 +152,7 @@ func (r DockerClientSearcher) Search(precise bool, terms ...string) (ComponentMa
 				Description: descriptionFor(dockerImage, match.Value, ref.Registry, ""),
 				Score:       match.Score,
 				DockerImage: dockerImage,
+				ImportMode:  imagev1.ImportModeType(r.ImportMode),
 				ImageTag:    ref.Tag,
 				Insecure:    r.Insecure,
 				Meta:        map[string]string{"registry": ref.Registry},
@@ -254,6 +258,7 @@ type ImageImportSearcher struct {
 	Client        imagev1client.ImageStreamImportInterface
 	AllowInsecure bool
 	Fallback      Searcher
+	ImportMode    string
 }
 
 func (s ImageImportSearcher) Type() string {
@@ -271,8 +276,11 @@ func (s ImageImportSearcher) Search(precise bool, terms ...string) (ComponentMat
 			continue
 		}
 		isi.Spec.Images = append(isi.Spec.Images, imagev1.ImageImportSpec{
-			From:         corev1.ObjectReference{Kind: "DockerImage", Name: term},
-			ImportPolicy: imagev1.TagImportPolicy{Insecure: s.AllowInsecure},
+			From: corev1.ObjectReference{Kind: "DockerImage", Name: term},
+			ImportPolicy: imagev1.TagImportPolicy{
+				Insecure:   s.AllowInsecure,
+				ImportMode: imagev1.ImportModeType(s.ImportMode),
+			},
 		})
 	}
 	isi.Name = "newapp"
@@ -334,6 +342,7 @@ func (s ImageImportSearcher) Search(precise bool, terms ...string) (ComponentMat
 			Description: descriptionFor(dockerImage, term, ref.Registry, ref.Tag),
 			Score:       0,
 			DockerImage: dockerImage,
+			ImportMode:  imagev1.ImportModeType(s.ImportMode),
 			ImageTag:    ref.Tag,
 			Insecure:    s.AllowInsecure,
 			Meta:        map[string]string{"registry": ref.Registry, "direct-tag": "1"},
@@ -356,7 +365,8 @@ type RegistryImageClient interface {
 // not return images with the name "ruby".
 // TODO: replace ImageByTag to allow partial matches
 type DockerRegistrySearcher struct {
-	Client RegistryImageClient
+	Client     RegistryImageClient
+	ImportMode string
 }
 
 func (r DockerRegistrySearcher) Type() string {
@@ -397,6 +407,7 @@ func (r DockerRegistrySearcher) Search(precise bool, terms ...string) (Component
 			Description: descriptionFor(image, term, ref.Registry, ref.Tag),
 			Score:       0,
 			DockerImage: image,
+			ImportMode:  imagev1.ImportModeType(r.ImportMode),
 			ImageTag:    ref.Tag,
 			Meta:        map[string]string{"registry": ref.Registry},
 		}

--- a/pkg/helpers/newapp/app/imageref.go
+++ b/pkg/helpers/newapp/app/imageref.go
@@ -170,6 +170,9 @@ type ImageRef struct {
 	// Stream and Info should *only* be set if the image stream already exists
 	Stream *imagev1.ImageStream
 	Info   *dockerv10.DockerImage
+
+	// The ImportMode for the image
+	ImportMode imagev1.ImportModeType
 }
 
 // Exists returns true if the image stream exists
@@ -371,7 +374,7 @@ func (r *ImageRef) ImageStream() (*imagev1.ImageStream, error) {
 			Kind: "DockerImage",
 			Name: r.PullSpec(),
 		},
-		ImportPolicy: imagev1.TagImportPolicy{Insecure: r.Insecure},
+		ImportPolicy: imagev1.TagImportPolicy{Insecure: r.Insecure, ImportMode: r.ImportMode},
 	})
 
 	return stream, nil
@@ -398,7 +401,7 @@ func (r *ImageRef) ImageStreamTag() (*imagev1.ImageStreamTag, error) {
 				Kind: "DockerImage",
 				Name: r.PullSpec(),
 			},
-			ImportPolicy: imagev1.TagImportPolicy{Insecure: r.Insecure},
+			ImportPolicy: imagev1.TagImportPolicy{Insecure: r.Insecure, ImportMode: r.ImportMode},
 		},
 	}
 	return ist, nil

--- a/pkg/helpers/newapp/app/imagestreamlookup.go
+++ b/pkg/helpers/newapp/app/imagestreamlookup.go
@@ -242,6 +242,7 @@ func InputImageFromMatch(match *ComponentMatch) (*ImageRef, error) {
 		}
 		input.AsImageStream = true
 		input.Info = match.DockerImage
+		input.ImportMode = match.ImportMode
 		return input, nil
 
 	case match.DockerImage != nil:
@@ -256,6 +257,7 @@ func InputImageFromMatch(match *ComponentMatch) (*ImageRef, error) {
 		input.AsImageStream = !match.LocalOnly
 		input.Info = match.DockerImage
 		input.Insecure = match.Insecure
+		input.ImportMode = match.ImportMode
 		return input, nil
 
 	default:

--- a/pkg/helpers/newapp/app/pipeline.go
+++ b/pkg/helpers/newapp/app/pipeline.go
@@ -123,6 +123,11 @@ func (pb *pipelineBuilder) NewBuildPipeline(from string, input *ImageRef, source
 					Config: &dockerv10.DockerConfig{},
 				}
 			}
+			input.ImportMode = imagev1.ImportModeType(input.ImportMode)
+			// If there is no DockerConfig, otherwise a panic results
+			if input.Info.Config == nil {
+				input.Info.Config = &dockerv10.DockerConfig{}
+			}
 			input.Info.Config.ExposedPorts = map[string]struct{}{}
 			for _, p := range ports {
 				input.Info.Config.ExposedPorts[p] = struct{}{}
@@ -134,6 +139,7 @@ func (pb *pipelineBuilder) NewBuildPipeline(from string, input *ImageRef, source
 		// TODO: assumes that build doesn't change the image metadata. In the future
 		// we could get away with deferred generation possibly.
 		output.Info = input.Info
+		output.ImportMode = imagev1.ImportModeType(input.ImportMode)
 	}
 
 	build := &BuildRef{
@@ -145,7 +151,6 @@ func (pb *pipelineBuilder) NewBuildPipeline(from string, input *ImageRef, source
 		DockerStrategyOptions: pb.dockerStrategyOptions,
 		Binary:                binary,
 	}
-
 	return &Pipeline{
 		Name:       name,
 		From:       from,

--- a/pkg/helpers/newapp/cmd/newapp.go
+++ b/pkg/helpers/newapp/cmd/newapp.go
@@ -215,7 +215,10 @@ func NewAppConfig() *AppConfig {
 func (c *AppConfig) DockerRegistrySearcher() app.Searcher {
 	r := NewImageRegistrySearcher()
 	r.ImageRetriever.SecurityOptions.Insecure = c.InsecureRegistry
-	return app.DockerRegistrySearcher{Client: r}
+	return app.DockerRegistrySearcher{
+		Client:     r,
+		ImportMode: c.ImportMode,
+	}
 }
 
 type ImageRegistrySearcher struct {
@@ -295,7 +298,9 @@ func (c *AppConfig) SetOpenShiftClient(imageClient imagev1typedclient.ImageV1Int
 			Client:        c.ImageClient.ImageStreamImports(OriginNamespace),
 			AllowInsecure: c.InsecureRegistry,
 			Fallback:      c.DockerRegistrySearcher(),
+			ImportMode:    c.ImportMode,
 		},
+		ImportMode: c.ImportMode,
 	}
 }
 
@@ -501,6 +506,7 @@ func (c *AppConfig) buildPipelines(components app.ComponentReferences, environme
 						klog.Warningf(msg, from)
 					}
 					image = inputImage
+					image.ImportMode = imagev1.ImportModeType(c.ImportMode)
 				}
 
 				klog.V(4).Infof("will use %q as the base image for a source build of %q", ref, refInput.Uses)


### PR DESCRIPTION
[IR-300](https://issues.redhat.com//browse/IR-300)
- add new flag --import-mode=Legacy or --import-mode=PreserveOriginal
- the default is Legacy

[IR-301](https://issues.redhat.com//browse/IR-301)
- support Legacy and PreserveOriginal import-mode with oc new-build
- add a guard to protect a panic when no DockerConfig exists
- add a PreserveOriginal guard for IsBuilderImage

The scope of this issue is limited to the imported images. The use of BuildConfig is not addressed in this PR, and is addressed in a separate backlog issue with the BuildConfig team.