### PR TITLE
Test Fix: Allow submodule using file transport with newer git

### DIFF
--- a/pkg/helpers/source-to-image/git/testhelpers.go
+++ b/pkg/helpers/source-to-image/git/testhelpers.go
@@ -87,7 +87,8 @@ func CreateLocalGitDirectoryWithSubmodule() (string, error) {
 		return "", err
 	}
 
-	err = cr.RunWithOptions(cmd.CommandOpts{Dir: dir}, "git", "submodule", "add", submodule, "submodule")
+	// Allow submodule from file, see https://github.blog/2022-10-18-git-security-vulnerabilities-announced/#cve-2022-39253
+	err = cr.RunWithOptions(cmd.CommandOpts{Dir: dir}, "git", "-c", "protocol.file.allow=always", "submodule", "add", submodule, "submodule")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
We can't run the unit tests out-of-the-box on up-to-date systems because of the fix for CVE-2022-39253.

Newer git versions default to not trusting cloning over the file transport. We now need to explicitly turn it on for this test, which we know is safe because we just created both repos.

More info: https://github.blog/2022-10-18-git-security-vulnerabilities-announced/#cve-2022-39253

## Before this fix

```
jammy:oc$ SKIP_EXTERNAL_GIT=true make test
go test -mod=vendor -race ./...
ok      github.com/openshift/oc/cmd/oc  0.121s
ok      github.com/openshift/oc/pkg/cli 0.665s
?       github.com/openshift/oc/pkg/cli/admin   [no test files]
?       github.com/openshift/oc/pkg/cli/admin/buildchain        [no test files]
ok      github.com/openshift/oc/pkg/cli/admin/catalog   7.830s
?       github.com/openshift/oc/pkg/cli/admin/createbootstrapprojecttemplate    [no test files]
?       github.com/openshift/oc/pkg/cli/admin/createerrortemplate       [no test files]
?       github.com/openshift/oc/pkg/cli/admin/createkubeconfig  [no test files]
?       github.com/openshift/oc/pkg/cli/admin/createlogintemplate       [no test files]
?       github.com/openshift/oc/pkg/cli/admin/createproviderselectiontemplate   [no test files]
?       github.com/openshift/oc/pkg/cli/admin/groups    [no test files]
ok      github.com/openshift/oc/pkg/cli/admin/groups/examples   (cached)
?       github.com/openshift/oc/pkg/cli/admin/groups/new        [no test files]
?       github.com/openshift/oc/pkg/cli/admin/groups/sync       [no test files]
?       github.com/openshift/oc/pkg/cli/admin/groups/users      [no test files]
ok      github.com/openshift/oc/pkg/cli/admin/inspect   (cached)
?       github.com/openshift/oc/pkg/cli/admin/internal/codesign [no test files]
ok      github.com/openshift/oc/pkg/cli/admin/migrate   (cached)
ok      github.com/openshift/oc/pkg/cli/admin/migrate/icsp      (cached)
ok      github.com/openshift/oc/pkg/cli/admin/migrate/templateinstances (cached)
ok      github.com/openshift/oc/pkg/cli/admin/mustgather        (cached)
?       github.com/openshift/oc/pkg/cli/admin/network   [no test files]
ok      github.com/openshift/oc/pkg/cli/admin/node      (cached)
ok      github.com/openshift/oc/pkg/cli/admin/policy    (cached)
?       github.com/openshift/oc/pkg/cli/admin/project   [no test files]
?       github.com/openshift/oc/pkg/cli/admin/prune     [no test files]
ok      github.com/openshift/oc/pkg/cli/admin/prune/auth        (cached)
ok      github.com/openshift/oc/pkg/cli/admin/prune/builds      (cached)
ok      github.com/openshift/oc/pkg/cli/admin/prune/deployments (cached)
ok      github.com/openshift/oc/pkg/cli/admin/prune/imageprune  (cached)
ok      github.com/openshift/oc/pkg/cli/admin/prune/images      (cached)
ok      github.com/openshift/oc/pkg/cli/admin/release   0.120s
ok      github.com/openshift/oc/pkg/cli/admin/top       (cached)
ok      github.com/openshift/oc/pkg/cli/admin/upgrade   (cached)
?       github.com/openshift/oc/pkg/cli/admin/upgrade/channel   [no test files]
?       github.com/openshift/oc/pkg/cli/admin/verifyimagesignature      [no test files]
ok      github.com/openshift/oc/pkg/cli/cancelbuild     (cached)
ok      github.com/openshift/oc/pkg/cli/create  (cached)
?       github.com/openshift/oc/pkg/cli/create/route    [no test files]
ok      github.com/openshift/oc/pkg/cli/debug   (cached)
ok      github.com/openshift/oc/pkg/cli/deployer        (cached)
?       github.com/openshift/oc/pkg/cli/deployer/strategy       [no test files]
ok      github.com/openshift/oc/pkg/cli/deployer/strategy/recreate      (cached)
ok      github.com/openshift/oc/pkg/cli/deployer/strategy/rolling       (cached)
ok      github.com/openshift/oc/pkg/cli/deployer/strategy/support       (cached)
?       github.com/openshift/oc/pkg/cli/deployer/strategy/util  [no test files]
?       github.com/openshift/oc/pkg/cli/deployer/strategy/util/appstest [no test files]
?       github.com/openshift/oc/pkg/cli/expose  [no test files]
?       github.com/openshift/oc/pkg/cli/extract [no test files]
ok      github.com/openshift/oc/pkg/cli/idle    (cached)
?       github.com/openshift/oc/pkg/cli/image   [no test files]
?       github.com/openshift/oc/pkg/cli/image/append    [no test files]
?       github.com/openshift/oc/pkg/cli/image/archive   [no test files]
?       github.com/openshift/oc/pkg/cli/image/extract   [no test files]
ok      github.com/openshift/oc/pkg/cli/image/imagesource       (cached)
?       github.com/openshift/oc/pkg/cli/image/info      [no test files]
?       github.com/openshift/oc/pkg/cli/image/manifest  [no test files]
ok      github.com/openshift/oc/pkg/cli/image/manifest/dockercredentials        (cached)
?       github.com/openshift/oc/pkg/cli/image/mirror    [no test files]
?       github.com/openshift/oc/pkg/cli/image/serve     [no test files]
ok      github.com/openshift/oc/pkg/cli/image/strategy  (cached)
?       github.com/openshift/oc/pkg/cli/image/workqueue [no test files]
ok      github.com/openshift/oc/pkg/cli/importimage     (cached)
?       github.com/openshift/oc/pkg/cli/kubectlwrappers [no test files]
ok      github.com/openshift/oc/pkg/cli/login   (cached)
?       github.com/openshift/oc/pkg/cli/logout  [no test files]
ok      github.com/openshift/oc/pkg/cli/logs    (cached)
ok      github.com/openshift/oc/pkg/cli/newapp  1.414s
ok      github.com/openshift/oc/pkg/cli/newbuild        0.259s
?       github.com/openshift/oc/pkg/cli/observe [no test files]
?       github.com/openshift/oc/pkg/cli/options [no test files]
?       github.com/openshift/oc/pkg/cli/policy  [no test files]
ok      github.com/openshift/oc/pkg/cli/process (cached)
?       github.com/openshift/oc/pkg/cli/project [no test files]
?       github.com/openshift/oc/pkg/cli/projects        [no test files]
ok      github.com/openshift/oc/pkg/cli/recycle (cached)
?       github.com/openshift/oc/pkg/cli/registry        [no test files]
?       github.com/openshift/oc/pkg/cli/registry/info   [no test files]
?       github.com/openshift/oc/pkg/cli/registry/login  [no test files]
ok      github.com/openshift/oc/pkg/cli/requestproject  (cached)
ok      github.com/openshift/oc/pkg/cli/rollback        (cached)
?       github.com/openshift/oc/pkg/cli/rollout [no test files]
?       github.com/openshift/oc/pkg/cli/rsh     [no test files]
ok      github.com/openshift/oc/pkg/cli/rsync   (cached)
?       github.com/openshift/oc/pkg/cli/rsync/fsnotification    [no test files]
?       github.com/openshift/oc/pkg/cli/secrets [no test files]
?       github.com/openshift/oc/pkg/cli/serviceaccounts [no test files]
ok      github.com/openshift/oc/pkg/cli/set     (cached)
ok      github.com/openshift/oc/pkg/cli/startbuild      (cached)
?       github.com/openshift/oc/pkg/cli/status  [no test files]
ok      github.com/openshift/oc/pkg/cli/tag     (cached)
?       github.com/openshift/oc/pkg/cli/version [no test files]
?       github.com/openshift/oc/pkg/cli/whoami  [no test files]
?       github.com/openshift/oc/pkg/helpers     [no test files]
?       github.com/openshift/oc/pkg/helpers/apps/test   [no test files]
?       github.com/openshift/oc/pkg/helpers/authorization       [no test files]
ok      github.com/openshift/oc/pkg/helpers/build       (cached)
?       github.com/openshift/oc/pkg/helpers/build/client/v1     [no test files]
ok      github.com/openshift/oc/pkg/helpers/bulk        (cached)
ok      github.com/openshift/oc/pkg/helpers/clientcmd   (cached)
ok      github.com/openshift/oc/pkg/helpers/cmd (cached)
?       github.com/openshift/oc/pkg/helpers/conditions  [no test files]
?       github.com/openshift/oc/pkg/helpers/deployment  [no test files]
ok      github.com/openshift/oc/pkg/helpers/describe    (cached)
ok      github.com/openshift/oc/pkg/helpers/dot (cached)
?       github.com/openshift/oc/pkg/helpers/env [no test files]
?       github.com/openshift/oc/pkg/helpers/errors      [no test files]
?       github.com/openshift/oc/pkg/helpers/file        [no test files]
ok      github.com/openshift/oc/pkg/helpers/flagtypes   (cached)
ok      github.com/openshift/oc/pkg/helpers/graph/appsgraph     (cached)
ok      github.com/openshift/oc/pkg/helpers/graph/appsgraph/analysis    (cached)
ok      github.com/openshift/oc/pkg/helpers/graph/appsgraph/nodes       (cached)
ok      github.com/openshift/oc/pkg/helpers/graph/buildgraph    (cached)
ok      github.com/openshift/oc/pkg/helpers/graph/buildgraph/analysis   (cached)
?       github.com/openshift/oc/pkg/helpers/graph/buildgraph/nodes      [no test files]
ok      github.com/openshift/oc/pkg/helpers/graph/genericgraph  (cached)
ok      github.com/openshift/oc/pkg/helpers/graph/genericgraph/graphview        (cached)
?       github.com/openshift/oc/pkg/helpers/graph/genericgraph/test     [no test files]
?       github.com/openshift/oc/pkg/helpers/graph/imagegraph    [no test files]
ok      github.com/openshift/oc/pkg/helpers/graph/imagegraph/nodes      (cached)
ok      github.com/openshift/oc/pkg/helpers/graph/kubegraph     (cached)
ok      github.com/openshift/oc/pkg/helpers/graph/kubegraph/analysis    (cached)
ok      github.com/openshift/oc/pkg/helpers/graph/kubegraph/nodes       (cached)
?       github.com/openshift/oc/pkg/helpers/graph/routegraph    [no test files]
ok      github.com/openshift/oc/pkg/helpers/graph/routegraph/analysis   (cached)
?       github.com/openshift/oc/pkg/helpers/graph/routegraph/nodes      [no test files]
ok      github.com/openshift/oc/pkg/helpers/groupsync   (cached)
ok      github.com/openshift/oc/pkg/helpers/groupsync/ad        (cached)
ok      github.com/openshift/oc/pkg/helpers/groupsync/groupdetector     (cached)
?       github.com/openshift/oc/pkg/helpers/groupsync/interfaces        [no test files]
?       github.com/openshift/oc/pkg/helpers/groupsync/ldap      [no test files]
ok      github.com/openshift/oc/pkg/helpers/groupsync/rfc2307   (cached)
ok      github.com/openshift/oc/pkg/helpers/groupsync/syncerror (cached)
ok      github.com/openshift/oc/pkg/helpers/image       (cached)
ok      github.com/openshift/oc/pkg/helpers/image/credentialprovider    (cached)
?       github.com/openshift/oc/pkg/helpers/image/dockerlayer   [no test files]
?       github.com/openshift/oc/pkg/helpers/image/dockerlayer/add       [no test files]
?       github.com/openshift/oc/pkg/helpers/image/test  [no test files]
?       github.com/openshift/oc/pkg/helpers/kubeconfig  [no test files]
?       github.com/openshift/oc/pkg/helpers/legacy      [no test files]
ok      github.com/openshift/oc/pkg/helpers/motd        (cached)
?       github.com/openshift/oc/pkg/helpers/newapp      [no test files]
ok      github.com/openshift/oc/pkg/helpers/newapp/app  (cached)
?       github.com/openshift/oc/pkg/helpers/newapp/app/test     [no test files]
?       github.com/openshift/oc/pkg/helpers/newapp/appjson      [no test files]
ok      github.com/openshift/oc/pkg/helpers/newapp/cmd  0.201s
ok      github.com/openshift/oc/pkg/helpers/newapp/docker       (cached)
ok      github.com/openshift/oc/pkg/helpers/newapp/docker/dockerfile    (cached)
ok      github.com/openshift/oc/pkg/helpers/newapp/dockerfile   (cached)
?       github.com/openshift/oc/pkg/helpers/newapp/jenkinsfile  [no test files]
ok      github.com/openshift/oc/pkg/helpers/newapp/newapptest   3.415s
ok      github.com/openshift/oc/pkg/helpers/newapp/portutils    (cached)
?       github.com/openshift/oc/pkg/helpers/newapp/source       [no test files]
?       github.com/openshift/oc/pkg/helpers/originpolymorphichelpers    [no test files]
?       github.com/openshift/oc/pkg/helpers/originpolymorphichelpers/deploymentconfigs  [no test files]
ok      github.com/openshift/oc/pkg/helpers/parallel    (cached)
?       github.com/openshift/oc/pkg/helpers/proc        [no test files]
?       github.com/openshift/oc/pkg/helpers/project     [no test files]
?       github.com/openshift/oc/pkg/helpers/quota       [no test files]
?       github.com/openshift/oc/pkg/helpers/route       [no test files]
?       github.com/openshift/oc/pkg/helpers/source-to-image/api [no test files]
?       github.com/openshift/oc/pkg/helpers/source-to-image/cmd [no test files]
?       github.com/openshift/oc/pkg/helpers/source-to-image/cmd/test    [no test files]
?       github.com/openshift/oc/pkg/helpers/source-to-image/cygpath     [no test files]
?       github.com/openshift/oc/pkg/helpers/source-to-image/errors      [no test files]
ok      github.com/openshift/oc/pkg/helpers/source-to-image/fs  (cached)
?       github.com/openshift/oc/pkg/helpers/source-to-image/fs/test     [no test files]
--- FAIL: TestIsValidGitRepository (0.07s)
    git_test.go:61: exit status 128
ERROR: Clone failed: source source1, target target1, with output ""
FAIL
FAIL    github.com/openshift/oc/pkg/helpers/source-to-image/git 0.079s
?       github.com/openshift/oc/pkg/helpers/source-to-image/log [no test files]
ok      github.com/openshift/oc/pkg/helpers/source-to-image/tar (cached)
ok      github.com/openshift/oc/pkg/helpers/source-to-image/timeout     (cached)
?       github.com/openshift/oc/pkg/helpers/template/templateprocessorclient    [no test files]
ok      github.com/openshift/oc/pkg/helpers/term        (cached)
ok      github.com/openshift/oc/pkg/helpers/tokencmd    (cached)
?       github.com/openshift/oc/pkg/version     [no test files]
?       github.com/openshift/oc/tools/clicheck  [no test files]
?       github.com/openshift/oc/tools/clicheck/sanity   [no test files]
?       github.com/openshift/oc/tools/gendocs   [no test files]
?       github.com/openshift/oc/tools/gendocs/gendocs   [no test files]
?       github.com/openshift/oc/tools/genman    [no test files]
?       github.com/openshift/oc/tools/genman/md2man     [no test files]
FAIL
make: *** [vendor/github.com/openshift/build-machinery-go/make/targets/golang/test-unit.mk:7: test-unit] Error 1
```

## After this fix

```
jammy:oc$ SKIP_EXTERNAL_GIT=true make test
go test -mod=vendor -race ./...
ok      github.com/openshift/oc/cmd/oc  0.154s
ok      github.com/openshift/oc/pkg/cli 0.501s
?       github.com/openshift/oc/pkg/cli/admin   [no test files]
?       github.com/openshift/oc/pkg/cli/admin/buildchain        [no test files]
ok      github.com/openshift/oc/pkg/cli/admin/catalog   (cached)
?       github.com/openshift/oc/pkg/cli/admin/createbootstrapprojecttemplate    [no test files]
?       github.com/openshift/oc/pkg/cli/admin/createerrortemplate       [no test files]
?       github.com/openshift/oc/pkg/cli/admin/createkubeconfig  [no test files]
?       github.com/openshift/oc/pkg/cli/admin/createlogintemplate       [no test files]
?       github.com/openshift/oc/pkg/cli/admin/createproviderselectiontemplate   [no test files]
?       github.com/openshift/oc/pkg/cli/admin/groups    [no test files]
ok      github.com/openshift/oc/pkg/cli/admin/groups/examples   (cached)
?       github.com/openshift/oc/pkg/cli/admin/groups/new        [no test files]
?       github.com/openshift/oc/pkg/cli/admin/groups/sync       [no test files]
?       github.com/openshift/oc/pkg/cli/admin/groups/users      [no test files]
ok      github.com/openshift/oc/pkg/cli/admin/inspect   (cached)
?       github.com/openshift/oc/pkg/cli/admin/internal/codesign [no test files]
ok      github.com/openshift/oc/pkg/cli/admin/migrate   (cached)
ok      github.com/openshift/oc/pkg/cli/admin/migrate/icsp      (cached)
ok      github.com/openshift/oc/pkg/cli/admin/migrate/templateinstances (cached)
ok      github.com/openshift/oc/pkg/cli/admin/mustgather        (cached)
?       github.com/openshift/oc/pkg/cli/admin/network   [no test files]
ok      github.com/openshift/oc/pkg/cli/admin/node      (cached)
ok      github.com/openshift/oc/pkg/cli/admin/policy    (cached)
?       github.com/openshift/oc/pkg/cli/admin/project   [no test files]
?       github.com/openshift/oc/pkg/cli/admin/prune     [no test files]
ok      github.com/openshift/oc/pkg/cli/admin/prune/auth        (cached)
ok      github.com/openshift/oc/pkg/cli/admin/prune/builds      (cached)
ok      github.com/openshift/oc/pkg/cli/admin/prune/deployments (cached)
ok      github.com/openshift/oc/pkg/cli/admin/prune/imageprune  (cached)
ok      github.com/openshift/oc/pkg/cli/admin/prune/images      (cached)
ok      github.com/openshift/oc/pkg/cli/admin/release   (cached)
ok      github.com/openshift/oc/pkg/cli/admin/top       (cached)
ok      github.com/openshift/oc/pkg/cli/admin/upgrade   (cached)
?       github.com/openshift/oc/pkg/cli/admin/upgrade/channel   [no test files]
?       github.com/openshift/oc/pkg/cli/admin/verifyimagesignature      [no test files]
ok      github.com/openshift/oc/pkg/cli/cancelbuild     (cached)
ok      github.com/openshift/oc/pkg/cli/create  (cached)
?       github.com/openshift/oc/pkg/cli/create/route    [no test files]
ok      github.com/openshift/oc/pkg/cli/debug   0.118s
ok      github.com/openshift/oc/pkg/cli/deployer        (cached)
?       github.com/openshift/oc/pkg/cli/deployer/strategy       [no test files]
ok      github.com/openshift/oc/pkg/cli/deployer/strategy/recreate      (cached)
ok      github.com/openshift/oc/pkg/cli/deployer/strategy/rolling       (cached)
ok      github.com/openshift/oc/pkg/cli/deployer/strategy/support       (cached)
?       github.com/openshift/oc/pkg/cli/deployer/strategy/util  [no test files]
?       github.com/openshift/oc/pkg/cli/deployer/strategy/util/appstest [no test files]
?       github.com/openshift/oc/pkg/cli/expose  [no test files]
?       github.com/openshift/oc/pkg/cli/extract [no test files]
ok      github.com/openshift/oc/pkg/cli/idle    (cached)
?       github.com/openshift/oc/pkg/cli/image   [no test files]
?       github.com/openshift/oc/pkg/cli/image/append    [no test files]
?       github.com/openshift/oc/pkg/cli/image/archive   [no test files]
?       github.com/openshift/oc/pkg/cli/image/extract   [no test files]
ok      github.com/openshift/oc/pkg/cli/image/imagesource       (cached)
?       github.com/openshift/oc/pkg/cli/image/info      [no test files]
?       github.com/openshift/oc/pkg/cli/image/manifest  [no test files]
ok      github.com/openshift/oc/pkg/cli/image/manifest/dockercredentials        (cached)
?       github.com/openshift/oc/pkg/cli/image/mirror    [no test files]
?       github.com/openshift/oc/pkg/cli/image/serve     [no test files]
ok      github.com/openshift/oc/pkg/cli/image/strategy  (cached)
?       github.com/openshift/oc/pkg/cli/image/workqueue [no test files]
ok      github.com/openshift/oc/pkg/cli/importimage     (cached)
?       github.com/openshift/oc/pkg/cli/kubectlwrappers [no test files]
ok      github.com/openshift/oc/pkg/cli/login   (cached)
?       github.com/openshift/oc/pkg/cli/logout  [no test files]
ok      github.com/openshift/oc/pkg/cli/logs    (cached)
ok      github.com/openshift/oc/pkg/cli/newapp  1.341s
ok      github.com/openshift/oc/pkg/cli/newbuild        0.142s
?       github.com/openshift/oc/pkg/cli/observe [no test files]
?       github.com/openshift/oc/pkg/cli/options [no test files]
?       github.com/openshift/oc/pkg/cli/policy  [no test files]
ok      github.com/openshift/oc/pkg/cli/process 0.241s
?       github.com/openshift/oc/pkg/cli/project [no test files]
?       github.com/openshift/oc/pkg/cli/projects        [no test files]
ok      github.com/openshift/oc/pkg/cli/recycle (cached)
?       github.com/openshift/oc/pkg/cli/registry        [no test files]
?       github.com/openshift/oc/pkg/cli/registry/info   [no test files]
?       github.com/openshift/oc/pkg/cli/registry/login  [no test files]
ok      github.com/openshift/oc/pkg/cli/requestproject  (cached)
ok      github.com/openshift/oc/pkg/cli/rollback        (cached)
?       github.com/openshift/oc/pkg/cli/rollout [no test files]
?       github.com/openshift/oc/pkg/cli/rsh     [no test files]
ok      github.com/openshift/oc/pkg/cli/rsync   (cached)
?       github.com/openshift/oc/pkg/cli/rsync/fsnotification    [no test files]
?       github.com/openshift/oc/pkg/cli/secrets [no test files]
?       github.com/openshift/oc/pkg/cli/serviceaccounts [no test files]
ok      github.com/openshift/oc/pkg/cli/set     0.325s
ok      github.com/openshift/oc/pkg/cli/startbuild      (cached)
?       github.com/openshift/oc/pkg/cli/status  [no test files]
ok      github.com/openshift/oc/pkg/cli/tag     (cached)
?       github.com/openshift/oc/pkg/cli/version [no test files]
?       github.com/openshift/oc/pkg/cli/whoami  [no test files]
?       github.com/openshift/oc/pkg/helpers     [no test files]
?       github.com/openshift/oc/pkg/helpers/apps/test   [no test files]
?       github.com/openshift/oc/pkg/helpers/authorization       [no test files]
ok      github.com/openshift/oc/pkg/helpers/build       (cached)
?       github.com/openshift/oc/pkg/helpers/build/client/v1     [no test files]
ok      github.com/openshift/oc/pkg/helpers/bulk        (cached)
ok      github.com/openshift/oc/pkg/helpers/clientcmd   (cached)
ok      github.com/openshift/oc/pkg/helpers/cmd (cached)
?       github.com/openshift/oc/pkg/helpers/conditions  [no test files]
?       github.com/openshift/oc/pkg/helpers/deployment  [no test files]
ok      github.com/openshift/oc/pkg/helpers/describe    (cached)
ok      github.com/openshift/oc/pkg/helpers/dot (cached)
?       github.com/openshift/oc/pkg/helpers/env [no test files]
?       github.com/openshift/oc/pkg/helpers/errors      [no test files]
?       github.com/openshift/oc/pkg/helpers/file        [no test files]
ok      github.com/openshift/oc/pkg/helpers/flagtypes   (cached)
ok      github.com/openshift/oc/pkg/helpers/graph/appsgraph     (cached)
ok      github.com/openshift/oc/pkg/helpers/graph/appsgraph/analysis    (cached)
ok      github.com/openshift/oc/pkg/helpers/graph/appsgraph/nodes       (cached)
ok      github.com/openshift/oc/pkg/helpers/graph/buildgraph    (cached)
ok      github.com/openshift/oc/pkg/helpers/graph/buildgraph/analysis   (cached)
?       github.com/openshift/oc/pkg/helpers/graph/buildgraph/nodes      [no test files]
ok      github.com/openshift/oc/pkg/helpers/graph/genericgraph  (cached)
ok      github.com/openshift/oc/pkg/helpers/graph/genericgraph/graphview        (cached)
?       github.com/openshift/oc/pkg/helpers/graph/genericgraph/test     [no test files]
?       github.com/openshift/oc/pkg/helpers/graph/imagegraph    [no test files]
ok      github.com/openshift/oc/pkg/helpers/graph/imagegraph/nodes      (cached)
ok      github.com/openshift/oc/pkg/helpers/graph/kubegraph     (cached)
ok      github.com/openshift/oc/pkg/helpers/graph/kubegraph/analysis    (cached)
ok      github.com/openshift/oc/pkg/helpers/graph/kubegraph/nodes       (cached)
?       github.com/openshift/oc/pkg/helpers/graph/routegraph    [no test files]
ok      github.com/openshift/oc/pkg/helpers/graph/routegraph/analysis   (cached)
?       github.com/openshift/oc/pkg/helpers/graph/routegraph/nodes      [no test files]
ok      github.com/openshift/oc/pkg/helpers/groupsync   (cached)
ok      github.com/openshift/oc/pkg/helpers/groupsync/ad        (cached)
ok      github.com/openshift/oc/pkg/helpers/groupsync/groupdetector     (cached)
?       github.com/openshift/oc/pkg/helpers/groupsync/interfaces        [no test files]
?       github.com/openshift/oc/pkg/helpers/groupsync/ldap      [no test files]
ok      github.com/openshift/oc/pkg/helpers/groupsync/rfc2307   (cached)
ok      github.com/openshift/oc/pkg/helpers/groupsync/syncerror (cached)
ok      github.com/openshift/oc/pkg/helpers/image       (cached)
ok      github.com/openshift/oc/pkg/helpers/image/credentialprovider    (cached)
?       github.com/openshift/oc/pkg/helpers/image/dockerlayer   [no test files]
?       github.com/openshift/oc/pkg/helpers/image/dockerlayer/add       [no test files]
?       github.com/openshift/oc/pkg/helpers/image/test  [no test files]
?       github.com/openshift/oc/pkg/helpers/kubeconfig  [no test files]
?       github.com/openshift/oc/pkg/helpers/legacy      [no test files]
ok      github.com/openshift/oc/pkg/helpers/motd        (cached)
?       github.com/openshift/oc/pkg/helpers/newapp      [no test files]
ok      github.com/openshift/oc/pkg/helpers/newapp/app  0.179s
?       github.com/openshift/oc/pkg/helpers/newapp/app/test     [no test files]
?       github.com/openshift/oc/pkg/helpers/newapp/appjson      [no test files]
ok      github.com/openshift/oc/pkg/helpers/newapp/cmd  0.192s
ok      github.com/openshift/oc/pkg/helpers/newapp/docker       (cached)
ok      github.com/openshift/oc/pkg/helpers/newapp/docker/dockerfile    (cached)
ok      github.com/openshift/oc/pkg/helpers/newapp/dockerfile   (cached)
?       github.com/openshift/oc/pkg/helpers/newapp/jenkinsfile  [no test files]
ok      github.com/openshift/oc/pkg/helpers/newapp/newapptest   3.200s
ok      github.com/openshift/oc/pkg/helpers/newapp/portutils    (cached)
?       github.com/openshift/oc/pkg/helpers/newapp/source       [no test files]
?       github.com/openshift/oc/pkg/helpers/originpolymorphichelpers    [no test files]
?       github.com/openshift/oc/pkg/helpers/originpolymorphichelpers/deploymentconfigs  [no test files]
ok      github.com/openshift/oc/pkg/helpers/parallel    (cached)
?       github.com/openshift/oc/pkg/helpers/proc        [no test files]
?       github.com/openshift/oc/pkg/helpers/project     [no test files]
?       github.com/openshift/oc/pkg/helpers/quota       [no test files]
?       github.com/openshift/oc/pkg/helpers/route       [no test files]
?       github.com/openshift/oc/pkg/helpers/source-to-image/api [no test files]
?       github.com/openshift/oc/pkg/helpers/source-to-image/cmd [no test files]
?       github.com/openshift/oc/pkg/helpers/source-to-image/cmd/test    [no test files]
?       github.com/openshift/oc/pkg/helpers/source-to-image/cygpath     [no test files]
?       github.com/openshift/oc/pkg/helpers/source-to-image/errors      [no test files]
ok      github.com/openshift/oc/pkg/helpers/source-to-image/fs  (cached)
?       github.com/openshift/oc/pkg/helpers/source-to-image/fs/test     [no test files]
ok      github.com/openshift/oc/pkg/helpers/source-to-image/git 0.366s
?       github.com/openshift/oc/pkg/helpers/source-to-image/log [no test files]
ok      github.com/openshift/oc/pkg/helpers/source-to-image/tar (cached)
ok      github.com/openshift/oc/pkg/helpers/source-to-image/timeout     (cached)
?       github.com/openshift/oc/pkg/helpers/template/templateprocessorclient    [no test files]
ok      github.com/openshift/oc/pkg/helpers/term        (cached)
ok      github.com/openshift/oc/pkg/helpers/tokencmd    (cached)
?       github.com/openshift/oc/pkg/version     [no test files]
?       github.com/openshift/oc/tools/clicheck  [no test files]
?       github.com/openshift/oc/tools/clicheck/sanity   [no test files]
?       github.com/openshift/oc/tools/gendocs   [no test files]
?       github.com/openshift/oc/tools/gendocs/gendocs   [no test files]
?       github.com/openshift/oc/tools/genman    [no test files]
?       github.com/openshift/oc/tools/genman/md2man     [no test files]
```