### PR TITLE
Exclude autoscale from MicroShift documentation

### DIFF
--- a/tools/gendocs/gendocs/microshift.go
+++ b/tools/gendocs/gendocs/microshift.go
@@ -6,6 +6,7 @@ import (
 
 // a set of commands excluded from microshift
 var microshiftCommands = sets.NewString(
+	"oc autoscale",
 	"oc cancel-build",
 	"oc create build",
 	"oc create clusterresourcequota",


### PR DESCRIPTION
Update the list of commands excluded from MicroShift documentation so
that the autoscale command is also excluded.