### PR TITLE
OCPBUGS-10622: bump repo sclorg/s2i-ruby-container location for newapp test

### DIFF
--- a/pkg/helpers/newapp/newapptest/newapp_test.go
+++ b/pkg/helpers/newapp/newapptest/newapp_test.go
@@ -531,7 +531,7 @@ func TestNewAppRunAll(t *testing.T) {
 					SourceRepositories: []string{"https://github.com/openshift/sti-ruby"},
 				},
 				GenerationInputs: cmd.GenerationInputs{
-					ContextDir: "2.0/test/rack-test-app",
+					ContextDir: "3.1/test/rack-test-app",
 				},
 
 				Resolvers: cmd.Resolvers{
@@ -572,7 +572,7 @@ func TestNewAppRunAll(t *testing.T) {
 					SourceRepositories: []string{"https://github.com/openshift/sti-ruby"},
 				},
 				GenerationInputs: cmd.GenerationInputs{
-					ContextDir: "2.0/test/missing-dir",
+					ContextDir: "3.1/test/missing-dir",
 				},
 
 				Resolvers: cmd.Resolvers{
@@ -605,7 +605,7 @@ func TestNewAppRunAll(t *testing.T) {
 			expectedName:    "sti-ruby",
 			expectedVolumes: nil,
 			errFn: func(err error) bool {
-				return err.Error() == "supplied context directory '2.0/test/missing-dir' does not exist in 'https://github.com/openshift/sti-ruby'"
+				return err.Error() == "supplied context directory '3.1/test/missing-dir' does not exist in 'https://github.com/openshift/sti-ruby'"
 			},
 		},
 


### PR DESCRIPTION
needed because of the files removal in https://github.com/sclorg/s2i-ruby-container/pull/462