### PR TITLE
OCPBUGS-14340: Name containers w/'multi' when mirroring a multi release image

### DIFF
--- a/pkg/cli/admin/release/mirror.go
+++ b/pkg/cli/admin/release/mirror.go
@@ -492,7 +492,10 @@ func (o *MirrorOptions) Run() error {
 		extractOpts.ImageMetadataCallback = func(m *extract.Mapping, dgst, contentDigest digest.Digest, config *dockerv1client.DockerImageConfig, manifestListDigest digest.Digest) {
 			releaseDigest = contentDigest.String()
 			if config != nil {
-				if val, ok := archMap[config.Architecture]; ok {
+				// Use 'multi' instead of config.Architecture if keeping the ManifestList.
+				if o.KeepManifestList && manifestListDigest != "" {
+					archExt = "-multi"
+				} else if val, ok := archMap[config.Architecture]; ok {
 					archExt = "-" + val
 				} else {
 					archExt = "-" + config.Architecture


### PR DESCRIPTION
Currently, `oc adm release mirror` does mirror the multi release image, but it will mirror all of the images with `-x86_64` in the tag:

`oc adm release mirror quay.io/openshift-release-dev/ocp-release:4.12.13-multi --keep-manifest-list=true --to=someregistry.io/somewhere/release `


This PR will rename containers w/`-multi` if the release image is manifest listed AND if `--keep-manifest-list=true`.
