### PR TITLE
OCPBUGS-10612: make registry auth prefence default to podman config locations 

### DIFF
--- a/pkg/cli/image/manifest/dockercredentials/auth_resolver.go
+++ b/pkg/cli/image/manifest/dockercredentials/auth_resolver.go
@@ -50,12 +50,14 @@ func NewAuthResolver(authFilePath string) (*AuthResolver, error) {
 		if err != nil {
 			return nil, err
 		}
-		if pref, warn := image.GetRegistryAuthConfigPreference(); pref == image.DockerPreference {
+		// TODO: remove REGISTRY_AUTH_PREFERENCE env variable support and support only podman in 4.15
+		pref, warn := image.GetRegistryAuthConfigPreference()
+		if len(warn) > 0 {
+			fmt.Fprint(os.Stderr, warn)
+		}
+		if pref == image.DockerPreference {
 			config := defaultClientDockerConfig()
 			if config != nil {
-				if len(warn) > 0 {
-					fmt.Fprint(os.Stderr, warn)
-				}
 				// give priority to the docker config file $HOME/.docker/config.json
 				for registry, entry := range config {
 					credentials[registry] = containertypes.DockerAuthConfig{
@@ -65,7 +67,6 @@ func NewAuthResolver(authFilePath string) (*AuthResolver, error) {
 					}
 				}
 			}
-
 		}
 	}
 
@@ -74,7 +75,7 @@ func NewAuthResolver(authFilePath string) (*AuthResolver, error) {
 	}, nil
 }
 
-// TODO: switch this for dockerconfig.GetCredentials or dockerconfig.GetAllCredentials once we remove REGISTRY_AUTH_PREFERENCE env variable
+// TODO: switch findAuthentication for dockerconfig.GetCredentials or dockerconfig.GetAllCredentials once we remove REGISTRY_AUTH_PREFERENCE env variable in 4.15
 // original: https://github.com/containers/image/blob/main/pkg/docker/config/config.go
 // findAuthentication looks for auth of registry in path. If ref is
 // not nil, then it will be taken into account when looking up the

--- a/pkg/cli/image/manifest/manifest.go
+++ b/pkg/cli/image/manifest/manifest.go
@@ -50,8 +50,8 @@ type SecurityOptions struct {
 }
 
 func (o *SecurityOptions) Bind(flags *pflag.FlagSet) {
-	// TODO: fix priority and deprecation notice in 4.13
-	flags.StringVarP(&o.RegistryConfig, "registry-config", "a", o.RegistryConfig, "Path to your registry credentials. Alternatively REGISTRY_AUTH_FILE env variable can be also specified. Defaults to  ~/.docker/config.json, ${XDG_RUNTIME_DIR}/containers/auth.json, ${XDG_CONFIG_HOME}/containers/auth.json, /run/containers/${UID}/auth.json, ${DOCKER_CONFIG}, ~/.dockercfg. The order can be changed via REGISTRY_AUTH_PREFERENCE env variable to docker (current default - deprecated) or podman (prioritizes podman credentials over docker).")
+	// TODO: remove REGISTRY_AUTH_PREFERENCE env variable support and support only podman in 4.15
+	flags.StringVarP(&o.RegistryConfig, "registry-config", "a", o.RegistryConfig, "Path to your registry credentials. Alternatively REGISTRY_AUTH_FILE env variable can be also specified. Defaults to ${XDG_RUNTIME_DIR}/containers/auth.json, /run/containers/${UID}/auth.json, ${XDG_CONFIG_HOME}/containers/auth.json, ${DOCKER_CONFIG}, ~/.docker/config.json, ~/.dockercfg. The order can be changed via the REGISTRY_AUTH_PREFERENCE env variable (deprecated) to a \"docker\" value to prioritizes Docker credentials over Podman's.")
 	flags.BoolVar(&o.Insecure, "insecure", o.Insecure, "Allow push and pull operations to registries to be made over HTTP")
 	flags.BoolVar(&o.SkipVerification, "skip-verification", o.SkipVerification, "Skip verifying the integrity of the retrieved content. This is not recommended, but may be necessary when importing images from older image registries. Only bypass verification if the registry is known to be trustworthy.")
 }

--- a/pkg/cli/registry/login/login.go
+++ b/pkg/cli/registry/login/login.go
@@ -122,9 +122,10 @@ func NewRegistryLoginCmd(f kcmdutil.Factory, streams genericclioptions.IOStreams
 
 	flag := cmd.Flags()
 	flag.StringVar(&o.AuthBasic, "auth-basic", o.AuthBasic, "Provide credentials in the form 'user:password' to authenticate (advanced)")
-	// TODO: fix priority and deprecation notice in 4.13
-	flag.StringVarP(&o.ConfigFile, "registry-config", "a", o.ConfigFile, "The location of the file your credentials will be stored in. Alternatively REGISTRY_AUTH_FILE env variable can be also specified. Defaults to ~/.docker/config.json. Default can be changed via REGISTRY_AUTH_PREFERENCE env variable to docker (current default - deprecated) or podman (prioritizes podman credentials over docker).")
-	flag.StringVar(&o.ConfigFile, "to", o.ConfigFile, "The location of the file your credentials will be stored in. Alternatively REGISTRY_AUTH_FILE env variable can be also specified. Default is Docker config.json (deprecated). Default can be changed via REGISTRY_AUTH_PREFERENCE env variable to docker or podman.")
+	// TODO: remove REGISTRY_AUTH_PREFERENCE env variable support and support only podman in 4.15
+	flag.StringVarP(&o.ConfigFile, "registry-config", "a", o.ConfigFile, "The location of the file your credentials will be stored in. Alternatively REGISTRY_AUTH_FILE env variable can be also specified. Defaults to ${XDG_RUNTIME_DIR}/containers/auth.json or /run/containers/${UID}/auth.json. Default can be changed via the REGISTRY_AUTH_PREFERENCE env variable (deprecated) to a \"docker\" value to prioritizes Docker credentials over Podman's.")
+	// TODO: remove REGISTRY_AUTH_PREFERENCE env variable support and support only podman in 4.15
+	flag.StringVar(&o.ConfigFile, "to", o.ConfigFile, "The location of the file your credentials will be stored in. Alternatively REGISTRY_AUTH_FILE env variable can be also specified. Defaults to ${XDG_RUNTIME_DIR}/containers/auth.json or /run/containers/${UID}/auth.json. Default can be changed via the REGISTRY_AUTH_PREFERENCE env variable (deprecated) to a \"docker\" value to prioritizes Docker credentials over Podman's.")
 	flag.StringVarP(&o.ServiceAccount, "service-account", "z", o.ServiceAccount, "Log in as the specified service account name in the specified namespace.")
 	flag.MarkDeprecated("service-account", "and will be removed in the future version. Use oc create token instead.")
 	flag.StringVar(&o.HostPort, "registry", o.HostPort, "An alternate domain name and port to use for the registry, defaults to the cluster's configured external hostname.")
@@ -236,12 +237,16 @@ func (o *LoginOptions) Complete(f kcmdutil.Factory, args []string) error {
 	if len(o.ConfigFile) == 0 {
 		if authFile := os.Getenv("REGISTRY_AUTH_FILE"); authFile != "" {
 			o.ConfigFile = authFile
-		} else if pref, warn := image.GetRegistryAuthConfigPreference(); pref == image.DockerPreference {
+		} else {
+			// TODO: remove REGISTRY_AUTH_PREFERENCE env variable support and support only podman in 4.15
+			pref, warn := image.GetRegistryAuthConfigPreference()
 			if len(warn) > 0 {
 				fmt.Fprint(o.IOStreams.ErrOut, warn)
 			}
-			home := homedir.HomeDir()
-			o.ConfigFile = filepath.Join(home, ".docker", "config.json")
+			if pref == image.DockerPreference {
+				home := homedir.HomeDir()
+				o.ConfigFile = filepath.Join(home, ".docker", "config.json")
+			}
 		}
 	}
 
@@ -293,10 +298,11 @@ func (o *LoginOptions) Run() error {
 	}
 
 	ctx := &containertypes.SystemContext{AuthFilePath: o.ConfigFile}
-	if err := dockerconfig.SetAuthentication(ctx, o.HostPort, o.Credentials.Username, o.Credentials.Password); err != nil {
+	credentialLocation, err := dockerconfig.SetCredentials(ctx, o.HostPort, o.Credentials.Username, o.Credentials.Password)
+	if err != nil {
 		return err
 	}
 
-	fmt.Fprintf(o.Out, "Saved credentials for %s\n", o.HostPort)
+	fmt.Fprintf(o.Out, "Saved credentials for %s into %s\n", o.HostPort, credentialLocation)
 	return nil
 }

--- a/pkg/helpers/image/helpers.go
+++ b/pkg/helpers/image/helpers.go
@@ -140,15 +140,16 @@ var (
 	PodmanPreference RegistryAuthConfigPreference = "podman"
 )
 
+// TODO: remove REGISTRY_AUTH_PREFERENCE env variable support and support only podman in 4.15
 func GetRegistryAuthConfigPreference() (RegistryAuthConfigPreference, string) {
-	// TODO: docker default is deprecated and will be changed to podman in 4.13
-	result := DockerPreference // default to docker
+	result := PodmanPreference // default to podman
 	warning := ""
 	if authPreference := strings.ToLower(os.Getenv("REGISTRY_AUTH_PREFERENCE")); authPreference == string(DockerPreference) || authPreference == string(PodmanPreference) {
 		result = RegistryAuthConfigPreference(authPreference)
-	} else {
-		// TODO: remove once deprecated in 4.13
-		warning = "Warning: the default reading order of registry auth file will be changed from \"${HOME}/.docker/config.json\" to podman registry config locations in the future version of oc. \"${HOME}/.docker/config.json\" is deprecated, but can still be used for storing credentials as a fallback. See https://github.com/containers/image/blob/main/docs/containers-auth.json.5.md for the order of podman registry config locations.\n"
+		warning = "Warning: The REGISTRY_AUTH_PREFERENCE environment variable is deprecated and will be removed in the future version of oc and" +
+			" only podman reading order of registry auth file will be supported. \"${HOME}/.docker/config.json\" is deprecated, but can still be used to store credentials as a fallback." +
+			" See https://github.com/containers/image/blob/main/docs/containers-auth.json.5.md for the order of podman registry config locations.\n"
+
 	}
 	return result, warning
 }


### PR DESCRIPTION
for storing and retrieving credentials
(${XDG_RUNTIME_DIR}/containers/auth.json by default). Docker config locations (usually ~/.docker/config.json) are still used as a fallback when podman
 credentials are not found.

deprecate REGISTRY_AUTH_PREFERENCE env variable and warn about removal of docker auth preference in the future

TODO:
- [x] https://github.com/openshift/ci-tools/pull/3345
- [x] https://github.com/openshift/release/pull/37726#pullrequestreview-1359972453
- [x] https://github.com/openshift/release-controller/pull/513
- [x] https://github.com/openshift/release/pull/40255
- [x] https://github.com/openshift/release/pull/40287