### PR TITLE
start to command to monitor certificate regeneration

### DIFF
--- a/pkg/cli/admin/ocpcertificates/monitorregeneration/clusteroperator.go
+++ b/pkg/cli/admin/ocpcertificates/monitorregeneration/clusteroperator.go
@@ -1,0 +1,225 @@
+package monitorregeneration
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"strings"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (o *MonitorCertificatesRuntime) createClusterOperator(obj interface{}, isFirstSync bool) {
+	clusterOperator, ok := obj.(*configv1.ClusterOperator)
+	if !ok {
+		fmt.Fprint(o.IOStreams.ErrOut, "unexpected create obj %T", obj)
+	}
+
+	if oldObj, _ := o.interestingClusterOperators.get(clusterOperator.Name); oldObj != nil {
+		o.updateClusterOperator(obj, oldObj)
+		return
+	}
+
+	o.interestingClusterOperators.upsert(clusterOperator.Name, clusterOperator)
+}
+
+func (o *MonitorCertificatesRuntime) updateClusterOperator(obj, oldObj interface{}) {
+	clusterOperator, ok := obj.(*configv1.ClusterOperator)
+	if !ok {
+		fmt.Fprint(o.IOStreams.ErrOut, "unexpected update obj %T", obj)
+	}
+	defer o.interestingClusterOperators.upsert(clusterOperator.Name, clusterOperator)
+
+	oldClusterOperator, ok := oldObj.(*configv1.ClusterOperator)
+	if !ok {
+		fmt.Fprint(o.IOStreams.ErrOut, "unexpected update oldObj %T", oldObj)
+	}
+
+	o.handleClusterOperator(clusterOperator, oldClusterOperator)
+}
+
+func defaultCondition(conditionType configv1.ClusterStatusConditionType) *configv1.ClusterOperatorStatusCondition {
+	return &configv1.ClusterOperatorStatusCondition{
+		Type:               conditionType,
+		Status:             configv1.ConditionUnknown,
+		LastTransitionTime: metav1.Now(),
+		Reason:             "Missing",
+		Message:            "Missing",
+	}
+}
+
+func FindStatusConditionOrSynthetic(conditions []configv1.ClusterOperatorStatusCondition, conditionType configv1.ClusterStatusConditionType) *configv1.ClusterOperatorStatusCondition {
+	ret := v1helpers.FindStatusCondition(conditions, conditionType)
+	if ret != nil {
+		return ret
+	}
+
+	return defaultCondition(conditionType)
+}
+
+func meaningfulChange(condition, oldCondition *configv1.ClusterOperatorStatusCondition) bool {
+	if condition.Status != oldCondition.Status {
+		return true
+	}
+	if condition.Reason != oldCondition.Reason {
+		return true
+	}
+	if messageMinusConflicts(condition.Message) != messageMinusConflicts(oldCondition.Message) {
+		return true
+	}
+
+	return false
+}
+
+func messageMinusConflicts(message string) string {
+	nonConflictLines := []string{}
+	scanner := bufio.NewScanner(bytes.NewBufferString(message))
+	for scanner.Scan() {
+		currLine := scanner.Text()
+		if strings.Contains(currLine, "the object has been modified") {
+			continue
+		}
+		nonConflictLines = append(nonConflictLines, currLine)
+	}
+
+	return strings.Join(nonConflictLines, "\n")
+}
+
+func availableStatusString(status configv1.ConditionStatus) string {
+	switch {
+	case status == configv1.ConditionFalse:
+		return "Unavailable"
+	case status == configv1.ConditionTrue:
+		return "Available"
+	default:
+		return fmt.Sprintf("Available=%v", status)
+	}
+}
+
+func degradedStatusString(status configv1.ConditionStatus) string {
+	switch {
+	case status == configv1.ConditionFalse:
+		return "NotDegraded"
+	case status == configv1.ConditionTrue:
+		return "Degraded"
+	default:
+		return fmt.Sprintf("Degraded=%v", status)
+	}
+}
+func progressingStatusString(status configv1.ConditionStatus) string {
+	switch {
+	case status == configv1.ConditionFalse:
+		return "NotProgressing"
+	case status == configv1.ConditionTrue:
+		return "Progressing"
+	default:
+		return fmt.Sprintf("Progressing=%v", status)
+	}
+}
+
+func (o *MonitorCertificatesRuntime) describeConditionChange(clusterOperatorName string, newCondition, oldCondition *configv1.ClusterOperatorStatusCondition, conditionDescription string) {
+	if meaningfulChange(newCondition, oldCondition) {
+		switch {
+		case newCondition.Status != oldCondition.Status:
+			fmt.Fprintf(o.IOStreams.Out, "clusteroperators/%v -- %v - %v - %v\n", clusterOperatorName, conditionDescription, newCondition.Reason, strings.ReplaceAll(newCondition.Message, "\n", "\n   "))
+		case newCondition.Reason != oldCondition.Reason:
+			fmt.Fprintf(o.IOStreams.Out, "clusteroperators/%v -- Still %v, new reason - %v - %v\n", clusterOperatorName, conditionDescription, newCondition.Reason, strings.ReplaceAll(newCondition.Message, "\n", "\n   "))
+		case messageMinusConflicts(newCondition.Message) != messageMinusConflicts(oldCondition.Message):
+			fmt.Fprintf(o.IOStreams.Out, "clusteroperators/%v -- Still %v, new message - %v - %v\n", clusterOperatorName, conditionDescription, newCondition.Reason, strings.ReplaceAll(messageMinusConflicts(newCondition.Message), "\n", "\n   "))
+		}
+	}
+}
+
+func (o *MonitorCertificatesRuntime) describeOperator(clusterOperatorName string, newCondition, oldCondition *configv1.ClusterOperatorStatusCondition, conditionDescription string) {
+	if meaningfulChange(newCondition, oldCondition) {
+		switch {
+		case newCondition.Status != oldCondition.Status:
+			fmt.Fprintf(o.IOStreams.Out, "clusteroperators/%v -- %v - %v - %v\n", clusterOperatorName, conditionDescription, newCondition.Reason, strings.ReplaceAll(newCondition.Message, "\n", "\n   "))
+		case newCondition.Reason != oldCondition.Reason:
+			fmt.Fprintf(o.IOStreams.Out, "clusteroperators/%v -- Still %v, new reason - %v - %v\n", clusterOperatorName, conditionDescription, newCondition.Reason, strings.ReplaceAll(newCondition.Message, "\n", "\n   "))
+		case messageMinusConflicts(newCondition.Message) != messageMinusConflicts(oldCondition.Message):
+			fmt.Fprintf(o.IOStreams.Out, "clusteroperators/%v -- Still %v, new message - %v - %v\n", clusterOperatorName, conditionDescription, newCondition.Reason, strings.ReplaceAll(messageMinusConflicts(newCondition.Message), "\n", "\n   "))
+		}
+	}
+}
+
+func (o *MonitorCertificatesRuntime) handleClusterOperator(clusterOperator, oldClusterOperator *configv1.ClusterOperator) {
+	oldAvailable := FindStatusConditionOrSynthetic(oldClusterOperator.Status.Conditions, configv1.OperatorAvailable)
+	newAvailable := FindStatusConditionOrSynthetic(clusterOperator.Status.Conditions, configv1.OperatorAvailable)
+	oldDegraded := FindStatusConditionOrSynthetic(oldClusterOperator.Status.Conditions, configv1.OperatorDegraded)
+	newDegraded := FindStatusConditionOrSynthetic(clusterOperator.Status.Conditions, configv1.OperatorDegraded)
+	oldProgressing := FindStatusConditionOrSynthetic(oldClusterOperator.Status.Conditions, configv1.OperatorProgressing)
+	newProgressing := FindStatusConditionOrSynthetic(clusterOperator.Status.Conditions, configv1.OperatorProgressing)
+
+	availableChanged := meaningfulChange(newAvailable, oldAvailable)
+	degradedChanged := meaningfulChange(newDegraded, oldDegraded)
+	progressingChanged := meaningfulChange(newProgressing, oldProgressing)
+	meaningfulStatusChange := availableChanged || degradedChanged || progressingChanged
+	if !meaningfulStatusChange {
+		return
+	}
+
+	statusLines := []string{}
+	headerLine := ""
+
+	oldIsStable := oldAvailable.Status == configv1.ConditionTrue && oldDegraded.Status == configv1.ConditionFalse && oldProgressing.Status == configv1.ConditionFalse
+	newIsStable := newAvailable.Status == configv1.ConditionTrue && newDegraded.Status == configv1.ConditionFalse && newProgressing.Status == configv1.ConditionFalse
+	switch {
+	case oldIsStable && !newIsStable:
+		headerLine = fmt.Sprintf("clusteroperators/%v -- Destabilized", clusterOperator.Name)
+	case oldIsStable && newIsStable:
+		headerLine = fmt.Sprintf("clusteroperators/%v -- Stable", clusterOperator.Name)
+	case !oldIsStable && newIsStable:
+		headerLine = fmt.Sprintf("clusteroperators/%v -- Stabilized", clusterOperator.Name)
+	case !oldIsStable && !newIsStable:
+		headerLine = fmt.Sprintf("clusteroperators/%v -- Unstable", clusterOperator.Name)
+	}
+
+	if newAvailable.Status == configv1.ConditionTrue {
+		statusLines = append(statusLines, fmt.Sprintf("Available - %v", newAvailable.Reason))
+	} else {
+		statusLines = append(statusLines, fmt.Sprintf("Unavailable - %v", newAvailable.Reason))
+	}
+	if availableChanged {
+		lines := strings.Split(messageMinusConflicts(newAvailable.Message), "\n")
+		for _, line := range lines {
+			statusLines = append(statusLines, "    "+line)
+		}
+	}
+	if newDegraded.Status != configv1.ConditionTrue {
+		statusLines = append(statusLines, fmt.Sprintf("Not Degraded - %v", newDegraded.Reason))
+	} else {
+		statusLines = append(statusLines, fmt.Sprintf("Degraded - %v", newDegraded.Reason))
+	}
+	if degradedChanged {
+		lines := strings.Split(messageMinusConflicts(newDegraded.Message), "\n")
+		for _, line := range lines {
+			statusLines = append(statusLines, "    "+line)
+		}
+	}
+	if newProgressing.Status != configv1.ConditionTrue {
+		statusLines = append(statusLines, fmt.Sprintf("Not Progressing - %v", newProgressing.Reason))
+	} else {
+		statusLines = append(statusLines, fmt.Sprintf("Progressing - %v", newProgressing.Reason))
+	}
+	if progressingChanged {
+		lines := strings.Split(messageMinusConflicts(newProgressing.Message), "\n")
+		for _, line := range lines {
+			statusLines = append(statusLines, "    "+line)
+		}
+	}
+
+	statusMessage := strings.Join(statusLines, "\n    ")
+	fmt.Fprintf(o.IOStreams.Out, "%v\n    %v\n", headerLine, statusMessage)
+}
+
+func (o *MonitorCertificatesRuntime) deleteClusterOperator(obj interface{}) {
+	clusterOperator, ok := obj.(*configv1.ClusterOperator)
+	if !ok {
+		fmt.Fprint(o.IOStreams.ErrOut, "unexpected create obj %T", obj)
+	}
+
+	o.interestingClusterOperators.remove(clusterOperator.Name)
+}

--- a/pkg/cli/admin/ocpcertificates/monitorregeneration/command.go
+++ b/pkg/cli/admin/ocpcertificates/monitorregeneration/command.go
@@ -1,0 +1,92 @@
+package monitorregeneration
+
+import (
+	"context"
+
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
+
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/kubernetes"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+var (
+	monitorCertificatesLong = templates.LongDesc(`
+		Watch the platform certificates in the cluster.
+		
+		Experimental: This command is under active development and may change without notice.
+	`)
+
+	monitorCertificatesExample = templates.Examples(`
+		# Watch platform certificates.
+		oc adm ocp-certificates monitor-certificates
+	`)
+)
+
+type MonitorCertificatesOptions struct {
+	RESTClientGetter genericclioptions.RESTClientGetter
+
+	genericclioptions.IOStreams
+}
+
+func NewMonitorCertificatesOptions(restClientGetter genericclioptions.RESTClientGetter, streams genericclioptions.IOStreams) *MonitorCertificatesOptions {
+	return &MonitorCertificatesOptions{
+		RESTClientGetter: restClientGetter,
+
+		IOStreams: streams,
+	}
+}
+
+func NewCmdMonitorCertificates(restClientGetter genericclioptions.RESTClientGetter, streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewMonitorCertificatesOptions(restClientGetter, streams)
+
+	cmd := &cobra.Command{
+		Use:                   "monitor-certificates",
+		DisableFlagsInUseLine: true,
+		Short:                 i18n.T("Watch platform certificates."),
+		Long:                  monitorCertificatesLong,
+		Example:               monitorCertificatesExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			r, err := o.ToRuntime(args)
+			cmdutil.CheckErr(err)
+			cmdutil.CheckErr(r.Run(context.Background()))
+		},
+	}
+
+	o.AddFlags(cmd)
+
+	return cmd
+}
+
+// AddFlags registers flags for a cli
+func (o *MonitorCertificatesOptions) AddFlags(cmd *cobra.Command) {
+}
+
+func (o *MonitorCertificatesOptions) ToRuntime(args []string) (*MonitorCertificatesRuntime, error) {
+	clientConfig, err := o.RESTClientGetter.ToRESTConfig()
+	if err != nil {
+		return nil, err
+	}
+	kubeClient, err := kubernetes.NewForConfig(clientConfig)
+	if err != nil {
+		return nil, err
+	}
+	configClient, err := configclient.NewForConfig(clientConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := &MonitorCertificatesRuntime{
+		KubeClient:                  kubeClient,
+		ConfigClient:                configClient,
+		IOStreams:                   o.IOStreams,
+		interestingSecrets:          newNamespacedCache(),
+		interestingClusterOperators: newUnnamespacedCache(),
+	}
+
+	return ret, nil
+}

--- a/pkg/cli/admin/ocpcertificates/monitorregeneration/monitor.go
+++ b/pkg/cli/admin/ocpcertificates/monitorregeneration/monitor.go
@@ -1,0 +1,125 @@
+package monitorregeneration
+
+import (
+	"context"
+	"strings"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/tools/cache"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes"
+)
+
+type MonitorCertificatesRuntime struct {
+	KubeClient   kubernetes.Interface
+	ConfigClient configclient.Interface
+
+	genericclioptions.IOStreams
+
+	interestingSecrets          *namespacedCache
+	interestingClusterOperators *unnamespacedCache
+}
+
+type namespacedCache struct {
+	cache map[string]*unnamespacedCache
+}
+
+func newNamespacedCache() *namespacedCache {
+	return &namespacedCache{
+		cache: map[string]*unnamespacedCache{},
+	}
+}
+
+func (c *namespacedCache) get(namespace, name string) (runtime.Object, bool) {
+	next, ok := c.cache[namespace]
+	if !ok {
+		return nil, false
+	}
+	return next.get(name)
+}
+
+func (c *namespacedCache) upsert(namespace, name string, obj runtime.Object) {
+	if _, ok := c.cache[namespace]; !ok {
+		c.cache[namespace] = newUnnamespacedCache()
+	}
+	c.cache[namespace].upsert(name, obj)
+}
+
+func (c *namespacedCache) remove(namespace, name string) {
+	c.cache[namespace].remove(name)
+}
+
+type unnamespacedCache struct {
+	cache map[string]runtime.Object
+}
+
+func newUnnamespacedCache() *unnamespacedCache {
+	return &unnamespacedCache{
+		cache: map[string]runtime.Object{},
+	}
+}
+
+func (c *unnamespacedCache) get(name string) (runtime.Object, bool) {
+	ret, ok := c.cache[name]
+	return ret, ok
+}
+
+func (c *unnamespacedCache) upsert(name string, obj runtime.Object) {
+	c.cache[name] = obj
+}
+
+func (c *unnamespacedCache) remove(name string) {
+	delete(c.cache, name)
+}
+
+func (o *MonitorCertificatesRuntime) Run(ctx context.Context) error {
+	interestingNamespaces := sets.NewString("kube-system", "default", "openshift")
+	namespaces, err := o.KubeClient.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for _, namespace := range namespaces.Items {
+		if strings.HasPrefix(namespace.Name, "openshift-") {
+			interestingNamespaces.Insert(namespace.Name)
+		}
+	}
+
+	// we want to see every change, so we will wire up directly to a reflector (NOT to an informer) with a
+	// synthentic store that will allow us to watch.
+	// we create a separate list/watch for every namespace so that in large clusters we don't produce a surge of
+	// "list secrets in all namespaces".
+	// We expect connection drops as the kube-apiserver restarts, but we expect rapid reconnection.
+
+	for _, namespace := range interestingNamespaces.List() {
+		listWatch := cache.NewListWatchFromClient(o.KubeClient.CoreV1().RESTClient(), "secrets", namespace, fields.Everything())
+		customStore := newMonitoringStore(
+			[]objCreateFunc{o.createSecret},
+			[]objUpdateFunc{o.updateSecret},
+			[]objDeleteFunc{o.deleteSecret},
+		)
+		reflector := cache.NewReflector(listWatch, &corev1.Secret{}, customStore, 0)
+		go reflector.Run(ctx.Done())
+	}
+
+	listWatch := cache.NewListWatchFromClient(o.ConfigClient.ConfigV1().RESTClient(), "clusteroperators", "", fields.Everything())
+	customStore := newMonitoringStore(
+		[]objCreateFunc{o.createClusterOperator},
+		[]objUpdateFunc{o.updateClusterOperator},
+		[]objDeleteFunc{o.deleteClusterOperator},
+	)
+	reflector := cache.NewReflector(listWatch, &configv1.ClusterOperator{}, customStore, 0)
+	go reflector.Run(ctx.Done())
+
+	<-ctx.Done()
+	return nil
+}

--- a/pkg/cli/admin/ocpcertificates/monitorregeneration/monitor.go
+++ b/pkg/cli/admin/ocpcertificates/monitorregeneration/monitor.go
@@ -83,7 +83,7 @@ func (c *unnamespacedCache) remove(name string) {
 }
 
 func (o *MonitorCertificatesRuntime) Run(ctx context.Context) error {
-	interestingNamespaces := sets.NewString("kube-system", "default", "openshift")
+	interestingNamespaces := sets.NewString("kube-lease", "kube-public", "kube-system", "default", "openshift")
 	namespaces, err := o.KubeClient.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return err

--- a/pkg/cli/admin/ocpcertificates/monitorregeneration/monitoring_reflector_store.go
+++ b/pkg/cli/admin/ocpcertificates/monitorregeneration/monitoring_reflector_store.go
@@ -1,0 +1,164 @@
+package monitorregeneration
+
+import (
+	"fmt"
+	"strconv"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+)
+
+type objCreateFunc func(obj interface{}, isFirstSync bool)
+type objUpdateFunc func(obj, oldObj interface{})
+type objDeleteFunc func(obj interface{})
+
+type monitoringStore struct {
+	*cache.FakeCustomStore
+
+	addFunc func(obj interface{}, isReplace bool) error
+
+	// map event UIDs to the last resource version we observed, used to skip recording resources
+	// we've already recorded.
+	processedResourceUIDs map[types.UID]int
+	cacheOfNow            map[types.UID]interface{}
+}
+
+func newMonitoringStore(
+	createHandlers []objCreateFunc,
+	updateHandlers []objUpdateFunc,
+	deleteHandlers []objDeleteFunc,
+) *monitoringStore {
+	s := &monitoringStore{
+		FakeCustomStore:       &cache.FakeCustomStore{},
+		processedResourceUIDs: map[types.UID]int{},
+		cacheOfNow:            map[types.UID]interface{}{},
+	}
+
+	s.UpdateFunc = func(obj interface{}) error {
+		currentUID := uidOf(obj)
+		currentResourceVersion := resourceVersionAsInt(obj)
+		if s.processedResourceUIDs[currentUID] >= currentResourceVersion {
+			return nil
+		}
+
+		defer func() {
+			s.processedResourceUIDs[currentUID] = currentResourceVersion
+			s.cacheOfNow[currentUID] = obj
+		}()
+
+		oldObj, ok := s.cacheOfNow[currentUID]
+		if !ok {
+			fmt.Printf("#### missing object on update for %v\n", currentUID)
+			return nil
+		}
+
+		for _, updateHandler := range updateHandlers {
+			updateHandler(obj, oldObj)
+		}
+
+		return nil
+	}
+
+	s.addFunc = func(obj interface{}, isFirstSync bool) error {
+		currentUID := uidOf(obj)
+		currentResourceVersion := resourceVersionAsInt(obj)
+		if s.processedResourceUIDs[currentUID] >= currentResourceVersion {
+			return nil
+		}
+
+		defer func() {
+			s.processedResourceUIDs[currentUID] = currentResourceVersion
+			s.cacheOfNow[currentUID] = obj
+		}()
+
+		for _, createHandler := range createHandlers {
+			createHandler(obj, isFirstSync)
+		}
+
+		return nil
+	}
+
+	s.AddFunc = func(obj interface{}) error {
+		return s.addFunc(obj, false)
+	}
+
+	s.DeleteFunc = func(obj interface{}) error {
+		currentUID := uidOf(obj)
+		currentResourceVersion := resourceVersionAsInt(obj)
+		if s.processedResourceUIDs[currentUID] >= currentResourceVersion {
+			return nil
+		}
+
+		// clear values that have been deleted
+		defer func() {
+			delete(s.processedResourceUIDs, currentUID)
+			delete(s.cacheOfNow, currentUID)
+		}()
+
+		for _, deleteHandler := range deleteHandlers {
+			deleteHandler(obj)
+		}
+
+		return nil
+	}
+
+	isFirstSync := true
+	// ReplaceFunc called when we do our initial list on starting the reflector.
+	// This can do adds, updates, and deletes.
+	s.ReplaceFunc = func(items []interface{}, rv string) error {
+		defer func() {
+			isFirstSync = false
+		}()
+
+		newUids := map[types.UID]bool{}
+		for _, item := range items {
+			newUids[uidOf(item)] = true
+		}
+		deletedUIDs := map[types.UID]bool{}
+		for uid := range s.cacheOfNow {
+			if !newUids[uid] {
+				deletedUIDs[uid] = true
+			}
+		}
+
+		for _, obj := range items {
+			currentUID := uidOf(obj)
+
+			_, oldObjExists := s.cacheOfNow[currentUID]
+			switch {
+			case oldObjExists:
+				s.UpdateFunc(obj)
+			case deletedUIDs[currentUID]:
+				s.DeleteFunc(obj)
+			default:
+				s.addFunc(obj, isFirstSync)
+			}
+		}
+		return nil
+	}
+
+	return s
+}
+
+func resourceVersionAsInt(obj interface{}) int {
+	metadata, err := meta.Accessor(obj)
+	if err != nil {
+		panic(err)
+	}
+
+	asInt, err := strconv.ParseInt(metadata.GetResourceVersion(), 10, 64)
+	if err != nil {
+		panic(err)
+	}
+
+	return int(asInt)
+}
+
+func uidOf(obj interface{}) types.UID {
+	metadata, err := meta.Accessor(obj)
+	if err != nil {
+		panic(err)
+	}
+	return metadata.GetUID()
+}

--- a/pkg/cli/admin/ocpcertificates/monitorregeneration/secret.go
+++ b/pkg/cli/admin/ocpcertificates/monitorregeneration/secret.go
@@ -1,0 +1,144 @@
+package monitorregeneration
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/openshift/library-go/pkg/operator/certrotation"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (o *MonitorCertificatesRuntime) createSecret(obj interface{}, isFirstSync bool) {
+	secret, ok := obj.(*corev1.Secret)
+	if !ok {
+		fmt.Fprint(o.IOStreams.ErrOut, "unexpected create obj %T", obj)
+	}
+
+	if oldObj, _ := o.interestingSecrets.get(secret.Namespace, secret.Name); oldObj != nil {
+		o.updateSecret(obj, oldObj)
+		return
+	}
+
+	// not all replaces are the same.  we only really want to skip this on the first attempt
+	if !isFirstSync {
+		if isSAToken(secret) {
+			fmt.Fprintf(o.IOStreams.Out, "secrets/%v[%v] -- serviceaccount token created\n", secret.Name, secret.Namespace)
+		}
+		if isDockerPullSecret(secret) {
+			fmt.Fprintf(o.IOStreams.Out, "secrets/%v[%v] -- docker pull secret created\n", secret.Name, secret.Namespace)
+		}
+	}
+
+	o.interestingSecrets.upsert(secret.Namespace, secret.Name, secret)
+}
+
+func (o *MonitorCertificatesRuntime) updateSecret(obj, oldObj interface{}) {
+	secret, ok := obj.(*corev1.Secret)
+	if !ok {
+		fmt.Fprint(o.IOStreams.ErrOut, "unexpected update obj %T", obj)
+	}
+	defer o.interestingSecrets.upsert(secret.Namespace, secret.Name, secret)
+
+	oldSecret, ok := oldObj.(*corev1.Secret)
+	if !ok {
+		fmt.Fprint(o.IOStreams.ErrOut, "unexpected update oldObj %T", oldObj)
+	}
+
+	// we skip revisions because their information is not unique
+	if isForRevision(secret.OwnerReferences) {
+		return
+	}
+
+	o.handleTLSSecret(secret, oldSecret)
+}
+
+func (o *MonitorCertificatesRuntime) handleTLSSecret(secret, oldSecret *corev1.Secret) {
+	oldTLS, oldHasTLS := oldSecret.Data["tls.crt"]
+	newTLS, newHasTLS := secret.Data["tls.crt"]
+	if oldHasTLS && newHasTLS {
+		if !reflect.DeepEqual(oldTLS, newTLS) {
+			fmt.Fprintf(o.IOStreams.Out, "secrets/%v[%v] -- updated certificate, now expires at %v\n", secret.Name, secret.Namespace, secret.Annotations[certrotation.CertificateNotAfterAnnotation])
+		}
+	}
+
+	_, oldHasNotAfter := oldSecret.Annotations[certrotation.CertificateNotAfterAnnotation]
+	_, newHasNotAfter := secret.Annotations[certrotation.CertificateNotAfterAnnotation]
+	if oldHasNotAfter && newHasNotAfter {
+		oldRegenerating := oldSecret.Annotations[certrotation.CertificateNotAfterAnnotation] == "force-regeneration"
+		newRegenerating := secret.Annotations[certrotation.CertificateNotAfterAnnotation] == "force-regeneration"
+		switch {
+		case oldRegenerating && !newRegenerating:
+			fmt.Fprintf(o.IOStreams.Out, "secrets/%v[%v] -- finished regeneration\n", secret.Name, secret.Namespace)
+		case !oldRegenerating && newRegenerating:
+			fmt.Fprintf(o.IOStreams.Out, "secrets/%v[%v] -- started regeneration\n", secret.Name, secret.Namespace)
+		}
+	}
+}
+
+func (o *MonitorCertificatesRuntime) handleSAToken(secret, oldSecret *corev1.Secret) {
+	if isSAToken(secret) {
+		return
+	}
+
+	oldToken, oldHasToken := oldSecret.Data["token"]
+	newToken, newHasToken := secret.Data["token"]
+	switch {
+	case oldHasToken && !newHasToken:
+		fmt.Fprintf(o.IOStreams.Out, "secrets/%v[%v] -- serviceaccount token started regeneration\n", secret.Name, secret.Namespace)
+	case oldHasToken && newHasToken:
+		if !reflect.DeepEqual(newToken, oldToken) {
+			fmt.Fprintf(o.IOStreams.Out, "secrets/%v[%v] -- serviceaccount token updated\n", secret.Name, secret.Namespace)
+		}
+	case !oldHasToken && !newHasToken:
+	case !oldHasToken && newHasToken && len(newToken) > 0:
+		fmt.Fprintf(o.IOStreams.Out, "secrets/%v[%v] -- serviceaccount token finished regeneration\n", secret.Name, secret.Namespace)
+	}
+}
+
+func isSAToken(secret *corev1.Secret) bool {
+	if _, isSAToken := secret.Annotations["kubernetes.io/service-account.name"]; !isSAToken {
+		return false
+	}
+	if isDockerPullSecret(secret) {
+		return false
+	}
+	return true
+}
+
+func isDockerPullSecret(secret *corev1.Secret) bool {
+	if _, hasDockerCfg := secret.Data[".dockercfg"]; hasDockerCfg {
+		return true
+	}
+	if _, isDockerPullSecret := secret.Annotations["openshift.io/token-secret.name"]; isDockerPullSecret {
+		return true
+	}
+	return false
+}
+
+func isForRevision(ownerReferences []metav1.OwnerReference) bool {
+	for _, ownerReference := range ownerReferences {
+		if strings.HasPrefix(ownerReference.Name, "revision-status-") {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (o *MonitorCertificatesRuntime) deleteSecret(obj interface{}) {
+	secret, ok := obj.(*corev1.Secret)
+	if !ok {
+		fmt.Fprint(o.IOStreams.ErrOut, "unexpected create obj %T", obj)
+	}
+
+	if isSAToken(secret) {
+		fmt.Fprintf(o.IOStreams.Out, "secrets/%v[%v] -- serviceaccount token deleted\n", secret.Name, secret.Namespace)
+	}
+	if isDockerPullSecret(secret) {
+		fmt.Fprintf(o.IOStreams.Out, "secrets/%v[%v] -- docker pull secret deleted\n", secret.Name, secret.Namespace)
+	}
+
+	o.interestingSecrets.remove(secret.Namespace, secret.Name)
+}

--- a/pkg/cli/admin/ocpcertificates/ocp_certificates.go
+++ b/pkg/cli/admin/ocpcertificates/ocp_certificates.go
@@ -3,6 +3,8 @@ package ocpcertificates
 import (
 	"fmt"
 
+	"github.com/openshift/oc/pkg/cli/admin/ocpcertificates/monitorregeneration"
+
 	"github.com/openshift/oc/pkg/cli/admin/ocpcertificates/regeneratetoplevel"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -26,6 +28,7 @@ func NewCommandOCPCertificates(f kcmdutil.Factory, streams genericclioptions.IOS
 
 	cmds.AddCommand(
 		regeneratetoplevel.NewCmdRegenerateTopLevel(f, streams),
+		monitorregeneration.NewCmdMonitorCertificates(f, streams),
 	)
 
 	return cmds


### PR DESCRIPTION
This wires up a command `[deads@fedora oc]$ oc adm ocp-certificates monitor-certificates` that will set up watches on all openshift-* namespaces for secrets, configmaps, and clusteroperators.  It watches the diff to print out logical summaries of "important" changes so we can see if the operators are correctly regenerating.