### PR TITLE
OCPBUGS-8356: pkg/cli/admin/upgrade: Use JSON Patch

### DIFF
--- a/pkg/cli/admin/upgrade/upgrade.go
+++ b/pkg/cli/admin/upgrade/upgrade.go
@@ -646,12 +646,17 @@ func targetMatch(target *configv1.Release, to string, toImage string) (bool, err
 func patchDesiredUpdate(ctx context.Context, update *configv1.Update, client configv1client.Interface,
 	clusterVersionName string) error {
 
-	updateJSON, err := json.Marshal(update)
+	data := []map[string]interface{}{{
+		"op":    "add",
+		"path":  "/spec/desiredUpdate",
+		"value": update,
+	}}
+
+	patch, err := json.Marshal(data)
 	if err != nil {
 		return fmt.Errorf("marshal ClusterVersion patch: %v", err)
 	}
-	patch := []byte(fmt.Sprintf(`{"spec":{"desiredUpdate": %s}}`, updateJSON))
-	if _, err := client.ConfigV1().ClusterVersions().Patch(ctx, clusterVersionName, types.MergePatchType, patch,
+	if _, err := client.ConfigV1().ClusterVersions().Patch(ctx, clusterVersionName, types.JSONPatchType, patch,
 		metav1.PatchOptions{}); err != nil {
 
 		return fmt.Errorf("Unable to upgrade: %v", err)


### PR DESCRIPTION
[In 4.11.0][1] (#1111) and [4.10.14][2] (#1114), I ported `oc adm upgrade --to ...` and friends from POST to PATCH.  I used `MergePatchType`, [based on][3] [RFC 7386][4], which isn't powerful enough for `omitempty` zero-value properties in the `Update` structure to clear any in-cluster values for that property.  Luckily, [we currently have no `omitempty` Update properties][5].  But this commit transitions us to the more explict [RFC 6902 JSON Patch][6], to ensure complete control over `spec.desiredUpdate` with the PATCH, even if `Update` grows 'omitempty' properties in the future.

I'm also taking the opportunity to transition to complete `Marshal` serialization, instead of using `Sprintf` to hand-craft part of the JSON patch body.  This reduces the chances of coding typos introducing invalid-JSON issues.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=2075647#c6
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=2077332#c7
[3]: https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/#use-a-json-merge-patch-to-update-a-deployment
[4]: https://www.rfc-editor.org/rfc/rfc7386
[5]: https://github.com/openshift/api/blob/8bbcb7ca71836dc87cce3ef63647403dc9d0fbea/config/v1/types_cluster_version.go#L454-L495
[6]: https://www.rfc-editor.org/rfc/rfc6902