### PR TITLE
OCPBUGS-1117: The architecture of oc in the cli-artifacts' /usr/bin folder should to the one of the built image

### DIFF
--- a/images/cli-artifacts/Dockerfile.rhel
+++ b/images/cli-artifacts/Dockerfile.rhel
@@ -6,15 +6,15 @@ COPY . .
 RUN make cross-build --warn-undefined-variables
 
 FROM registry.ci.openshift.org/ocp/4.13:cli
-COPY --from=builder /go/src/github.com/openshift/oc/_output/bin/darwin_amd64/oc /usr/share/openshift/mac/oc
-COPY --from=builder /go/src/github.com/openshift/oc/_output/bin/darwin_arm64/oc /usr/share/openshift/mac_arm64/oc
-COPY --from=builder /go/src/github.com/openshift/oc/_output/bin/windows_amd64/oc.exe /usr/share/openshift/windows/oc.exe
-COPY --from=builder /go/src/github.com/openshift/oc/_output/bin/linux_amd64/oc /usr/share/openshift/linux_amd64/oc
-COPY --from=builder /go/src/github.com/openshift/oc/_output/bin/linux_amd64/oc /usr/bin/
-COPY --from=builder /go/src/github.com/openshift/oc/_output/bin/linux_arm64/oc /usr/share/openshift/linux_arm64/oc
-COPY --from=builder /go/src/github.com/openshift/oc/_output/bin/linux_ppc64le/oc /usr/share/openshift/linux_ppc64le/oc
-COPY --from=builder /go/src/github.com/openshift/oc/_output/bin/linux_s390x/oc /usr/share/openshift/linux_s390x/oc
+
+COPY --from=builder /go/src/github.com/openshift/oc/_output/bin/ /usr/share/openshift/
+
+RUN cd /usr/share/openshift && \
+    ln -sf /usr/share/openshift/linux_$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/')/oc /usr/bin/oc && \
+    mv windows_amd64 windows && mv darwin_amd64 mac && mv darwin_arm64 mac_arm64
+
 COPY --from=builder /go/src/github.com/openshift/oc/LICENSE /usr/share/openshift/LICENSE
+
 LABEL io.k8s.display-name="OpenShift Clients" \
       io.k8s.description="OpenShift is a platform for developing, building, and deploying containerized applications." \
       io.openshift.tags="openshift,cli"


### PR DESCRIPTION
The `oc` binary copied into the `/usr/bin` folder when building the cli-artifacts image is always the one built for amd64. 

This PR proposes:

1. To shorten the number of `COPY` layers by copying and adapting the folder names later in a `RUN` layer;
2. instead of copying, a symbolic link to the correct architecture binary in /usr/bin, to also reduce the size of the final image.

Refers OCPBUGS-1117