### PR TITLE
OCPBUGS-12143: oc login: unwrap tls.CertificateVerificationError to use x509 errors

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.19-openshift-4.14
+  tag: rhel-8-release-golang-1.20-openshift-4.14

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/oc
 
-go 1.19
+go 1.20
 
 require (
 	github.com/AaronO/go-git-http v0.0.0-20161214145340-1d9485b3a98f

--- a/images/cli-artifacts/Dockerfile.rhel
+++ b/images/cli-artifacts/Dockerfile.rhel
@@ -1,6 +1,6 @@
 # This Dockerfile builds an image containing the Mac and Windows version of oc
 # layered on top of the Linux cli image.
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.14 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS builder
 WORKDIR /go/src/github.com/openshift/oc
 COPY . .
 RUN make cross-build --warn-undefined-variables

--- a/images/cli/Dockerfile.rhel
+++ b/images/cli/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.14 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS builder
 WORKDIR /go/src/github.com/openshift/oc
 COPY . .
 RUN make build --warn-undefined-variables


### PR DESCRIPTION
Currently, `oc login` has some logic when user gets x509 certificate errors.
However in Go 1.20(with [this commit](https://go-review.googlesource.com/c/go/+/449336)) and upward versions, these certificate errors are wrapped in
`tls.CertificateVerificationError`(https://pkg.go.dev/crypto/tls#CertificateVerificationError). In order to keep the same functionality,
`oc login` needs to detect this type and extract correct error.
Furthermore, since this new type has been only added into Go 1.20,
we also need to bump `oc` to 1.20. 

This PR is also prerequisite for the openshift/kubernetes
1.27 vendoring of `oc`.