### PR TITLE
OCPBUGS-8048: pkg/cli/admin/upgrade: Client-side checks for --to-multi-arch

### DIFF
--- a/pkg/cli/admin/upgrade/upgrade.go
+++ b/pkg/cli/admin/upgrade/upgrade.go
@@ -216,6 +216,14 @@ func (o *Options) Run() error {
 		if cv.Spec.DesiredUpdate != nil && cv.Spec.DesiredUpdate.Architecture == configv1.ClusterVersionArchitectureMulti {
 			return fmt.Errorf("info: Update to multi cluster architecture has already been requested")
 		}
+
+		if err := checkForUpgrade(cv); err != nil {
+			if !o.AllowUpgradeWithWarnings {
+				return fmt.Errorf("%s\n\nIf you want to upgrade anyway, use --allow-upgrade-with-warnings.", err)
+			}
+			fmt.Fprintf(o.ErrOut, "warning: --allow-upgrade-with-warnings is bypassing: %s", err)
+		}
+
 		if err := patchDesiredUpdate(ctx, &configv1.Update{Architecture: configv1.ClusterVersionArchitectureMulti,
 			Version: cv.Status.Desired.Version}, o.Client, cv.Name); err != nil {
 


### PR DESCRIPTION
`Invalid=True`, `Failing=True`, and `Progressing=True` are all reasons we might want to delay a transition to multi-arch.  Copy over the block from the version-bumping switch case, so we get the usual checks for `--to-multi-arch` too.  The user may opt to waive these guards with `--allow-upgrade-with-warnings` as usual, but at least they'll be aware that there are issues they may want to look into.