### PR TITLE
OCPNODE-1656: oc image extract: Introduce IDMS as alternative source

### DIFF
--- a/pkg/cli/image/extract/extract.go
+++ b/pkg/cli/image/extract/extract.go
@@ -137,6 +137,7 @@ type ExtractOptions struct {
 
 	FileDir  string
 	ICSPFile string
+	IDMSFile string
 
 	genericclioptions.IOStreams
 
@@ -185,6 +186,8 @@ func NewExtract(streams genericclioptions.IOStreams) *cobra.Command {
 	flag.BoolVar(&o.DryRun, "dry-run", o.DryRun, "Print the actions that would be taken and exit without writing any contents.")
 
 	flag.StringVar(&o.ICSPFile, "icsp-file", o.ICSPFile, "Path to an ImageContentSourcePolicy file. If set, data from this file will be used to find alternative locations for images.")
+	flag.MarkDeprecated("icsp-file", "support for it will be removed in a future release. Use --idms-file instead.")
+	flag.StringVar(&o.IDMSFile, "idms-file", o.ICSPFile, "Path to an ImageDigestMirrorSet file. If set, data from this file will be used to find alternative locations for images.")
 
 	flag.StringSliceVar(&o.Files, "file", o.Files, "Extract the specified files to the current directory.")
 	flag.StringSliceVar(&o.Paths, "path", o.Paths, "Extract only part of an image, or, designate the directory on disk to extract image contents into. Must be SRC:DST where SRC is the path within the image and DST a local directory. If not specified the default is to extract everything to the current directory.")
@@ -340,6 +343,9 @@ func (o *ExtractOptions) Validate() error {
 	if len(o.Mappings) == 0 {
 		return fmt.Errorf("you must specify one or more paths or files")
 	}
+	if len(o.ICSPFile) > 0 && len(o.IDMSFile) > 0 {
+		return fmt.Errorf("icsp-file and idms-file are mutually exclusive")
+	}
 	return o.FilterOptions.Validate()
 }
 
@@ -352,6 +358,9 @@ func (o *ExtractOptions) Run() error {
 	if len(o.ICSPFile) > 0 {
 		fromContext = fromContext.WithAlternateBlobSourceStrategy(strategy.NewICSPOnErrorStrategy(o.ICSPFile))
 	}
+	if len(o.IDMSFile) > 0 {
+		fromContext = fromContext.WithAlternateBlobSourceStrategy(strategy.NewIDMSOnErrorStrategy(o.IDMSFile))
+	}
 	fromOptions := &imagesource.Options{
 		FileDir:         o.FileDir,
 		Insecure:        o.SecurityOptions.Insecure,
@@ -362,13 +371,13 @@ func (o *ExtractOptions) Run() error {
 	defer close(stopCh)
 	q := workqueue.New(o.ParallelOptions.MaxPerRegistry, stopCh)
 	return q.Try(func(q workqueue.Try) {
-		icspWarned := false
+		alternateSourceWarned := false
 		for i := range o.Mappings {
 			mapping := o.Mappings[i]
 			from := mapping.ImageRef
-			if !icspWarned && len(o.ICSPFile) > 0 && len(from.Ref.Tag) > 0 {
-				fmt.Fprintf(o.ErrOut, "warning: --icsp-file only applies to images referenced by digest and will be ignored for tags\n")
-				icspWarned = true
+			if !alternateSourceWarned && (len(o.ICSPFile) > 0 || len(o.IDMSFile) > 0) && len(from.Ref.Tag) > 0 {
+				fmt.Fprintf(o.ErrOut, "warning: --idms-file(and --icsp-file) only applies to images referenced by digest and will be ignored for tags\n")
+				alternateSourceWarned = true
 			}
 			q.Try(func() error {
 				repo, err := fromOptions.Repository(ctx, from)

--- a/pkg/cli/image/strategy/explicit.go
+++ b/pkg/cli/image/strategy/explicit.go
@@ -127,8 +127,8 @@ func (s *explicitIDMSStrategy) OnFailure(ctx context.Context, locator reference.
 }
 
 // resolve gathers possible image sources for a given image
-// gathered from ImageContentSourcePolicy objects and user-passed image.
-// Will lookup from cluster or from ImageContentSourcePolicy file passed from user.
+// gathered from ImageDigestMirrorSet objects and user-passed image.
+// Will lookup from cluster or from ImageDigestMirrorSet file passed from user.
 // Image reference of user-given image may be different from original in case of mirrored images.
 func (s *explicitIDMSStrategy) resolve(ctx context.Context, imageRef reference.DockerImageReference) ([]reference.DockerImageReference, error) {
 	if len(s.idmsFile) == 0 {

--- a/pkg/cli/image/strategy/explicit.go
+++ b/pkg/cli/image/strategy/explicit.go
@@ -11,7 +11,7 @@ import (
 	"github.com/openshift/library-go/pkg/image/registryclient"
 )
 
-type explicitStrategy struct {
+type explicitICSPStrategy struct {
 	lock sync.Mutex
 
 	alternates            map[reference.DockerImageReference][]reference.DockerImageReference
@@ -19,19 +19,19 @@ type explicitStrategy struct {
 	readICSPsFromFileFunc readICSPsFromFileFunc
 }
 
-var _ registryclient.AlternateBlobSourceStrategy = &explicitStrategy{}
+var _ registryclient.AlternateBlobSourceStrategy = &explicitICSPStrategy{}
 
 // NewICSPExplicitStrategy returns ICSP alternate strategy which always reads
 // alternate sources first rather than original requested.
 func NewICSPExplicitStrategy(file string) registryclient.AlternateBlobSourceStrategy {
-	return &explicitStrategy{
+	return &explicitICSPStrategy{
 		icspFile:              file,
 		alternates:            make(map[reference.DockerImageReference][]reference.DockerImageReference),
 		readICSPsFromFileFunc: readICSPsFromFile,
 	}
 }
 
-func (s *explicitStrategy) FirstRequest(ctx context.Context, locator reference.DockerImageReference) (alternateRepositories []reference.DockerImageReference, err error) {
+func (s *explicitICSPStrategy) FirstRequest(ctx context.Context, locator reference.DockerImageReference) (alternateRepositories []reference.DockerImageReference, err error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	if alternates, ok := s.alternates[locator]; ok {
@@ -49,7 +49,7 @@ func (s *explicitStrategy) FirstRequest(ctx context.Context, locator reference.D
 
 }
 
-func (s *explicitStrategy) OnFailure(ctx context.Context, locator reference.DockerImageReference) (alternateRepositories []reference.DockerImageReference, err error) {
+func (s *explicitICSPStrategy) OnFailure(ctx context.Context, locator reference.DockerImageReference) (alternateRepositories []reference.DockerImageReference, err error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	if len(s.alternates) == 0 {
@@ -62,7 +62,7 @@ func (s *explicitStrategy) OnFailure(ctx context.Context, locator reference.Dock
 // gathered from ImageContentSourcePolicy objects and user-passed image.
 // Will lookup from cluster or from ImageContentSourcePolicy file passed from user.
 // Image reference of user-given image may be different from original in case of mirrored images.
-func (s *explicitStrategy) resolve(ctx context.Context, imageRef reference.DockerImageReference) ([]reference.DockerImageReference, error) {
+func (s *explicitICSPStrategy) resolve(ctx context.Context, imageRef reference.DockerImageReference) ([]reference.DockerImageReference, error) {
 	if len(s.icspFile) == 0 {
 		return nil, fmt.Errorf("no ImageContentSourceFile specified")
 	}
@@ -72,7 +72,75 @@ func (s *explicitStrategy) resolve(ctx context.Context, imageRef reference.Docke
 		return nil, err
 	}
 	// always add the original as the last reference
-	imageRefList, err := alternativeImageSources(imageRef, icspList, true)
+	imageRefList, err := alternativeImageSourcesICSP(imageRef, icspList, true)
+	if err != nil {
+		return nil, err
+	}
+	return imageRefList, nil
+}
+
+type explicitIDMSStrategy struct {
+	lock sync.Mutex
+
+	alternates            map[reference.DockerImageReference][]reference.DockerImageReference
+	idmsFile              string
+	readIDMSsFromFileFunc readIDMSsFromFileFunc
+}
+
+var _ registryclient.AlternateBlobSourceStrategy = &explicitIDMSStrategy{}
+
+// NewIDMSExplicitStrategy returns IDMS alternate strategy which always reads
+// alternate sources first rather than original requested.
+func NewIDMSExplicitStrategy(file string) registryclient.AlternateBlobSourceStrategy {
+	return &explicitIDMSStrategy{
+		idmsFile:              file,
+		alternates:            make(map[reference.DockerImageReference][]reference.DockerImageReference),
+		readIDMSsFromFileFunc: readIDMSsFromFile,
+	}
+}
+
+func (s *explicitIDMSStrategy) FirstRequest(ctx context.Context, locator reference.DockerImageReference) (alternateRepositories []reference.DockerImageReference, err error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if alternates, ok := s.alternates[locator]; ok {
+		return alternates, nil
+	}
+	alternates, err := s.resolve(ctx, locator)
+	if err != nil {
+		return nil, err
+	}
+	if len(alternates) == 0 {
+		return nil, fmt.Errorf("no alternative image references found for image: %s", locator.String())
+	}
+	s.alternates[locator] = alternates
+	return s.alternates[locator], nil
+
+}
+
+func (s *explicitIDMSStrategy) OnFailure(ctx context.Context, locator reference.DockerImageReference) (alternateRepositories []reference.DockerImageReference, err error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if len(s.alternates) == 0 {
+		return nil, fmt.Errorf("no alternative image references found for image: %s", locator.String())
+	}
+	return s.alternates[locator], nil
+}
+
+// resolve gathers possible image sources for a given image
+// gathered from ImageContentSourcePolicy objects and user-passed image.
+// Will lookup from cluster or from ImageContentSourcePolicy file passed from user.
+// Image reference of user-given image may be different from original in case of mirrored images.
+func (s *explicitIDMSStrategy) resolve(ctx context.Context, imageRef reference.DockerImageReference) ([]reference.DockerImageReference, error) {
+	if len(s.idmsFile) == 0 {
+		return nil, fmt.Errorf("no ImageContentSourceFile specified")
+	}
+	klog.V(5).Infof("Reading IDMS from file %s", s.idmsFile)
+	idmsList, err := s.readIDMSsFromFileFunc(s.idmsFile)
+	if err != nil {
+		return nil, err
+	}
+	// always add the original as the last reference
+	imageRefList, err := alternativeImageSourcesIDMS(imageRef, idmsList, true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cli/image/strategy/explicit_test.go
+++ b/pkg/cli/image/strategy/explicit_test.go
@@ -7,11 +7,13 @@ import (
 	"strings"
 	"testing"
 
+	apicfgv1 "github.com/openshift/api/config/v1"
+
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	"github.com/openshift/library-go/pkg/image/reference"
 )
 
-func TestExplicitStrategy(t *testing.T) {
+func TestExplicitStrategyICSP(t *testing.T) {
 	tests := []struct {
 		name                 string
 		icspList             []operatorv1alpha1.ImageContentSourcePolicy
@@ -242,7 +244,238 @@ func TestExplicitStrategy(t *testing.T) {
 	}
 }
 
-func TestExplicitStrategyErrors(t *testing.T) {
+func TestExplicitStrategyIDMS(t *testing.T) {
+	tests := []struct {
+		name                 string
+		idmsList             []apicfgv1.ImageDigestMirrorSet
+		image                string
+		imageSourcesExpected []string
+	}{
+		{
+			name: "multiple IDMSs",
+			idmsList: []apicfgv1.ImageDigestMirrorSet{
+				{
+					Spec: apicfgv1.ImageDigestMirrorSetSpec{
+						ImageDigestMirrors: []apicfgv1.ImageDigestMirrors{
+							{
+								Source: "quay.io/multiple/idmss",
+								Mirrors: []apicfgv1.ImageMirror{
+									"someregistry/somerepo/release",
+								},
+							},
+							{
+								Source: "quay.io/ocp-test/another-release",
+								Mirrors: []apicfgv1.ImageMirror{
+									"someregistry/repo/does-not-exist",
+								},
+							},
+						},
+					},
+				},
+				{
+					Spec: apicfgv1.ImageDigestMirrorSetSpec{
+						ImageDigestMirrors: []apicfgv1.ImageDigestMirrors{
+							{
+								Source: "quay.io/multiple/idmss",
+								Mirrors: []apicfgv1.ImageMirror{
+									"anotherregistry/anotherrepo/release",
+								},
+							},
+						},
+					},
+				},
+			},
+			image:                "quay.io/multiple/idmss:4.5",
+			imageSourcesExpected: []string{"someregistry/somerepo/release", "anotherregistry/anotherrepo/release", "quay.io/multiple/idmss"},
+		},
+		{
+			name: "multiple mirrors, single source match",
+			idmsList: []apicfgv1.ImageDigestMirrorSet{
+				{
+					Spec: apicfgv1.ImageDigestMirrorSetSpec{
+						ImageDigestMirrors: []apicfgv1.ImageDigestMirrors{
+							{
+								Source: "docker.io/ocp-test/does-not-exist",
+								Mirrors: []apicfgv1.ImageMirror{
+									"does.not.exist/match/image",
+								},
+							},
+							{
+								Source: "quay.io/ocp-test/does-not-exist",
+								Mirrors: []apicfgv1.ImageMirror{
+									"exists/match/image",
+								},
+							},
+						},
+					},
+				},
+			},
+			image:                "quay.io/ocp-test/does-not-exist:4.7",
+			imageSourcesExpected: []string{"exists/match/image", "quay.io/ocp-test/does-not-exist"},
+		},
+		{
+			name: "single mirror and match",
+			idmsList: []apicfgv1.ImageDigestMirrorSet{
+				{
+					Spec: apicfgv1.ImageDigestMirrorSetSpec{
+						ImageDigestMirrors: []apicfgv1.ImageDigestMirrors{
+							{
+								Source: "quay.io/ocp-test/release",
+								Mirrors: []apicfgv1.ImageMirror{
+									"someregistry/mirrors/match",
+								},
+							},
+						},
+					},
+				},
+			},
+			image:                "quay.io/ocp-test/release:4.5",
+			imageSourcesExpected: []string{"someregistry/mirrors/match", "quay.io/ocp-test/release"},
+		},
+		{
+			name: "no source match",
+			idmsList: []apicfgv1.ImageDigestMirrorSet{
+				{
+					Spec: apicfgv1.ImageDigestMirrorSetSpec{
+						ImageDigestMirrors: []apicfgv1.ImageDigestMirrors{
+							{
+								Source: "docker.io/ocp-test/does-not-exist",
+								Mirrors: []apicfgv1.ImageMirror{
+									"does.not.exist/match/image",
+								},
+							},
+							{
+								Source: "quay.io/ocp-test/does-not-exist",
+								Mirrors: []apicfgv1.ImageMirror{
+									"exists/match/image",
+								},
+							},
+						},
+					},
+				},
+			},
+			image:                "quay.io/passed/image:4.5",
+			imageSourcesExpected: []string{"quay.io/passed/image"},
+		},
+		{
+			name: "multiple mirrors for single source match",
+			idmsList: []apicfgv1.ImageDigestMirrorSet{
+				{
+					Spec: apicfgv1.ImageDigestMirrorSetSpec{
+						ImageDigestMirrors: []apicfgv1.ImageDigestMirrors{
+							{
+								Source: "quay.io/ocp-test/release",
+								Mirrors: []apicfgv1.ImageMirror{
+									"someregistry/mirrors/match",
+									"quay.io/another/release",
+									"quay.io/andanother/release",
+								},
+							},
+						},
+					},
+				},
+			},
+			image:                "quay.io/ocp-test/release:4.5",
+			imageSourcesExpected: []string{"someregistry/mirrors/match", "quay.io/another/release", "quay.io/andanother/release", "quay.io/ocp-test/release"},
+		},
+		{
+			name: "docker.io vs registry-1.docker.io",
+			idmsList: []apicfgv1.ImageDigestMirrorSet{
+				{
+					Spec: apicfgv1.ImageDigestMirrorSetSpec{
+						ImageDigestMirrors: []apicfgv1.ImageDigestMirrors{
+							{
+								Source: "docker.io/ocp-test/release",
+								Mirrors: []apicfgv1.ImageMirror{
+									"quay.io/ocp-test/release",
+								},
+							},
+						},
+					},
+				},
+			},
+			image:                "registry-1.docker.io/ocp-test/release:4.5",
+			imageSourcesExpected: []string{"quay.io/ocp-test/release", "registry-1.docker.io/ocp-test/release"},
+		},
+		{
+			name: "docker.io and registry-1.docker.io as source",
+			idmsList: []apicfgv1.ImageDigestMirrorSet{
+				{
+					Spec: apicfgv1.ImageDigestMirrorSetSpec{
+						ImageDigestMirrors: []apicfgv1.ImageDigestMirrors{
+							{
+								Source: "docker.io/ocp-test/release",
+								Mirrors: []apicfgv1.ImageMirror{
+									"quay.io/ocp-test/release",
+								},
+							},
+						},
+					},
+				},
+				{
+					Spec: apicfgv1.ImageDigestMirrorSetSpec{
+						ImageDigestMirrors: []apicfgv1.ImageDigestMirrors{
+							{
+								Source: "registry-1.docker.io/ocp-test/release",
+								Mirrors: []apicfgv1.ImageMirror{
+									"quay.io/ocp-test/release",
+								},
+							},
+						},
+					},
+				},
+			},
+			image:                "registry-1.docker.io/ocp-test/release:4.5",
+			imageSourcesExpected: []string{"quay.io/ocp-test/release", "registry-1.docker.io/ocp-test/release"},
+		},
+		{
+			name:                 "no IDMS",
+			image:                "quay.io/ocp-test/release:4.5",
+			imageSourcesExpected: []string{"quay.io/ocp-test/release"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expected := []reference.DockerImageReference{}
+			for _, e := range tt.imageSourcesExpected {
+				ref, _ := reference.Parse(e)
+				expected = append(expected, ref)
+			}
+
+			alternates := NewIDMSExplicitStrategy("name")
+			readCount := 0
+			onErr := alternates.(*explicitIDMSStrategy)
+			onErr.readIDMSsFromFileFunc = func(string) ([]apicfgv1.ImageDigestMirrorSet, error) {
+				readCount++
+				return tt.idmsList, nil
+			}
+			imageRef, _ := reference.Parse(tt.image)
+
+			actual, err := alternates.FirstRequest(context.Background(), imageRef)
+			if err != nil {
+				t.Errorf("Unexpected error %v", err)
+				return
+			}
+			if !reflect.DeepEqual(expected, actual) {
+				t.Errorf("Unexpected alternates got = %v, want %v", actual, expected)
+			}
+
+			actual2, err := alternates.OnFailure(context.Background(), imageRef)
+			if err != nil {
+				t.Errorf("Unexpected error %v", err)
+				return
+			}
+			if !reflect.DeepEqual(actual2, actual) {
+				t.Errorf("Unexpected alternates got = %v, want %v", actual, expected)
+			}
+			if readCount > 1 {
+				t.Errorf("Unexpected number of ICSP reads, should be 1, got %d", readCount)
+			}
+		})
+	}
+}
+
+func TestExplicitStrategyErrorsICSP(t *testing.T) {
 	tests := []struct {
 		name         string
 		readICSPFunc readICSPsFromFileFunc
@@ -304,6 +537,76 @@ func TestExplicitStrategyErrors(t *testing.T) {
 			alternates := NewICSPExplicitStrategy("name")
 			onErr := alternates.(*explicitICSPStrategy)
 			onErr.readICSPsFromFileFunc = tt.readICSPFunc
+			_, err := alternates.FirstRequest(context.Background(), imageRef)
+			if err == nil || !strings.Contains(err.Error(), tt.expectedErr) {
+				t.Errorf("Unexpected error, got %v, want %v", err, tt.expectedErr)
+			}
+		})
+	}
+}
+
+func TestExplicitStrategyErrorsIDMS(t *testing.T) {
+	tests := []struct {
+		name         string
+		readIDMSFunc readIDMSsFromFileFunc
+		image        string
+		expectedErr  string
+	}{
+		{
+			name:  "non-existent IDMS file",
+			image: "quay.io/ocp-test/release:4.5",
+			readIDMSFunc: func(string) ([]apicfgv1.ImageDigestMirrorSet, error) {
+				return nil, errors.New("no ImageDigestMirrorSet")
+			},
+			expectedErr: "no ImageDigestMirrorSet",
+		},
+		{
+			name:  "invalid source locator",
+			image: "quay.io/ocp-test/release:4.5",
+			readIDMSFunc: func(string) ([]apicfgv1.ImageDigestMirrorSet, error) {
+				return []apicfgv1.ImageDigestMirrorSet{
+					{
+						Spec: apicfgv1.ImageDigestMirrorSetSpec{
+							ImageDigestMirrors: []apicfgv1.ImageDigestMirrors{
+								{
+									Source: ".invalid-source-spec",
+								},
+							},
+						},
+					},
+				}, nil
+			},
+			expectedErr: "invalid source",
+		},
+		{
+			name:  "invalid mirror locator",
+			image: "quay.io/ocp-test/release:4.5",
+			readIDMSFunc: func(string) ([]apicfgv1.ImageDigestMirrorSet, error) {
+				return []apicfgv1.ImageDigestMirrorSet{
+					{
+						Spec: apicfgv1.ImageDigestMirrorSetSpec{
+							ImageDigestMirrors: []apicfgv1.ImageDigestMirrors{
+								{
+									Source: "quay.io/ocp-test/release",
+									Mirrors: []apicfgv1.ImageMirror{
+										".invalid-mirror-spec",
+									},
+								},
+							},
+						},
+					},
+				}, nil
+			},
+			expectedErr: "invalid mirror",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			imageRef, _ := reference.Parse(tt.image)
+			alternates := NewIDMSExplicitStrategy("name")
+			onErr := alternates.(*explicitIDMSStrategy)
+			onErr.readIDMSsFromFileFunc = tt.readIDMSFunc
 			_, err := alternates.FirstRequest(context.Background(), imageRef)
 			if err == nil || !strings.Contains(err.Error(), tt.expectedErr) {
 				t.Errorf("Unexpected error, got %v, want %v", err, tt.expectedErr)

--- a/pkg/cli/image/strategy/explicit_test.go
+++ b/pkg/cli/image/strategy/explicit_test.go
@@ -211,7 +211,7 @@ func TestExplicitStrategy(t *testing.T) {
 
 			alternates := NewICSPExplicitStrategy("name")
 			readCount := 0
-			onErr := alternates.(*explicitStrategy)
+			onErr := alternates.(*explicitICSPStrategy)
 			onErr.readICSPsFromFileFunc = func(string) ([]operatorv1alpha1.ImageContentSourcePolicy, error) {
 				readCount++
 				return tt.icspList, nil
@@ -302,7 +302,7 @@ func TestExplicitStrategyErrors(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			imageRef, _ := reference.Parse(tt.image)
 			alternates := NewICSPExplicitStrategy("name")
-			onErr := alternates.(*explicitStrategy)
+			onErr := alternates.(*explicitICSPStrategy)
 			onErr.readICSPsFromFileFunc = tt.readICSPFunc
 			_, err := alternates.FirstRequest(context.Background(), imageRef)
 			if err == nil || !strings.Contains(err.Error(), tt.expectedErr) {

--- a/pkg/cli/image/strategy/explicit_test.go
+++ b/pkg/cli/image/strategy/explicit_test.go
@@ -469,7 +469,7 @@ func TestExplicitStrategyIDMS(t *testing.T) {
 				t.Errorf("Unexpected alternates got = %v, want %v", actual, expected)
 			}
 			if readCount > 1 {
-				t.Errorf("Unexpected number of ICSP reads, should be 1, got %d", readCount)
+				t.Errorf("Unexpected number of IDMS reads, should be 1, got %d", readCount)
 			}
 		})
 	}

--- a/pkg/cli/image/strategy/onerror.go
+++ b/pkg/cli/image/strategy/onerror.go
@@ -3,20 +3,22 @@ package strategy
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"sync"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
 
+	apicfgv1 "github.com/openshift/api/config/v1"
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
+	apicfgv1scheme "github.com/openshift/client-go/config/clientset/versioned/scheme"
 	operatorv1alpha1scheme "github.com/openshift/client-go/operator/clientset/versioned/scheme"
 	"github.com/openshift/library-go/pkg/image/reference"
 	"github.com/openshift/library-go/pkg/image/registryclient"
 )
 
-type onErrorStrategy struct {
+type onErrorICSPStrategy struct {
 	lock sync.Mutex
 
 	alternates            map[reference.DockerImageReference][]reference.DockerImageReference
@@ -24,23 +26,23 @@ type onErrorStrategy struct {
 	readICSPsFromFileFunc readICSPsFromFileFunc
 }
 
-var _ registryclient.AlternateBlobSourceStrategy = &onErrorStrategy{}
+var _ registryclient.AlternateBlobSourceStrategy = &onErrorICSPStrategy{}
 
 // NewICSPOnErrorStrategy returns ICSP alternate strategy which reads alternate
 // sources only after getting an error from the original requested.
 func NewICSPOnErrorStrategy(file string) registryclient.AlternateBlobSourceStrategy {
-	return &onErrorStrategy{
+	return &onErrorICSPStrategy{
 		icspFile:              file,
 		alternates:            make(map[reference.DockerImageReference][]reference.DockerImageReference),
 		readICSPsFromFileFunc: readICSPsFromFile,
 	}
 }
 
-func (s *onErrorStrategy) FirstRequest(ctx context.Context, locator reference.DockerImageReference) (alternateRepositories []reference.DockerImageReference, err error) {
+func (s *onErrorICSPStrategy) FirstRequest(ctx context.Context, locator reference.DockerImageReference) (alternateRepositories []reference.DockerImageReference, err error) {
 	return nil, nil
 }
 
-func (s *onErrorStrategy) OnFailure(ctx context.Context, locator reference.DockerImageReference) (alternateRepositories []reference.DockerImageReference, err error) {
+func (s *onErrorICSPStrategy) OnFailure(ctx context.Context, locator reference.DockerImageReference) (alternateRepositories []reference.DockerImageReference, err error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	if alternates, ok := s.alternates[locator]; ok {
@@ -60,7 +62,7 @@ func (s *onErrorStrategy) OnFailure(ctx context.Context, locator reference.Docke
 // resolve gathers possible image sources for a given image
 // gathered from ImageContentSourcePolicy file.
 // Image reference of user-given image may be different from original in case of mirrored images.
-func (s *onErrorStrategy) resolve(ctx context.Context, imageRef reference.DockerImageReference) ([]reference.DockerImageReference, error) {
+func (s *onErrorICSPStrategy) resolve(ctx context.Context, imageRef reference.DockerImageReference) ([]reference.DockerImageReference, error) {
 	if len(s.icspFile) == 0 {
 		return nil, fmt.Errorf("no ImageContentSourceFile specified")
 	}
@@ -70,26 +72,16 @@ func (s *onErrorStrategy) resolve(ctx context.Context, imageRef reference.Docker
 		return nil, err
 	}
 	// always add the original as the first reference
-	imageRefList, err := alternativeImageSources(imageRef, icspList, false)
+	imageRefList, err := alternativeImageSourcesICSP(imageRef, icspList, false)
 	if err != nil {
 		return nil, err
 	}
 	return imageRefList, nil
 }
 
-func isSubrepo(repo, ancestor string) bool {
-	if repo == ancestor {
-		return true
-	}
-	if len(repo) > len(ancestor) {
-		return strings.HasPrefix(repo, ancestor) && repo[len(ancestor)] == '/'
-	}
-	return false
-}
-
-// alternativeImageSources returns unique list of DockerImageReference objects from list of ImageContentSourcePolicy objects
+// alternativeImageSourcesICSP returns unique list of DockerImageReference objects from list of ImageContentSourcePolicy objects
 // addSourceAsLastAlternate decides whether the original imageRef is first or the last element in the result
-func alternativeImageSources(imageRef reference.DockerImageReference, icspList []operatorv1alpha1.ImageContentSourcePolicy, addSourceAsLastAlternate bool) ([]reference.DockerImageReference, error) {
+func alternativeImageSourcesICSP(imageRef reference.DockerImageReference, icspList []operatorv1alpha1.ImageContentSourcePolicy, addSourceAsLastAlternate bool) ([]reference.DockerImageReference, error) {
 	var imageSources []reference.DockerImageReference
 	klog.V(5).Infof("%v ImageReference added to potential ImageSourcePrefixes from ImageContentSourcePolicy", imageRef.AsRepository().AsV2())
 	if !addSourceAsLastAlternate {
@@ -145,7 +137,7 @@ type readICSPsFromFileFunc func(string) ([]operatorv1alpha1.ImageContentSourcePo
 // readICSPsFromFile appends to list of alternative image sources from ICSP file
 // returns error if no icsp object decoded from file data
 func readICSPsFromFile(icspFile string) ([]operatorv1alpha1.ImageContentSourcePolicy, error) {
-	icspData, err := ioutil.ReadFile(icspFile)
+	icspData, err := os.ReadFile(icspFile)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read ImageContentSourceFile %s: %v", icspFile, err)
 	}
@@ -161,4 +153,151 @@ func readICSPsFromFile(icspFile string) ([]operatorv1alpha1.ImageContentSourcePo
 		return nil, fmt.Errorf("could not decode ImageContentSourcePolicy from %s", icspFile)
 	}
 	return []operatorv1alpha1.ImageContentSourcePolicy{*icsp}, nil
+}
+
+type onErrorIDMSStrategy struct {
+	lock sync.Mutex
+
+	alternates            map[reference.DockerImageReference][]reference.DockerImageReference
+	idmsFile              string
+	readIDMSsFromFileFunc readIDMSsFromFileFunc
+}
+
+var _ registryclient.AlternateBlobSourceStrategy = &onErrorIDMSStrategy{}
+
+// NewIDMSOnErrorStrategy returns IDMS alternate strategy which reads alternate
+// sources only after getting an error from the original requested.
+func NewIDMSOnErrorStrategy(file string) registryclient.AlternateBlobSourceStrategy {
+	return &onErrorIDMSStrategy{
+		idmsFile:              file,
+		alternates:            make(map[reference.DockerImageReference][]reference.DockerImageReference),
+		readIDMSsFromFileFunc: readIDMSsFromFile,
+	}
+}
+
+func (s *onErrorIDMSStrategy) FirstRequest(ctx context.Context, locator reference.DockerImageReference) (alternateRepositories []reference.DockerImageReference, err error) {
+	return nil, nil
+}
+
+func (s *onErrorIDMSStrategy) OnFailure(ctx context.Context, locator reference.DockerImageReference) (alternateRepositories []reference.DockerImageReference, err error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if alternates, ok := s.alternates[locator]; ok {
+		return alternates, nil
+	}
+	alternates, err := s.resolve(ctx, locator)
+	if err != nil {
+		return nil, err
+	}
+	if len(alternates) == 0 {
+		return nil, fmt.Errorf("no alternative image references found for image: %s", locator.String())
+	}
+	s.alternates[locator] = alternates
+	return s.alternates[locator], nil
+}
+
+// resolve gathers possible image sources for a given image
+// gathered from ImageContentSourcePolicy file.
+// Image reference of user-given image may be different from original in case of mirrored images.
+func (s *onErrorIDMSStrategy) resolve(ctx context.Context, imageRef reference.DockerImageReference) ([]reference.DockerImageReference, error) {
+	if len(s.idmsFile) == 0 {
+		return nil, fmt.Errorf("no ImageDigestMirrorSet specified")
+	}
+	klog.V(5).Infof("Reading IDMS from file %s", s.idmsFile)
+	idmsList, err := s.readIDMSsFromFileFunc(s.idmsFile)
+	if err != nil {
+		return nil, err
+	}
+	// always add the original as the first reference
+	imageRefList, err := alternativeImageSourcesIDMS(imageRef, idmsList, false)
+	if err != nil {
+		return nil, err
+	}
+	return imageRefList, nil
+}
+
+// alternativeImageSourcesIDMS returns unique list of DockerImageReference objects from list of ImageDigestMirrorSet objects
+// addSourceAsLastAlternate decides whether the original imageRef is first or the last element in the result
+func alternativeImageSourcesIDMS(imageRef reference.DockerImageReference, idmsList []apicfgv1.ImageDigestMirrorSet, addSourceAsLastAlternate bool) ([]reference.DockerImageReference, error) {
+	var imageSources []reference.DockerImageReference
+	klog.V(5).Infof("%v ImageReference added to potential ImageSourcePrefixes from ImageDigestMirrorSet", imageRef.AsRepository().AsV2())
+	if !addSourceAsLastAlternate {
+		imageSources = append(imageSources, imageRef.AsRepository().AsV2())
+	}
+	repo := imageRef.AsRepository().Exact()
+	for _, idms := range idmsList {
+		repoDigestMirrors := idms.Spec.ImageDigestMirrors
+		for _, rdm := range repoDigestMirrors {
+			var suffix string
+			var err error
+			rdmSourceRef, err := reference.Parse(rdm.Source)
+			if err != nil {
+				return nil, fmt.Errorf("invalid source %q: %w", rdm.Source, err)
+			}
+			// AsV2 in the right call is required to ensure we transform docker registry
+			// from docker.io to registry-1.docker.io
+			if imageRef.AsRepository().AsV2() != rdmSourceRef.AsRepository().AsV2() {
+				if !isSubrepo(repo, rdm.Source) {
+					continue
+				}
+				suffix = repo[len(rdm.Source):]
+			}
+			klog.V(5).Infof("%v ImageDigestMirrors source matches given image", imageRef.AsRepository().AsV2())
+			for _, m := range rdm.Mirrors {
+				mRef, err := reference.Parse(string(m) + suffix)
+				if err != nil {
+					return nil, fmt.Errorf("invalid mirror %q: %w", m, err)
+				}
+				imageSources = append(imageSources, mRef)
+				klog.V(5).Infof("%v RepositoryDigestMirrors mirror added to potential ImageSourcePrefixes from ImageContentSourcePolicy", m)
+			}
+		}
+	}
+	if addSourceAsLastAlternate {
+		imageSources = append(imageSources, imageRef.AsRepository().AsV2())
+	}
+	uniqueMirrors := make([]reference.DockerImageReference, 0, len(imageSources))
+	uniqueMap := make(map[reference.DockerImageReference]bool)
+	for _, imageSourceMirror := range imageSources {
+		if _, ok := uniqueMap[imageSourceMirror]; !ok {
+			uniqueMap[imageSourceMirror] = true
+			uniqueMirrors = append(uniqueMirrors, imageSourceMirror)
+		}
+	}
+	klog.V(2).Infof("Found sources: %v for image: %v", uniqueMirrors, imageRef)
+	return uniqueMirrors, nil
+}
+
+// readIDMSsFromFileFunc is used for testing to be able to inject IDMS data
+type readIDMSsFromFileFunc func(string) ([]apicfgv1.ImageDigestMirrorSet, error)
+
+// readIDMSsFromFile appends to list of alternative image sources from IDMS file
+// returns error if no idms object decoded from file data
+func readIDMSsFromFile(idmsFile string) ([]apicfgv1.ImageDigestMirrorSet, error) {
+	idmsData, err := os.ReadFile(idmsFile)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read ImageDigestMirrorSet %s: %v", idmsFile, err)
+	}
+	if len(idmsData) == 0 {
+		return nil, fmt.Errorf("no data found in ImageDigestMirrorSet %s", idmsFile)
+	}
+	idmsObj, err := runtime.Decode(apicfgv1scheme.Codecs.UniversalDeserializer(), idmsData)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding ImageDigestMirrorSet from %s: %v", idmsFile, err)
+	}
+	idms, ok := idmsObj.(*apicfgv1.ImageDigestMirrorSet)
+	if !ok {
+		return nil, fmt.Errorf("could not decode ImageDigestMirrorSet from %s", idmsFile)
+	}
+	return []apicfgv1.ImageDigestMirrorSet{*idms}, nil
+}
+
+func isSubrepo(repo, ancestor string) bool {
+	if repo == ancestor {
+		return true
+	}
+	if len(repo) > len(ancestor) {
+		return strings.HasPrefix(repo, ancestor) && repo[len(ancestor)] == '/'
+	}
+	return false
 }

--- a/pkg/cli/image/strategy/onerror_test.go
+++ b/pkg/cli/image/strategy/onerror_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	apicfgv1 "github.com/openshift/api/config/v1"
+
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	"github.com/openshift/library-go/pkg/image/reference"
 )
@@ -257,7 +259,253 @@ func TestOnErrorICSPStrategy(t *testing.T) {
 	}
 }
 
-func TestOnErrorStrategyErrors(t *testing.T) {
+func TestOnErrorIDMSStrategy(t *testing.T) {
+	tests := []struct {
+		name                 string
+		idmsList             []apicfgv1.ImageDigestMirrorSet
+		image                string
+		imageSourcesExpected []string
+	}{
+		{
+			name: "multiple IDMSs",
+			idmsList: []apicfgv1.ImageDigestMirrorSet{
+				{
+					Spec: apicfgv1.ImageDigestMirrorSetSpec{
+						ImageDigestMirrors: []apicfgv1.ImageDigestMirrors{
+							{
+								Source: "quay.io/multiple/idmss",
+								Mirrors: []apicfgv1.ImageMirror{
+									"someregistry/somerepo/release",
+								},
+							},
+							{
+								Source: "quay.io/ocp-test/another-release",
+								Mirrors: []apicfgv1.ImageMirror{
+									"someregistry/repo/does-not-exist",
+								},
+							},
+						},
+					},
+				},
+				{
+					Spec: apicfgv1.ImageDigestMirrorSetSpec{
+						ImageDigestMirrors: []apicfgv1.ImageDigestMirrors{
+							{
+								Source: "quay.io/multiple/idmss",
+								Mirrors: []apicfgv1.ImageMirror{
+									"anotherregistry/anotherrepo/release",
+								},
+							},
+						},
+					},
+				},
+			},
+			image:                "quay.io/multiple/idmss:4.5",
+			imageSourcesExpected: []string{"quay.io/multiple/idmss", "someregistry/somerepo/release", "anotherregistry/anotherrepo/release"},
+		},
+		{
+			name: "multiple mirrors, single source match",
+			idmsList: []apicfgv1.ImageDigestMirrorSet{
+				{
+					Spec: apicfgv1.ImageDigestMirrorSetSpec{
+						ImageDigestMirrors: []apicfgv1.ImageDigestMirrors{
+							{
+								Source: "docker.io/ocp-test/does-not-exist",
+								Mirrors: []apicfgv1.ImageMirror{
+									"does.not.exist/match/image",
+								},
+							},
+							{
+								Source: "quay.io/ocp-test/does-not-exist",
+								Mirrors: []apicfgv1.ImageMirror{
+									"exists/match/image",
+								},
+							},
+						},
+					},
+				},
+			},
+			image:                "quay.io/ocp-test/does-not-exist:4.7",
+			imageSourcesExpected: []string{"quay.io/ocp-test/does-not-exist", "exists/match/image"},
+		},
+		{
+			name: "single mirror and match",
+			idmsList: []apicfgv1.ImageDigestMirrorSet{
+				{
+					Spec: apicfgv1.ImageDigestMirrorSetSpec{
+						ImageDigestMirrors: []apicfgv1.ImageDigestMirrors{
+							{
+								Source: "quay.io/ocp-test/release",
+								Mirrors: []apicfgv1.ImageMirror{
+									"someregistry/mirrors/match",
+								},
+							},
+						},
+					},
+				},
+			},
+			image:                "quay.io/ocp-test/release:4.5",
+			imageSourcesExpected: []string{"quay.io/ocp-test/release", "someregistry/mirrors/match"},
+		},
+		{
+			name: "single mirror and match with subrepository",
+			idmsList: []apicfgv1.ImageDigestMirrorSet{
+				{
+					Spec: apicfgv1.ImageDigestMirrorSetSpec{
+						ImageDigestMirrors: []apicfgv1.ImageDigestMirrors{
+							{
+								Source: "quay.io/ocp-test",
+								Mirrors: []apicfgv1.ImageMirror{
+									"someregistry/mirrors",
+								},
+							},
+						},
+					},
+				},
+			},
+			image:                "quay.io/ocp-test/release:4.5",
+			imageSourcesExpected: []string{"quay.io/ocp-test/release", "someregistry/mirrors/release"},
+		},
+		{
+			name: "no source match",
+			idmsList: []apicfgv1.ImageDigestMirrorSet{
+				{
+					Spec: apicfgv1.ImageDigestMirrorSetSpec{
+						ImageDigestMirrors: []apicfgv1.ImageDigestMirrors{
+							{
+								Source: "docker.io/ocp-test/does-not-exist",
+								Mirrors: []apicfgv1.ImageMirror{
+									"does.not.exist/match/image",
+								},
+							},
+							{
+								Source: "quay.io/ocp-test/does-not-exist",
+								Mirrors: []apicfgv1.ImageMirror{
+									"exists/match/image",
+								},
+							},
+						},
+					},
+				},
+			},
+			image:                "quay.io/passed/image:4.5",
+			imageSourcesExpected: []string{"quay.io/passed/image"},
+		},
+		{
+			name: "multiple mirrors for single source match",
+			idmsList: []apicfgv1.ImageDigestMirrorSet{
+				{
+					Spec: apicfgv1.ImageDigestMirrorSetSpec{
+						ImageDigestMirrors: []apicfgv1.ImageDigestMirrors{
+							{
+								Source: "quay.io/ocp-test/release",
+								Mirrors: []apicfgv1.ImageMirror{
+									"someregistry/mirrors/match",
+									"quay.io/another/release",
+									"quay.io/andanother/release",
+								},
+							},
+						},
+					},
+				},
+			},
+			image:                "quay.io/ocp-test/release:4.5",
+			imageSourcesExpected: []string{"quay.io/ocp-test/release", "someregistry/mirrors/match", "quay.io/another/release", "quay.io/andanother/release"},
+		},
+		{
+			name: "docker.io vs registry-1.docker.io",
+			idmsList: []apicfgv1.ImageDigestMirrorSet{
+				{
+					Spec: apicfgv1.ImageDigestMirrorSetSpec{
+						ImageDigestMirrors: []apicfgv1.ImageDigestMirrors{
+							{
+								Source: "docker.io/ocp-test/release",
+								Mirrors: []apicfgv1.ImageMirror{
+									"quay.io/ocp-test/release",
+								},
+							},
+						},
+					},
+				},
+			},
+			image:                "registry-1.docker.io/ocp-test/release:4.5",
+			imageSourcesExpected: []string{"registry-1.docker.io/ocp-test/release", "quay.io/ocp-test/release"},
+		},
+		{
+			name: "docker.io and registry-1.docker.io as source",
+			idmsList: []apicfgv1.ImageDigestMirrorSet{
+				{
+					Spec: apicfgv1.ImageDigestMirrorSetSpec{
+						ImageDigestMirrors: []apicfgv1.ImageDigestMirrors{
+							{
+								Source: "docker.io/ocp-test/release",
+								Mirrors: []apicfgv1.ImageMirror{
+									"quay.io/ocp-test/release",
+								},
+							},
+						},
+					},
+				},
+				{
+					Spec: apicfgv1.ImageDigestMirrorSetSpec{
+						ImageDigestMirrors: []apicfgv1.ImageDigestMirrors{
+							{
+								Source: "registry-1.docker.io/ocp-test/release",
+								Mirrors: []apicfgv1.ImageMirror{
+									"quay.io/ocp-test/release",
+								},
+							},
+						},
+					},
+				},
+			},
+			image:                "registry-1.docker.io/ocp-test/release:4.5",
+			imageSourcesExpected: []string{"registry-1.docker.io/ocp-test/release", "quay.io/ocp-test/release"},
+		},
+		{
+			name:                 "no IDMS",
+			image:                "quay.io/ocp-test/release:4.5",
+			imageSourcesExpected: []string{"quay.io/ocp-test/release"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expected := []reference.DockerImageReference{}
+			for _, e := range tt.imageSourcesExpected {
+				ref, _ := reference.Parse(e)
+				expected = append(expected, ref)
+			}
+
+			alternates := NewIDMSOnErrorStrategy("name")
+			readCount := 0
+			onErr := alternates.(*onErrorIDMSStrategy)
+			onErr.readIDMSsFromFileFunc = func(string) ([]apicfgv1.ImageDigestMirrorSet, error) {
+				readCount++
+				return tt.idmsList, nil
+			}
+			imageRef, _ := reference.Parse(tt.image)
+
+			actual, err := alternates.FirstRequest(context.Background(), imageRef)
+			if actual != nil || err != nil {
+				t.Errorf("Unexpected values returned from FirstRequest\nactual: %v\nerr: %v", actual, err)
+			}
+
+			actual, err = alternates.OnFailure(context.Background(), imageRef)
+			if err != nil {
+				t.Errorf("Unexpected error %v", err)
+				return
+			}
+			if !reflect.DeepEqual(expected, actual) {
+				t.Errorf("Unexpected alternates got = %v, want %v", actual, expected)
+			}
+			if readCount > 1 {
+				t.Errorf("Unexpected number of ICSP reads, should be 1, got %d", readCount)
+			}
+		})
+	}
+}
+
+func TestOnErrorStrategyErrorsICSP(t *testing.T) {
 	tests := []struct {
 		name         string
 		readICSPFunc readICSPsFromFileFunc
@@ -319,6 +567,76 @@ func TestOnErrorStrategyErrors(t *testing.T) {
 			alternates := NewICSPOnErrorStrategy("name")
 			onErr := alternates.(*onErrorICSPStrategy)
 			onErr.readICSPsFromFileFunc = tt.readICSPFunc
+			_, err := alternates.OnFailure(context.Background(), imageRef)
+			if err == nil || !strings.Contains(err.Error(), tt.expectedErr) {
+				t.Errorf("Unexpected error, got %v, want %v", err, tt.expectedErr)
+			}
+		})
+	}
+}
+
+func TestOnErrorStrategyErrorsIDMS(t *testing.T) {
+	tests := []struct {
+		name         string
+		readIDMSFunc readIDMSsFromFileFunc
+		image        string
+		expectedErr  string
+	}{
+		{
+			name:  "non-existent IDMS file",
+			image: "quay.io/ocp-test/release:4.5",
+			readIDMSFunc: func(string) ([]apicfgv1.ImageDigestMirrorSet, error) {
+				return nil, errors.New("no ImageDigestMirrorSet")
+			},
+			expectedErr: "no ImageDigestMirrorSet",
+		},
+		{
+			name:  "invalid source locator",
+			image: "quay.io/ocp-test/release:4.5",
+			readIDMSFunc: func(string) ([]apicfgv1.ImageDigestMirrorSet, error) {
+				return []apicfgv1.ImageDigestMirrorSet{
+					{
+						Spec: apicfgv1.ImageDigestMirrorSetSpec{
+							ImageDigestMirrors: []apicfgv1.ImageDigestMirrors{
+								{
+									Source: ".invalid-source-spec",
+								},
+							},
+						},
+					},
+				}, nil
+			},
+			expectedErr: "invalid source",
+		},
+		{
+			name:  "invalid mirror locator",
+			image: "quay.io/ocp-test/release:4.5",
+			readIDMSFunc: func(string) ([]apicfgv1.ImageDigestMirrorSet, error) {
+				return []apicfgv1.ImageDigestMirrorSet{
+					{
+						Spec: apicfgv1.ImageDigestMirrorSetSpec{
+							ImageDigestMirrors: []apicfgv1.ImageDigestMirrors{
+								{
+									Source: "quay.io/ocp-test/release",
+									Mirrors: []apicfgv1.ImageMirror{
+										".invalid-mirror-spec",
+									},
+								},
+							},
+						},
+					},
+				}, nil
+			},
+			expectedErr: "invalid mirror",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			imageRef, _ := reference.Parse(tt.image)
+			alternates := NewIDMSOnErrorStrategy("name")
+			onErr := alternates.(*onErrorIDMSStrategy)
+			onErr.readIDMSsFromFileFunc = tt.readIDMSFunc
 			_, err := alternates.OnFailure(context.Background(), imageRef)
 			if err == nil || !strings.Contains(err.Error(), tt.expectedErr) {
 				t.Errorf("Unexpected error, got %v, want %v", err, tt.expectedErr)

--- a/pkg/cli/image/strategy/onerror_test.go
+++ b/pkg/cli/image/strategy/onerror_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/openshift/library-go/pkg/image/reference"
 )
 
-func TestOnErrorStrategy(t *testing.T) {
+func TestOnErrorICSPStrategy(t *testing.T) {
 	tests := []struct {
 		name                 string
 		icspList             []operatorv1alpha1.ImageContentSourcePolicy
@@ -230,7 +230,7 @@ func TestOnErrorStrategy(t *testing.T) {
 
 			alternates := NewICSPOnErrorStrategy("name")
 			readCount := 0
-			onErr := alternates.(*onErrorStrategy)
+			onErr := alternates.(*onErrorICSPStrategy)
 			onErr.readICSPsFromFileFunc = func(string) ([]operatorv1alpha1.ImageContentSourcePolicy, error) {
 				readCount++
 				return tt.icspList, nil
@@ -317,7 +317,7 @@ func TestOnErrorStrategyErrors(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			imageRef, _ := reference.Parse(tt.image)
 			alternates := NewICSPOnErrorStrategy("name")
-			onErr := alternates.(*onErrorStrategy)
+			onErr := alternates.(*onErrorICSPStrategy)
 			onErr.readICSPsFromFileFunc = tt.readICSPFunc
 			_, err := alternates.OnFailure(context.Background(), imageRef)
 			if err == nil || !strings.Contains(err.Error(), tt.expectedErr) {


### PR DESCRIPTION
This PR;

* adds foundational work to support IDMS(aka ImageDigestMirrorSet) as an alternative source
in addition to the ICSP. 
* introduces `--idms-file` in `oc image extract` depending on the foundational work above ^
* deprecates `--icsp-file` flag in `oc image extract` command to suggest `--idms-file` instead