### PR TITLE
OCPBUGS-10843: oc debug unique pod name

### DIFF
--- a/pkg/cli/debug/debug.go
+++ b/pkg/cli/debug/debug.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/printers"
@@ -451,7 +452,7 @@ func (o *DebugOptions) RunDebug() error {
 	}
 	defer cleanup()
 
-	pod.Name, pod.Namespace = fmt.Sprintf("%s-debug", generateapp.MakeSimpleName(infos[0].Name)), ns
+	pod.Name, pod.Namespace = fmt.Sprintf("%s-debug-%s", generateapp.MakeSimpleName(infos[0].Name), utilrand.String(5)), ns
 	o.Attach.Pod = pod
 
 	if len(o.ContainerName) == 0 && len(pod.Spec.Containers) > 0 {

--- a/pkg/cli/debug/debug.go
+++ b/pkg/cli/debug/debug.go
@@ -1243,6 +1243,9 @@ func (o *DebugOptions) getNamespace(infoNs string) (string, func(), error) {
 		}
 
 		cleanup := func() {
+			if o.PreservePod {
+				return
+			}
 			if err := o.CoreClient.Namespaces().Delete(context.TODO(), ns.Name, metav1.DeleteOptions{}); err != nil {
 				klog.V(2).Infof("Unable to delete temporary namespace %s: %v", ns.Name, err)
 			} else {


### PR DESCRIPTION
`oc debug` command uses same deterministic pod name in every execution(if matching pod name exists, it deletes this pod and re-creates it). 
Currently, some CI jobs rely on executing `oc debug` multiple times in a short period
of time. When it happens, sometimes informers might return previous container's
terminated state(although genuine container hasn't started yet). This causes debug command fails intermittently.

This might be considered an issue in informers but wouldn't it be also better to add suffix(just how [kubectl debug does](https://github.com/kubernetes/kubernetes/blob/d89d5ab2680bc74fe4487ad71e514f4e0812d9ce/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go#L584)) to set apart debug pods from each other. If user still wants to attach same container, he/she can pass `--preserve-pod` flag and attach it to via `attach` command.

In addition to that this PR prevents deletion of temporary namespace if the `--preserve-pod` flag is
passed to keep debug pod in cluster.