### PR TITLE
add command to produce an updated CA bundle for trusting the kube-apiserver

### DIFF
--- a/pkg/cli/config/refreshcabundle/refresh_ca_bundle.go
+++ b/pkg/cli/config/refreshcabundle/refresh_ca_bundle.go
@@ -63,7 +63,10 @@ func NewCmdConfigRefreshCABundle(restClientGetter genericclioptions.RESTClientGe
 		Example:               setClusterExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(cmd))
-			cmdutil.CheckErr(o.Run(context.TODO()))
+			cmdutil.CheckErr(o.Validate())
+			r, err := o.ToRuntime()
+			cmdutil.CheckErr(err)
+			cmdutil.CheckErr(r.Run(context.TODO()))
 
 		},
 	}
@@ -73,22 +76,62 @@ func NewCmdConfigRefreshCABundle(restClientGetter genericclioptions.RESTClientGe
 	return cmd
 }
 
-func (o RefreshCABundleOptions) Run(ctx context.Context) error {
-	err := o.Validate()
-	if err != nil {
-		return err
+func (o *RefreshCABundleOptions) Complete(cmd *cobra.Command) error {
+	args := cmd.Flags().Args()
+	if len(args) > 1 {
+		return helpErrorf(cmd, "Unexpected args: %v", args)
 	}
 
+	if len(args) == 1 {
+		o.ClusterName = args[0]
+	}
+
+	return nil
+}
+
+func (o RefreshCABundleOptions) Validate() error {
+	return nil
+}
+
+func (o *RefreshCABundleOptions) ToRuntime() (*RefreshCABundleRuntime, error) {
 	clientConfig, err := o.RESTClientGetter.ToRESTConfig()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	kubeClient, err := kubernetes.NewForConfig(clientConfig)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	kubeAPIServerCABundleConfigMap, err := kubeClient.CoreV1().ConfigMaps("openshift-kube-controller-manager").Get(ctx, "serviceaccount-ca", metav1.GetOptions{})
+	ret := &RefreshCABundleRuntime{
+		KubeClient:                    kubeClient,
+		ConfigAccess:                  o.ConfigAccess,
+		ClusterName:                   o.ClusterName,
+		DryRun:                        o.DryRun,
+		IOStreams:                     o.IOStreams,
+		OriginalInsecureSkipTLSVerify: clientConfig.Insecure,
+	}
+
+	return ret, nil
+}
+
+type RefreshCABundleRuntime struct {
+	KubeClient kubernetes.Interface
+
+	ConfigAccess clientcmd.ConfigAccess
+	ClusterName  string
+
+	OriginalInsecureSkipTLSVerify bool
+
+	// for convenience. You can compare to an original by doing.
+	// oc config view --raw -o jsonpath='{.clusters[?(@.name == "the-name")].cluster.certificate-authority-data}' | base64 -d
+	DryRun bool
+
+	genericclioptions.IOStreams
+}
+
+func (r *RefreshCABundleRuntime) Run(ctx context.Context) error {
+	kubeAPIServerCABundleConfigMap, err := r.KubeClient.CoreV1().ConfigMaps("openshift-kube-controller-manager").Get(ctx, "serviceaccount-ca", metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("unable to read the CA bundle from the cluster: %w", err)
 	}
@@ -97,47 +140,54 @@ func (o RefreshCABundleOptions) Run(ctx context.Context) error {
 		return fmt.Errorf("cluster somehow missing the CA bundle: not an OCP cluster?")
 	}
 
-	if o.DryRun {
-		fmt.Fprintf(o.Out, caBundle)
+	if r.DryRun {
+		fmt.Fprintf(r.Out, caBundle)
 		return nil
 	}
 
-	config, err := o.ConfigAccess.GetStartingConfig()
+	config, err := r.ConfigAccess.GetStartingConfig()
 	if err != nil {
 		return err
 	}
 
 	// if we have no name specified, then choose the current
-	if len(o.ClusterName) == 0 {
+	if len(r.ClusterName) == 0 {
 		currContext, ok := config.Contexts[config.CurrentContext]
 		if !ok {
 			return fmt.Errorf("cannot determine which context to update")
 		}
-		o.ClusterName = currContext.Cluster
+		r.ClusterName = currContext.Cluster
 	}
 
-	startingStanza, exists := config.Clusters[o.ClusterName]
+	startingStanza, exists := config.Clusters[r.ClusterName]
 	if !exists {
 		return fmt.Errorf("cannot determine which context to update")
 	}
 
-	cluster, err := o.modifyCluster(*startingStanza, caBundle)
+	cluster, err := r.modifyCluster(*startingStanza, caBundle)
 	if err != nil {
 		return fmt.Errorf("failed to update CA bundle: %w", err)
 	}
-	config.Clusters[o.ClusterName] = cluster
+	config.Clusters[r.ClusterName] = cluster
 
-	if err := clientcmd.ModifyConfig(o.ConfigAccess, *config, true); err != nil {
+	if err := clientcmd.ModifyConfig(r.ConfigAccess, *config, true); err != nil {
 		return err
 	}
 
-	fmt.Fprintf(o.Out, "CA bundle for cluster %q updated.\n", o.ClusterName)
+	fmt.Fprintf(r.Out, "CA bundle for cluster %q updated.\n", r.ClusterName)
 
 	return nil
 }
 
-func (o *RefreshCABundleOptions) modifyCluster(existingCluster clientcmdapi.Cluster, caBundle string) (*clientcmdapi.Cluster, error) {
+func (r *RefreshCABundleRuntime) modifyCluster(existingCluster clientcmdapi.Cluster, caBundle string) (*clientcmdapi.Cluster, error) {
 	modifiedCluster := existingCluster
+
+	// if we don't have CA information and we are not using insecure, then we are relying on the system certs
+	connectionReliesOnSystemCertificates := len(modifiedCluster.CertificateAuthorityData) == 0 && len(modifiedCluster.CertificateAuthority) == 0 && !r.OriginalInsecureSkipTLSVerify
+	if connectionReliesOnSystemCertificates {
+		// if we are relying on system certs, we must not rewrite the CA bundle
+		return nil, fmt.Errorf("using system CA bundle to verify server, not allowing refresh to overwrite")
+	}
 
 	if len(modifiedCluster.CertificateAuthorityData) > 0 {
 		modifiedCluster.CertificateAuthorityData = []byte(caBundle)
@@ -154,24 +204,6 @@ func (o *RefreshCABundleOptions) modifyCluster(existingCluster clientcmdapi.Clus
 	}
 
 	return &modifiedCluster, nil
-}
-
-func (o *RefreshCABundleOptions) Complete(cmd *cobra.Command) error {
-	args := cmd.Flags().Args()
-	if len(args) > 1 {
-		return helpErrorf(cmd, "Unexpected args: %v", args)
-	}
-
-	if len(args) == 0 {
-		return nil
-	}
-
-	o.ClusterName = args[0]
-	return nil
-}
-
-func (o RefreshCABundleOptions) Validate() error {
-	return nil
 }
 
 func helpErrorf(cmd *cobra.Command, format string, args ...interface{}) error {

--- a/pkg/cli/config/refreshcabundle/refresh_ca_bundle.go
+++ b/pkg/cli/config/refreshcabundle/refresh_ca_bundle.go
@@ -1,0 +1,181 @@
+package refreshcabundle
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+type RefreshCABundleOptions struct {
+	RESTClientGetter genericclioptions.RESTClientGetter
+
+	ConfigAccess clientcmd.ConfigAccess
+	ClusterName  string
+
+	// for convenience. You can compare to an original by doing.
+	// oc config view --raw -o jsonpath='{.clusters[?(@.name == "the-name")].cluster.certificate-authority-data}' | base64 -d
+	DryRun bool
+
+	genericclioptions.IOStreams
+}
+
+var (
+	setClusterLong = templates.LongDesc(i18n.T(`
+		Update the CA bundle by reading the content from an OpenShift cluster.`))
+
+	setClusterExample = templates.Examples(`
+		# Refresh the CA bundle for the current context's cluster
+		oc config refresh-ca-bundle
+
+		# Refresh the CA bundle for the cluster named e2e in your kubeconfig
+		oc config refresh-ca-bundle e2e
+
+		# Print the CA bundle from the current OpenShift cluster's apiserver.
+		oc config refresh-ca-bundle --dry-run`)
+)
+
+func NewRefreshCABundleOptions(restClientGetter genericclioptions.RESTClientGetter, configAccess clientcmd.ConfigAccess, streams genericclioptions.IOStreams) *RefreshCABundleOptions {
+	return &RefreshCABundleOptions{
+		RESTClientGetter: restClientGetter,
+		ConfigAccess:     configAccess,
+		IOStreams:        streams,
+	}
+}
+
+func NewCmdConfigRefreshCABundle(restClientGetter genericclioptions.RESTClientGetter, configAccess clientcmd.ConfigAccess, streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewRefreshCABundleOptions(restClientGetter, configAccess, streams)
+
+	cmd := &cobra.Command{
+		Use:                   fmt.Sprintf("refresh-ca-bundle [NAME]"),
+		DisableFlagsInUseLine: true,
+		Short:                 i18n.T("Update the OpenShift CA bundle by contacting the apiserver."),
+		Long:                  setClusterLong,
+		Example:               setClusterExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(o.Complete(cmd))
+			cmdutil.CheckErr(o.Run(context.TODO()))
+
+		},
+	}
+
+	cmd.Flags().BoolVar(&o.DryRun, "dry-run", o.DryRun, "display the CA bundle, but don't make any changes to the kubeconfig")
+
+	return cmd
+}
+
+func (o RefreshCABundleOptions) Run(ctx context.Context) error {
+	err := o.Validate()
+	if err != nil {
+		return err
+	}
+
+	clientConfig, err := o.RESTClientGetter.ToRESTConfig()
+	if err != nil {
+		return err
+	}
+	kubeClient, err := kubernetes.NewForConfig(clientConfig)
+	if err != nil {
+		return err
+	}
+
+	kubeAPIServerCABundleConfigMap, err := kubeClient.CoreV1().ConfigMaps("openshift-kube-controller-manager").Get(ctx, "serviceaccount-ca", metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("unable to read the CA bundle from the cluster: %w", err)
+	}
+	caBundle := kubeAPIServerCABundleConfigMap.Data["ca-bundle.crt"]
+	if len(caBundle) == 0 {
+		return fmt.Errorf("cluster somehow missing the CA bundle: not an OCP cluster?")
+	}
+
+	if o.DryRun {
+		fmt.Fprintf(o.Out, caBundle)
+		return nil
+	}
+
+	config, err := o.ConfigAccess.GetStartingConfig()
+	if err != nil {
+		return err
+	}
+
+	// if we have no name specified, then choose the current
+	if len(o.ClusterName) == 0 {
+		currContext, ok := config.Contexts[config.CurrentContext]
+		if !ok {
+			return fmt.Errorf("cannot determine which context to update")
+		}
+		o.ClusterName = currContext.Cluster
+	}
+
+	startingStanza, exists := config.Clusters[o.ClusterName]
+	if !exists {
+		return fmt.Errorf("cannot determine which context to update")
+	}
+
+	cluster, err := o.modifyCluster(*startingStanza, caBundle)
+	if err != nil {
+		return fmt.Errorf("failed to update CA bundle: %w", err)
+	}
+	config.Clusters[o.ClusterName] = cluster
+
+	if err := clientcmd.ModifyConfig(o.ConfigAccess, *config, true); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(o.Out, "CA bundle for cluster %q updated.\n", o.ClusterName)
+
+	return nil
+}
+
+func (o *RefreshCABundleOptions) modifyCluster(existingCluster clientcmdapi.Cluster, caBundle string) (*clientcmdapi.Cluster, error) {
+	modifiedCluster := existingCluster
+
+	if len(modifiedCluster.CertificateAuthorityData) > 0 {
+		modifiedCluster.CertificateAuthorityData = []byte(caBundle)
+	}
+
+	if len(modifiedCluster.CertificateAuthority) > 0 {
+		fileInfo, err := os.Stat(modifiedCluster.CertificateAuthority)
+		if err != nil {
+			return nil, err
+		}
+		if err := os.WriteFile(fileInfo.Name(), []byte(caBundle), fileInfo.Mode()); err != nil {
+			return nil, err
+		}
+	}
+
+	return &modifiedCluster, nil
+}
+
+func (o *RefreshCABundleOptions) Complete(cmd *cobra.Command) error {
+	args := cmd.Flags().Args()
+	if len(args) > 1 {
+		return helpErrorf(cmd, "Unexpected args: %v", args)
+	}
+
+	if len(args) == 0 {
+		return nil
+	}
+
+	o.ClusterName = args[0]
+	return nil
+}
+
+func (o RefreshCABundleOptions) Validate() error {
+	return nil
+}
+
+func helpErrorf(cmd *cobra.Command, format string, args ...interface{}) error {
+	cmd.Help()
+	msg := fmt.Sprintf(format, args...)
+	return fmt.Errorf("%s", msg)
+}

--- a/pkg/cli/kubectlwrappers/ocp_config_command.go
+++ b/pkg/cli/kubectlwrappers/ocp_config_command.go
@@ -1,0 +1,22 @@
+package kubectlwrappers
+
+import (
+	"github.com/openshift/oc/pkg/cli/config/refreshcabundle"
+	cmdutil "github.com/openshift/oc/pkg/helpers/cmd"
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	kclientcmd "k8s.io/client-go/tools/clientcmd"
+	"k8s.io/kubectl/pkg/cmd/config"
+	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+// NewCmdConfig is a wrapper for the Kubernetes cli config command
+func NewCmdConfig(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+	pathOptions := kclientcmd.NewDefaultPathOptions()
+
+	configCommand := config.NewCmdConfig(pathOptions, streams)
+	configCommand.AddCommand(refreshcabundle.NewCmdConfigRefreshCABundle(f, pathOptions, streams))
+
+	return cmdutil.ReplaceCommandName("kubectl", "oc", templates.Normalize(configCommand))
+}

--- a/pkg/cli/kubectlwrappers/wrappers.go
+++ b/pkg/cli/kubectlwrappers/wrappers.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	kclientcmd "k8s.io/client-go/tools/clientcmd"
 	"k8s.io/kubectl/pkg/cmd/annotate"
 	"k8s.io/kubectl/pkg/cmd/apiresources"
 	"k8s.io/kubectl/pkg/cmd/apply"
@@ -16,7 +15,6 @@ import (
 	"k8s.io/kubectl/pkg/cmd/autoscale"
 	"k8s.io/kubectl/pkg/cmd/clusterinfo"
 	"k8s.io/kubectl/pkg/cmd/completion"
-	"k8s.io/kubectl/pkg/cmd/config"
 	"k8s.io/kubectl/pkg/cmd/cp"
 	kcreate "k8s.io/kubectl/pkg/cmd/create"
 	"k8s.io/kubectl/pkg/cmd/delete"
@@ -191,13 +189,6 @@ func NewCmdExplain(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cob
 // NewCmdEdit is a wrapper for the Kubernetes cli edit command
 func NewCmdEdit(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
 	return cmdutil.ReplaceCommandName("kubectl", "oc", templates.Normalize(edit.NewCmdEdit(f, streams)))
-}
-
-// NewCmdConfig is a wrapper for the Kubernetes cli config command
-func NewCmdConfig(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
-	pathOptions := kclientcmd.NewDefaultPathOptions()
-
-	return cmdutil.ReplaceCommandName("kubectl", "oc", templates.Normalize(config.NewCmdConfig(pathOptions, streams)))
 }
 
 // NewCmdCp is a wrapper for the Kubernetes cli cp command


### PR DESCRIPTION
Realistically the starting point will only be useable by cluster-admins.  The point of this is to use existing trust to get the updated/rotated trust during a rotation.

Convenient way to see the ca bundle in your kubeconfig

`oc config view --raw -o jsonpath='{.clusters[?(@.name == "the-name")].cluster.certificate-authority-data}' | base64 -d`

I got this compatible with general kubeconfigs.  Still needs good testing.  


/assign @stlaz 