### PR TITLE
OCPBUGS-11632: Improve error log messages in event filtering

### DIFF
--- a/pkg/cli/admin/inspect/util.go
+++ b/pkg/cli/admin/inspect/util.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
@@ -181,18 +180,18 @@ func getAllEventsRecursive(rootDir string) (*corev1.EventList, error) {
 	err := filepath.Walk(rootDir,
 		func(path string, info os.FileInfo, err error) error {
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to walk err: %v", err)
 			}
 			if info.Name() != "events.yaml" {
 				return nil
 			}
-			eventBytes, err := ioutil.ReadFile(path)
+			eventBytes, err := os.ReadFile(path)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to read file err: %v", err)
 			}
 			events, err := readEvents(eventBytes)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to read event err: %v", err)
 			}
 			eventLists.Items = append(eventLists.Items, events.Items...)
 			return nil
@@ -271,7 +270,7 @@ func createEventFilterPage(events *corev1.EventList, rootDir string) error {
 		return err
 	}
 
-	return ioutil.WriteFile(filepath.Join(rootDir, "event-filter.html"), out.Bytes(), 0644)
+	return os.WriteFile(filepath.Join(rootDir, "event-filter.html"), out.Bytes(), 0644)
 }
 
 // CreateEventFilterPage reads all events in rootDir recursively, produces a single file, and produces a webpage


### PR DESCRIPTION
Currently, `oc adm inspect` command aggregates error messages and prints them once. 
Event filtering unification mechanism returns plain errors but we need more explanatory error messages
to troubleshoot issues. 

This PR improves these. This PR does not solve the referenced bug, instead
it makes it easier to investigate problem.