### PR TITLE
Add a command to remove older trust

### DIFF
--- a/pkg/cli/admin/ocpcertificates/certregen/command.go
+++ b/pkg/cli/admin/ocpcertificates/certregen/command.go
@@ -25,10 +25,10 @@ var (
 
 	regenerateSignersExample = templates.Examples(`
 		# Regenerate all known signing certificates on the cluster.
-		oc adm certificates regenerate-signers -A secrets --all
+		oc adm certificates regenerate-signers -A --all
 
 		# Regenerate the signing certificate contained in a particular secret.
-		oc adm certificates regenerate-signers -n openshift-kube-apiserver-operator secrets/loadbalancer-serving-signer
+		oc adm certificates regenerate-signers -n openshift-kube-apiserver-operator loadbalancer-serving-signer
 	`)
 )
 
@@ -125,7 +125,7 @@ func (o *RegenerateCertificatesOptions) ToRuntime(args []string) (*RegenerateCer
 	if err != nil {
 		return nil, err
 	}
-	builder := o.ResourceBuilderFlags.ToBuilder(o.RESTClientGetter, args)
+	builder := o.ResourceBuilderFlags.ToBuilder(o.RESTClientGetter, []string{"secrets"})
 	clientConfig, err := o.RESTClientGetter.ToRESTConfig()
 	if err != nil {
 		return nil, err

--- a/pkg/cli/admin/ocpcertificates/certregen/leavesregen.go
+++ b/pkg/cli/admin/ocpcertificates/certregen/leavesregen.go
@@ -76,7 +76,11 @@ func (o *LeavesRegen) forceRegenerationOnSecret(objPrinter *objectPrinter, kubeC
 	secretToApply.WithAnnotations(map[string]string{
 		certrotation.CertificateNotAfterAnnotation: "force-regeneration",
 	})
+
 	finalObject, err := kubeClient.CoreV1().Secrets(secret.Namespace).Apply(context.TODO(), secretToApply, applyOptions)
+	if err != nil {
+		return err
+	}
 
 	// required for printing
 	finalObject.GetObjectKind().SetGroupVersionKind(secretKind)

--- a/pkg/cli/admin/ocpcertificates/certregen/leavesregen_test.go
+++ b/pkg/cli/admin/ocpcertificates/certregen/leavesregen_test.go
@@ -1,0 +1,171 @@
+package certregen
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+	"time"
+
+	"github.com/openshift/library-go/pkg/operator/certrotation"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/printers"
+	"k8s.io/client-go/kubernetes/fake"
+	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/client-go/util/keyutil"
+)
+
+func TestLeavesRegen_forceRegenerationOnSecret(t *testing.T) {
+	tests := []struct {
+		name           string
+		validBefore    *time.Time
+		inputSecret    *corev1.Secret
+		expectedUpdate bool
+		wantErr        string
+	}{
+		{
+			name:        "no annotations",
+			inputSecret: withAnnotationKeysRemoved(testLeafCertSecret(t), certrotation.CertificateIssuer, certrotation.CertificateNotBeforeAnnotation),
+		},
+		{
+			name:        "invalid cert", // TODO: should we force cert regen or do we assume the system fixes itself?
+			inputSecret: withCertKey(testLeafCertSecret(t), []byte("bogus")),
+			wantErr:     "error interpretting content: data does not contain any valid RSA or ECDSA certificates",
+		},
+		{
+			name:           "invalid key",
+			inputSecret:    withKeyKey(testLeafCertSecret(t), []byte("bogus key")),
+			expectedUpdate: true,
+		},
+		{
+			name:           "force rotation by time",
+			inputSecret:    testLeafCertSecret(t),
+			validBefore:    ptime(time.Now().Add(20 * time.Second)),
+			expectedUpdate: true,
+		},
+		{
+			name:        "force rotation by time - cert was not valid at that time",
+			inputSecret: testLeafCertSecret(t),
+			validBefore: ptime(time.Now().Add(-2 * time.Hour)), // certutil generates leaf certs with "NotBefore = now - 1*time.Hour"
+		},
+		{
+			name:           "should just rotate",
+			inputSecret:    testLeafCertSecret(t),
+			expectedUpdate: true,
+		},
+		{
+			name:        "cert is a CA cert",
+			inputSecret: withCACert(t, testLeafCertSecret(t)),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			secrets := []runtime.Object{}
+			if tt.inputSecret != nil {
+				secrets = append(secrets, tt.inputSecret.DeepCopy())
+			}
+			fakeClient := fake.NewSimpleClientset(secrets...)
+
+			o := &LeavesRegen{
+				ValidBefore: tt.validBefore,
+			}
+			err := o.forceRegenerationOnSecret(
+				&objectPrinter{
+					out:     genericclioptions.NewTestIOStreamsDiscard().Out,
+					printer: printers.ResourcePrinterFunc(testPrinter),
+				},
+				fakeClient, tt.inputSecret, false,
+			)
+			testErr(t, tt.wantErr, err)
+
+			var expectedSecret *corev1.Secret
+			if tt.expectedUpdate {
+				expectedSecret = &corev1.Secret{
+					TypeMeta: tt.inputSecret.TypeMeta,
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      tt.inputSecret.Name,
+						Namespace: tt.inputSecret.Namespace,
+						Annotations: map[string]string{
+							certrotation.CertificateNotAfterAnnotation: "force-regeneration",
+						},
+					},
+				}
+
+			}
+			testActions(t, expectedSecret, fakeClient.Actions())
+		})
+	}
+}
+
+func testLeafCertSecret(t *testing.T) *corev1.Secret {
+	certPEM, key, err := certutil.GenerateSelfSignedCertKey("somehost.host", nil, nil)
+	if err != nil {
+		t.Fatalf("failed to generate certificate: %v", err)
+	}
+
+	certs, err := certutil.ParseCertsPEM(certPEM)
+	if err != nil {
+		t.Fatalf("failed to parse PEM for a cert: %v", err)
+	}
+	cert := certs[0]
+
+	s := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-secret",
+			Namespace: "test-namespace",
+			Annotations: map[string]string{
+				certrotation.CertificateIssuer:              cert.Issuer.CommonName,
+				certrotation.CertificateNotBeforeAnnotation: cert.NotBefore.Format(time.RFC3339),
+			},
+		},
+		Type: corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			corev1.TLSCertKey:       certPEM,
+			corev1.TLSPrivateKeyKey: key,
+		},
+	}
+
+	return s
+}
+
+func withCACert(t *testing.T, s *corev1.Secret) *corev1.Secret {
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		t.Fatalf("failed to generate key")
+	}
+
+	cert, err := certutil.NewSelfSignedCACert(
+		certutil.Config{
+			CommonName: "test-ca",
+		},
+		key,
+	)
+
+	if err != nil {
+		t.Fatalf("failed to generate CA cert: %v", err)
+	}
+
+	certPEM, err := certutil.EncodeCertificates(cert)
+	if err != nil {
+		t.Fatalf("failed to encode cert into PEM: %v", err)
+	}
+
+	keyPEM := bytes.NewBuffer(make([]byte, 0))
+	if err := pem.Encode(keyPEM, &pem.Block{Type: keyutil.RSAPrivateKeyBlockType, Bytes: x509.MarshalPKCS1PrivateKey(key)}); err != nil {
+		t.Fatalf("failed to encode key into PEM: %v", err)
+	}
+
+	s.Data[corev1.TLSCertKey] = certPEM
+	s.Data[corev1.TLSPrivateKeyKey] = keyPEM.Bytes()
+
+	return s
+}

--- a/pkg/cli/admin/ocpcertificates/certregen/rootregen.go
+++ b/pkg/cli/admin/ocpcertificates/certregen/rootregen.go
@@ -76,6 +76,9 @@ func (o *RootsRegen) forceRegenerationOnSecret(objPrinter *objectPrinter, kubeCl
 		certrotation.CertificateNotAfterAnnotation: "force-regeneration",
 	})
 	finalObject, err := kubeClient.CoreV1().Secrets(secret.Namespace).Apply(context.TODO(), secretToApply, applyOptions)
+	if err != nil {
+		return err
+	}
 
 	// required for printing
 	finalObject.GetObjectKind().SetGroupVersionKind(secretKind)

--- a/pkg/cli/admin/ocpcertificates/certregen/rootregen_test.go
+++ b/pkg/cli/admin/ocpcertificates/certregen/rootregen_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 	"io"
 	"reflect"
 	"testing"
@@ -29,11 +30,12 @@ import (
 
 func TestRootsRegen_forceRegenerationOnSecret(t *testing.T) {
 	tests := []struct {
-		name           string
-		validBefore    *time.Time
-		inputSecret    *corev1.Secret
-		expectedUpdate bool
-		wantErr        string
+		name             string
+		validBefore      *time.Time
+		inputSecret      *corev1.Secret
+		expectedUpdate   bool
+		injectApplyError bool
+		wantErr          string
 	}{
 		{
 			name:        "no annotations",
@@ -69,6 +71,13 @@ func TestRootsRegen_forceRegenerationOnSecret(t *testing.T) {
 			name:        "cert is a leaf cert",
 			inputSecret: withLeafCert(t, testSecret(t)),
 		},
+		{
+			name:             "apply fails",
+			inputSecret:      testSecret(t),
+			injectApplyError: true,
+			wantErr:          "ha, you failed!",
+			expectedUpdate:   true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -77,6 +86,11 @@ func TestRootsRegen_forceRegenerationOnSecret(t *testing.T) {
 				secrets = append(secrets, tt.inputSecret.DeepCopy())
 			}
 			fakeClient := fake.NewSimpleClientset(secrets...)
+			if tt.injectApplyError {
+				fakeClient.PrependReactor("patch", "secrets", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, nil, fmt.Errorf("ha, you failed!")
+				})
+			}
 
 			o := &RootsRegen{
 				ValidBefore: tt.validBefore,

--- a/pkg/cli/admin/ocpcertificates/certregen/rootregen_test.go
+++ b/pkg/cli/admin/ocpcertificates/certregen/rootregen_test.go
@@ -114,7 +114,7 @@ func testPrinter(runtime.Object, io.Writer) error {
 }
 
 func testSecret(t *testing.T) *corev1.Secret {
-	key, err := rsa.GenerateKey(rand.Reader, 4096)
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		t.Fatalf("failed to generate key")
 	}

--- a/pkg/cli/admin/ocpcertificates/ocp_certificates.go
+++ b/pkg/cli/admin/ocpcertificates/ocp_certificates.go
@@ -6,6 +6,7 @@ import (
 	"github.com/openshift/oc/pkg/cli/admin/ocpcertificates/monitorregeneration"
 
 	"github.com/openshift/oc/pkg/cli/admin/ocpcertificates/certregen"
+	"github.com/openshift/oc/pkg/cli/admin/ocpcertificates/trustpurge"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -30,6 +31,7 @@ func NewCommandOCPCertificates(f kcmdutil.Factory, streams genericclioptions.IOS
 		certregen.NewCmdRegenerateTopLevel(f, streams),
 		certregen.NewCmdRegenerateLeaves(f, streams),
 		monitorregeneration.NewCmdMonitorCertificates(f, streams),
+		trustpurge.NewCmdRemoveOldTrust(f, streams),
 	)
 
 	return cmds

--- a/pkg/cli/admin/ocpcertificates/trustpurge/command.go
+++ b/pkg/cli/admin/ocpcertificates/trustpurge/command.go
@@ -1,0 +1,121 @@
+package trustpurge
+
+import (
+	"context"
+	"time"
+
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/kubernetes"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+var (
+	removeOldTrustLong = templates.LongDesc(`
+		TODO:
+	`)
+
+	removeOldTrustExample = templates.Examples(`
+		TODO:
+	`)
+)
+
+type RemoveOldTrustOptions struct {
+	RESTClientGetter     genericclioptions.RESTClientGetter
+	PrintFlags           *genericclioptions.PrintFlags
+	ResourceBuilderFlags *genericclioptions.ResourceBuilderFlags
+
+	CreatedBefore string
+
+	// TODO push this into genericclioptions
+	DryRun bool
+
+	genericclioptions.IOStreams
+}
+
+func NewRemoveOldTrustOptions(restClientGetter genericclioptions.RESTClientGetter, streams genericclioptions.IOStreams) *RemoveOldTrustOptions {
+	return &RemoveOldTrustOptions{
+		RESTClientGetter: restClientGetter,
+		PrintFlags:       genericclioptions.NewPrintFlags("trust purged"),
+		ResourceBuilderFlags: genericclioptions.NewResourceBuilderFlags().
+			WithLabelSelector("").
+			WithFieldSelector("").
+			WithAll(false).
+			WithAllNamespaces(false).
+			WithLocal(false).
+			WithLatest(),
+
+		IOStreams: streams,
+	}
+}
+
+func NewCmdRemoveOldTrust(restClientGetter genericclioptions.RESTClientGetter, streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewRemoveOldTrustOptions(restClientGetter, streams)
+
+	cmd := &cobra.Command{
+		Use:                   "remove-old-trust",
+		DisableFlagsInUseLine: true,
+		Short:                 i18n.T("Remove old CAs from ConfigMaps representing platform trust bundles in an OpenShift cluster"),
+		Long:                  removeOldTrustLong,
+		Example:               removeOldTrustExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			r, err := o.ToRuntime(args)
+
+			cmdutil.CheckErr(err)
+			cmdutil.CheckErr(r.Run(context.Background()))
+		},
+	}
+
+	o.AddFlags(cmd)
+
+	return cmd
+}
+
+// AddFlags registers flags for a cli
+func (o *RemoveOldTrustOptions) AddFlags(cmd *cobra.Command) {
+	o.PrintFlags.AddFlags(cmd)
+	o.ResourceBuilderFlags.AddFlags(cmd.Flags())
+
+	cmd.Flags().BoolVar(&o.DryRun, "dry-run", o.DryRun, "Set to true to use server-side dry run.")
+	cmd.Flags().StringVar(&o.CreatedBefore, "created-before", o.CreatedBefore, "Only remove CA certificates that were created before this date.  Format: 2023-06-05T14:44:06Z")
+}
+
+func (o *RemoveOldTrustOptions) ToRuntime(args []string) (*RemoveOldTrustRuntime, error) {
+	printer, err := o.PrintFlags.ToPrinter()
+	if err != nil {
+		return nil, err
+	}
+
+	builder := o.ResourceBuilderFlags.ToBuilder(o.RESTClientGetter, args)
+	clientConfig, err := o.RESTClientGetter.ToRESTConfig()
+	if err != nil {
+		return nil, err
+	}
+	kubeClient, err := kubernetes.NewForConfig(clientConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := &RemoveOldTrustRuntime{
+		ResourceFinder: builder,
+		KubeClient:     kubeClient,
+
+		dryRun: o.DryRun,
+
+		Printer:   printer,
+		IOStreams: o.IOStreams,
+	}
+
+	if len(o.CreatedBefore) > 0 {
+		createdBefore, err := time.Parse(time.RFC3339, o.CreatedBefore)
+		if err != nil {
+			return nil, err
+		}
+		ret.createdBefore = createdBefore
+	}
+
+	return ret, nil
+}

--- a/pkg/cli/admin/ocpcertificates/trustpurge/command.go
+++ b/pkg/cli/admin/ocpcertificates/trustpurge/command.go
@@ -106,7 +106,7 @@ func (o *RemoveOldTrustOptions) ToRuntime(args []string) (*RemoveOldTrustRuntime
 		exclude[excludedPair[0]].Insert(excludedPair[1])
 	}
 
-	builder := o.ResourceBuilderFlags.ToBuilder(o.RESTClientGetter, args)
+	builder := o.ResourceBuilderFlags.ToBuilder(o.RESTClientGetter, []string{"configmaps"})
 	clientConfig, err := o.RESTClientGetter.ToRESTConfig()
 	if err != nil {
 		return nil, err

--- a/pkg/cli/admin/ocpcertificates/trustpurge/trustpurge.go
+++ b/pkg/cli/admin/ocpcertificates/trustpurge/trustpurge.go
@@ -58,7 +58,7 @@ func (r *RemoveOldTrustRuntime) purgeTrustFromResourceInfo(info *resource.Info, 
 	if err != nil {
 		return err
 	}
-	// TODO: can we just hardcode the kind and not take it as an argument?
+
 	if configMapKind != info.Object.GetObjectKind().GroupVersionKind() {
 		return fmt.Errorf("command must only be pointed at configMaps")
 	}

--- a/pkg/cli/admin/ocpcertificates/trustpurge/trustpurge.go
+++ b/pkg/cli/admin/ocpcertificates/trustpurge/trustpurge.go
@@ -1,0 +1,133 @@
+package trustpurge
+
+import (
+	"context"
+	"crypto/x509"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/printers"
+	"k8s.io/cli-runtime/pkg/resource"
+	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
+	"k8s.io/client-go/kubernetes"
+	certutil "k8s.io/client-go/util/cert"
+
+	"github.com/openshift/library-go/pkg/operator/certrotation"
+)
+
+var (
+	configMapKind = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+)
+
+const (
+	RemoveOldTrustFieldManager = "remove-old-trust"
+)
+
+type RemoveOldTrustRuntime struct {
+	ResourceFinder genericclioptions.ResourceFinder
+	KubeClient     kubernetes.Interface
+
+	dryRun        bool
+	createdBefore time.Time
+
+	Printer printers.ResourcePrinter
+
+	genericclioptions.IOStreams
+}
+
+func (r *RemoveOldTrustRuntime) Run(ctx context.Context) error {
+	visitor := r.ResourceFinder.Do()
+
+	// TODO need to wire context through the visitorFns
+	err := visitor.Visit(r.purgeTrustFromResourceInfo)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *RemoveOldTrustRuntime) purgeTrustFromResourceInfo(info *resource.Info, err error) error {
+	if err != nil {
+		return err
+	}
+	// TODO: can we just hardcode the kind and not take it as an argument?
+	if configMapKind != info.Object.GetObjectKind().GroupVersionKind() {
+		return fmt.Errorf("command must only be pointed at configMaps")
+	}
+
+	uncastObj, ok := info.Object.(*unstructured.Unstructured)
+	if !ok {
+		return fmt.Errorf("not unstructured: %w", err)
+	}
+	configMap := &corev1.ConfigMap{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(uncastObj.Object, configMap); err != nil {
+		return fmt.Errorf("not a secret: %w", err)
+	}
+
+	return r.purgeTrustFromConfigMap(configMap)
+}
+
+func (r *RemoveOldTrustRuntime) purgeTrustFromConfigMap(cm *corev1.ConfigMap) error {
+	if cm.Labels[certrotation.ManagedCertificateTypeLabelName] != "ca-bundle" {
+		return nil
+	}
+
+	caBundle := cm.Data["ca-bundle.crt"]
+	if len(caBundle) == 0 {
+		// somebody was faster
+		fmt.Fprintf(r.ErrOut, "the 'ca-bundle.crt' key of %s/%s was empty", cm.Namespace, cm.Name)
+		return nil
+	}
+
+	newCMData := map[string]string{
+		"ca-bundle.crt": "",
+	}
+	if !r.createdBefore.IsZero() {
+		certs, err := certutil.ParseCertsPEM([]byte(caBundle))
+		if err != nil {
+			return fmt.Errorf("failed to parse certificates of the %s/%s configMap: %v", cm.Namespace, cm.Name, err)
+		}
+
+		newCerts := make([]*x509.Certificate, 0, len(certs))
+		for i, cert := range certs {
+			if cert.NotBefore.After(r.createdBefore) {
+				newCerts = append(newCerts, certs[i])
+			}
+		}
+
+		if len(certs) == len(newCerts) {
+			return nil
+		}
+		newPEMBundle, err := certutil.EncodeCertificates(newCerts...)
+		if err != nil {
+			return fmt.Errorf("failed to PEM-encode certs for configMap %s/%s: %v", cm.Namespace, cm.Name, err)
+		}
+		newCMData["ca-bundle.crt"] = string(newPEMBundle)
+	}
+
+	applyOptions := metav1.ApplyOptions{
+		Force:        true,
+		FieldManager: RemoveOldTrustFieldManager,
+	}
+
+	if r.dryRun {
+		applyOptions.DryRun = []string{metav1.DryRunAll}
+	}
+
+	applyCM := applycorev1.ConfigMap(cm.Name, cm.Namespace)
+	applyCM = applyCM.WithData(newCMData)
+
+	finalObj, err := r.KubeClient.CoreV1().ConfigMaps(cm.Namespace).Apply(context.TODO(), applyCM, applyOptions)
+	if err != nil {
+		return err
+	}
+
+	finalObj.GetObjectKind().SetGroupVersionKind(configMapKind)
+	return r.Printer.PrintObj(finalObj, r.Out)
+}

--- a/pkg/cli/admin/ocpcertificates/trustpurge/trustpurge_test.go
+++ b/pkg/cli/admin/ocpcertificates/trustpurge/trustpurge_test.go
@@ -112,6 +112,8 @@ func TestRemoveOldTrustRuntime_purgeTrustFromConfigMap(t *testing.T) {
 				apierrors.NewConflict(schema.GroupResource{}, "test-configmap", fmt.Errorf("oh no, a conflict")),
 				apierrors.NewConflict(schema.GroupResource{}, "test-configmap", fmt.Errorf("oh no, a conflict")),
 				apierrors.NewConflict(schema.GroupResource{}, "test-configmap", fmt.Errorf("oh no, a conflict")),
+				apierrors.NewConflict(schema.GroupResource{}, "test-configmap", fmt.Errorf("oh no, a conflict")),
+				apierrors.NewConflict(schema.GroupResource{}, "test-configmap", fmt.Errorf("oh no, a conflict")),
 			},
 			wantErr: true,
 		},

--- a/pkg/cli/admin/ocpcertificates/trustpurge/trustpurge_test.go
+++ b/pkg/cli/admin/ocpcertificates/trustpurge/trustpurge_test.go
@@ -1,0 +1,360 @@
+package trustpurge
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"reflect"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/printers"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/utils/diff"
+
+	"github.com/openshift/library-go/pkg/operator/certrotation"
+)
+
+func TestRemoveOldTrustRuntime_purgeTrustFromConfigMap(t *testing.T) {
+	testBundle := bundleCerts(
+		makeCert(t, "testsub", time.Now()),
+		makeCert(t, "testsub2", time.Now().Add(-10*time.Hour)),
+	)
+	testPruneTime := time.Now().Add(-5 * time.Minute)
+	prunedTestBundle, pruned, err := pruneCertBundle(testPruneTime, string(testBundle))
+	if err != nil {
+		t.Fatalf("failed to prepare pruned cert bundle for tests: %v", err)
+	}
+	if !pruned {
+		t.Fatalf("the test bundle should've gotten pruned")
+	}
+
+	tests := []struct {
+		name           string
+		inputCM        *corev1.ConfigMap
+		createdBefore  time.Time
+		expectedUpdate bool
+		expectedBundle string
+		injectErrors   []error
+		wantErr        bool
+	}{
+		{
+			name:    "not a ca-bundle CM - no labels",
+			inputCM: withManagedCertTypeLabel(testCM(), "-"),
+		},
+		{
+			name:    "not a ca-bundle CM - different cert type",
+			inputCM: withManagedCertTypeLabel(testCM(), "client-cert"),
+		},
+		{
+			name:           "basic - remove the ca-bundle",
+			inputCM:        testCM(),
+			expectedUpdate: true,
+		},
+		{
+			name:           "only the CA bundle gets updated",
+			inputCM:        withAdditionalData(testCM(), map[string]string{"key of fun": "funny value"}),
+			expectedUpdate: true,
+		},
+		{
+			name: "created before - all certs get pruned",
+			inputCM: withAdditionalData(testCM(), map[string]string{
+				"ca-bundle.crt": string(bundleCerts(
+					makeCert(t, "testsub", time.Now()),
+				)),
+			}),
+			createdBefore:  time.Now().Add(10 * time.Second),
+			expectedUpdate: true,
+		},
+		{
+			name: "created before - some certs remain after the pruning",
+			inputCM: withAdditionalData(
+				testCM(), map[string]string{
+					"ca-bundle.crt": string(testBundle),
+				},
+			),
+			createdBefore:  testPruneTime,
+			expectedBundle: prunedTestBundle,
+			expectedUpdate: true,
+		},
+		{
+			name:           "first update fails on conflict",
+			inputCM:        testCM(),
+			expectedUpdate: true,
+			injectErrors:   []error{apierrors.NewConflict(schema.GroupResource{}, "test-configmap", fmt.Errorf("oh no, a conflict"))},
+		},
+		{
+			name:           "all updates fail on conflict",
+			inputCM:        testCM(),
+			expectedUpdate: true,
+			injectErrors: []error{
+				apierrors.NewConflict(schema.GroupResource{}, "test-configmap", fmt.Errorf("oh no, a conflict")),
+				apierrors.NewConflict(schema.GroupResource{}, "test-configmap", fmt.Errorf("oh no, a conflict")),
+				apierrors.NewConflict(schema.GroupResource{}, "test-configmap", fmt.Errorf("oh no, a conflict")),
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := fake.NewSimpleClientset(tt.inputCM.DeepCopy())
+			if len(tt.injectErrors) > 0 {
+				i := 0
+				fakeClient.PrependReactor("update", "configmaps", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+					if i < len(tt.injectErrors) {
+						i++
+						return true, nil, tt.injectErrors[i-1]
+					}
+					return false, nil, nil
+				})
+			}
+
+			r := &RemoveOldTrustRuntime{
+				KubeClient:    fakeClient,
+				dryRun:        false,
+				createdBefore: tt.createdBefore,
+				Printer:       printers.NewDiscardingPrinter(),
+				IOStreams:     genericclioptions.NewTestIOStreamsDiscard(),
+			}
+			if err := r.purgeTrustFromConfigMap(tt.inputCM.DeepCopy()); (err != nil) != tt.wantErr {
+				t.Errorf("RemoveOldTrustRuntime.purgeTrustFromConfigMap() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			var expectedCM *corev1.ConfigMap
+			if tt.expectedUpdate {
+				expectedCM = tt.inputCM.DeepCopy()
+				expectedCM.Data["ca-bundle.crt"] = tt.expectedBundle
+			}
+			expectedActionsNum := len(tt.injectErrors)
+			if tt.expectedUpdate {
+				expectedActionsNum++
+			}
+			testActions(t, expectedCM, fakeClient.Actions())
+		})
+	}
+}
+
+func Test_pruneCertBundle(t *testing.T) {
+	tests := []struct {
+		name          string
+		createdBefore time.Time
+		bundlePEM     []byte
+		expectCNs     []string
+		expectPruned  bool
+		wantErr       bool
+	}{
+		{
+			name:          "bogus in the cert bundle",
+			createdBefore: time.Now().Add(-5 * time.Second),
+			bundlePEM: bundleCerts(
+				[]byte("how did this get here"),
+			),
+			expectPruned: false,
+			wantErr:      true,
+		},
+		{
+			name:          "single cert, don't remove",
+			createdBefore: time.Now().Add(-5 * time.Minute),
+			bundlePEM: bundleCerts(
+				makeCert(t, "test1", time.Now()),
+			),
+			expectCNs:    []string{"test1"},
+			expectPruned: false,
+			wantErr:      false,
+		},
+		{
+			name:          "single cert, remove it",
+			createdBefore: time.Now().Add(5 * time.Minute),
+			bundlePEM: bundleCerts(
+				makeCert(t, "test1", time.Now()),
+			),
+			expectPruned: true,
+			wantErr:      false,
+		},
+		{
+			name:          "mutliple certs, all good",
+			createdBefore: time.Now().Add(-5 * time.Minute),
+			bundlePEM: bundleCerts(
+				makeCert(t, "test1", time.Now()),
+				makeCert(t, "test2", time.Now().Add(5*time.Hour)),
+				makeCert(t, "test3", time.Now().Add(-5*time.Second)),
+				makeCert(t, "test4", time.Now().Add(852*time.Hour*24)),
+			),
+			expectCNs:    []string{"test1", "test2", "test3", "test4"},
+			expectPruned: false,
+			wantErr:      false,
+		},
+		{
+			name:          "mutliple certs, prune some",
+			createdBefore: time.Now().Add(-5 * time.Minute),
+			bundlePEM: bundleCerts(
+				makeCert(t, "test1", time.Now()),
+				makeCert(t, "test2", time.Now().Add(-7*time.Minute)),
+				makeCert(t, "test3", time.Now().Add(-5*time.Second)),
+				makeCert(t, "test4", time.Now().Add(-4*time.Hour)),
+			),
+			expectCNs:    []string{"test1", "test3"},
+			expectPruned: true,
+			wantErr:      false,
+		},
+		{
+			name:          "mutliple certs, prune all",
+			createdBefore: time.Now().Add(10 * time.Minute),
+			bundlePEM: bundleCerts(
+				makeCert(t, "test1", time.Now()),
+				makeCert(t, "test2", time.Now().Add(-7*time.Minute)),
+				makeCert(t, "test3", time.Now().Add(-5*time.Second)),
+				makeCert(t, "test4", time.Now().Add(-4*time.Hour)),
+			),
+			expectPruned: true,
+			wantErr:      false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			got, gotPruned, err := pruneCertBundle(tt.createdBefore, string(tt.bundlePEM))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("pruneCertBundle() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			var gotSubjects []string
+			if len(got) > 0 {
+				gotCerts, err := certutil.ParseCertsPEM([]byte(got))
+				if err != nil {
+					t.Fatalf("failed to parse returned PEM bundle: %v", err)
+				}
+
+				for _, c := range gotCerts {
+					gotSubjects = append(gotSubjects, c.Subject.CommonName)
+				}
+			}
+
+			if !reflect.DeepEqual(gotSubjects, tt.expectCNs) {
+				t.Errorf("pruneCertBundle() got = %v, want %v", gotSubjects, tt.expectCNs)
+			}
+			if gotPruned != tt.expectPruned {
+				t.Errorf("pruneCertBundle() gotPruned = %v, want %v", gotPruned, tt.expectPruned)
+			}
+		})
+	}
+}
+
+func makeCert(t *testing.T, cn string, issuedOn time.Time) []byte {
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	tmpl := x509.Certificate{
+		SerialNumber: new(big.Int).SetInt64(0),
+		Subject: pkix.Name{
+			CommonName: cn,
+		},
+		NotBefore:             issuedOn.UTC(),
+		NotAfter:              issuedOn.Add(365 * 24 * time.Hour).UTC(),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	certDERBytes, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, key.Public(), key)
+	if err != nil {
+		t.Fatalf("failed to create a certificate: %v", err)
+	}
+
+	certBytes := bytes.NewBuffer([]byte{})
+	if err := pem.Encode(certBytes, &pem.Block{Type: "CERTIFICATE", Bytes: certDERBytes}); err != nil {
+		t.Fatalf("failed to PEM-encode certificate: %v", err)
+	}
+
+	return certBytes.Bytes()
+}
+
+func bundleCerts(certs ...[]byte) []byte {
+	var finalBundle []byte
+	for _, c := range certs {
+		finalBundle = append(finalBundle, c...)
+		finalBundle = append(finalBundle, '\n')
+	}
+	return finalBundle
+}
+
+func testCM() *corev1.ConfigMap {
+	cm := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-configmap",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				certrotation.ManagedCertificateTypeLabelName: "ca-bundle",
+			},
+		},
+		Data: map[string]string{
+			"ca-bundle.crt": "A bundled CA chain would normally live here",
+		},
+	}
+
+	return cm
+}
+
+func withManagedCertTypeLabel(cm *corev1.ConfigMap, val string) *corev1.ConfigMap {
+	if val == "-" {
+		delete(cm.Labels, certrotation.ManagedCertificateTypeLabelName)
+	} else {
+		cm.Labels[certrotation.ManagedCertificateTypeLabelName] = val
+	}
+	return cm
+}
+
+func withAdditionalData(cm *corev1.ConfigMap, data map[string]string) *corev1.ConfigMap {
+	for k, v := range data {
+		cm.Data[k] = v
+	}
+	return cm
+}
+
+func testActions(t *testing.T, expectedCM *corev1.ConfigMap, clientActions []clienttesting.Action) {
+	if expectedCM == nil {
+		if len(clientActions) != 0 {
+			t.Fatalf("no action expected, but got: %v", clientActions)
+		}
+		return
+	}
+
+	if len(clientActions) == 0 {
+		t.Fatalf("missing expected action")
+	}
+
+	action, ok := clientActions[0].(clienttesting.UpdateAction)
+	if !ok {
+		t.Fatalf("the action was not update: %v", clientActions[0])
+	}
+
+	actualCM, ok := action.GetObject().(*corev1.ConfigMap)
+	if !ok {
+		t.Fatalf("the updated object was not a configMap: %v", actualCM)
+	}
+	if !equality.Semantic.DeepEqual(expectedCM, actualCM) {
+		t.Logf("actual %v", actualCM)
+		t.Fatalf("unexpected diff: %v", diff.ObjectDiff(expectedCM, actualCM))
+	}
+}


### PR DESCRIPTION
Adds the `oc adm ocp-certificates remove-old-trust` command.

TODO:
- [x] add an easy way to exclude certain CMs
- [x] add unit tests
- [ ] test to see if it works

/assign @deads2k 

built on top of https://github.com/openshift/oc/pull/1443