### PR TITLE
OCPBUGS-3393: Always copy the blobs if the target isn't a registry

### DIFF
--- a/pkg/cli/image/mirror/mirror.go
+++ b/pkg/cli/image/mirror/mirror.go
@@ -586,6 +586,9 @@ func (o *MirrorImageOptions) plan() (*plan, error) {
 								mustCopyLayers = true
 							case src.ref.EqualRegistry(dst.ref) && canonicalFrom.String() == canonicalTo.String():
 								// if the source and destination repos are the same, we don't need to copy layers unless forced
+							case dst.ref.Type != imagesource.DestinationRegistry:
+								// If we're not copying to a registry, the destination doesn't guarantee the blobs exist for the manifest
+								mustCopyLayers = true
 							default:
 								if _, err := toManifests.Get(ctx, srcDigest); err != nil {
 									mustCopyLayers = true


### PR DESCRIPTION
The assuption that the manifest existing means that the blobs exist only works when the target is a registry that will validate that the blobs have been uploaded before the manifest. On other targets, we should check for layer existence each time because the user may have used "--continue-on-error" and end up with missing layers.

https://issues.redhat.com/browse/OCPBUGS-3393