### PR TITLE
OCPBUGS-11123: oc adm groups sync: print a warning when two or more groups are mapped to the same ldap uid

### DIFF
--- a/pkg/helpers/groupsync/grouplister.go
+++ b/pkg/helpers/groupsync/grouplister.go
@@ -8,6 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
 
 	userv1 "github.com/openshift/api/user/v1"
 	userv1client "github.com/openshift/client-go/user/clientset/versioned/typed/user/v1"
@@ -62,6 +63,9 @@ func (l *allOpenShiftGroupLister) ListGroups() ([]string, error) {
 
 		ldapGroupUID := group.Annotations[LDAPUIDAnnotation]
 		l.ldapGroupUIDToOpenShiftGroupName[ldapGroupUID] = group.Name
+		if existingGroupName, exists := l.ldapGroupUIDToOpenShiftGroupName[ldapGroupUID]; exists {
+			klog.Warningf("Group %q has the same %v as group %q. Only a single group is eligible for mapping. Group %q will be ignored.", existingGroupName, ldapGroupUID, group.Name, existingGroupName)
+		}
 		ldapGroupUIDs = append(ldapGroupUIDs, ldapGroupUID)
 	}
 
@@ -149,6 +153,9 @@ func (l *openshiftGroupLister) ListGroups() ([]string, error) {
 		}
 
 		ldapGroupUID := group.Annotations[LDAPUIDAnnotation]
+		if existingGroupName, exists := l.ldapGroupUIDToOpenShiftGroupName[ldapGroupUID]; exists {
+			klog.Warningf("Group %q has the same %v as group %q. Only a single group is eligible for mapping. Group %q will be ignored.", existingGroupName, ldapGroupUID, group.Name, existingGroupName)
+		}
 		l.ldapGroupUIDToOpenShiftGroupName[ldapGroupUID] = group.Name
 		ldapGroupUIDs = append(ldapGroupUIDs, ldapGroupUID)
 	}


### PR DESCRIPTION
The original design limited the ldap to openshift group mapping to a single group: https://github.com/openshift/api/blob/4f3c947a2271264efd787eebeec05deb141e0333/legacyconfig/v1/types.go#L1306

The current implementation does not allow to cleanly error without disrupting already existing automation which is either not aware of this restriction or willingly ignores it. We can only print a warning.