### PR TITLE
OCPBUGS-10879: Fix deprecated oc command suggestion

### DIFF
--- a/pkg/helpers/graph/buildgraph/analysis/bc.go
+++ b/pkg/helpers/graph/buildgraph/analysis/bc.go
@@ -66,7 +66,7 @@ bc:
 						Key:      MissingRequiredRegistryErr,
 						Message: fmt.Sprintf("%s is pushing to %s, but the administrator has not configured the integrated container image registry.",
 							f.ResourceName(bcNode), f.ResourceName(istNode)),
-						Suggestion: osgraph.Suggestion("oc adm registry -h"),
+						Suggestion: "oc registry -h",
 					})
 
 					continue bc


### PR DESCRIPTION
Currently when user runs `oc status --suggest` if misconfigured registry is detected, `oc` suggests to run `oc adm registry -h` command. However, this command is deprecated and removed, this PR instead suggests correct command `oc registry -h`.