### PR TITLE
replace trimLeft with trimPrefix

### DIFF
--- a/pkg/cli/admin/prune/imageprune/helper_test.go
+++ b/pkg/cli/admin/prune/imageprune/helper_test.go
@@ -169,7 +169,7 @@ func TestDefaultImagePinger(t *testing.T) {
 				server = httptest.NewServer(http.HandlerFunc(handler))
 			}
 			defer server.Close()
-			serverHost := strings.TrimLeft(strings.TrimLeft(server.URL, "http://"), "https://")
+			serverHost := strings.TrimPrefix(strings.TrimPrefix(server.URL, "http://"), "https://")
 
 			client := &secureClient
 			if tc.insecure {


### PR DESCRIPTION
replaces trimLeft function with the more appropriate trimPrefix to avoid potential bugs.
for example:
```golang
// will output ello.test
fmt.Println(strings.TrimLeft("hello.test", "http://"))
```