### PR TITLE
WIP: Revert "pkg/cli/admin/release/extract: Don't print image metadata verification messages when extracting to stdout"

### DIFF
--- a/pkg/cli/admin/release/extract.go
+++ b/pkg/cli/admin/release/extract.go
@@ -278,15 +278,13 @@ func (o *ExtractOptions) Run() error {
 		imageMetadataCallbacks = append(imageMetadataCallbacks, o.ImageMetadataCallback)
 	}
 
-	var metadataVerifyMsg string
-
 	verifier := imagemanifest.NewVerifier()
 	imageMetadataCallbacks = append(imageMetadataCallbacks, func(m *extract.Mapping, dgst, contentDigest digest.Digest, config *dockerv1client.DockerImageConfig, manifestListDigest digest.Digest) {
 		verifier.Verify(dgst, contentDigest)
 		if len(ref.Ref.ID) > 0 {
-			metadataVerifyMsg = fmt.Sprintf("Extracted release payload created at %s", config.Created.Format(time.RFC3339))
+			fmt.Fprintf(o.Out, "Extracted release payload created at %s\n", config.Created.Format(time.RFC3339))
 		} else {
-			metadataVerifyMsg = fmt.Sprintf("Extracted release payload from digest %s created at %s", dgst, config.Created.Format(time.RFC3339))
+			fmt.Fprintf(o.Out, "Extracted release payload from digest %s created at %s\n", dgst, config.Created.Format(time.RFC3339))
 		}
 	})
 
@@ -419,10 +417,6 @@ func (o *ExtractOptions) Run() error {
 		if err := opts.Run(); err != nil {
 			return err
 		}
-	}
-
-	if metadataVerifyMsg != "" {
-		fmt.Fprintf(o.Out, "%s\n", metadataVerifyMsg)
 	}
 
 	if !verifier.Verified() {


### PR DESCRIPTION
Reverts openshift/oc#1264

I'm just trying to excercise the new CI from openshift/origin#27822; we don't want to actually merge this change.