### PR TITLE
Minor updates to CLI help text

### DIFF
--- a/pkg/cli/admin/groups/sync/prune.go
+++ b/pkg/cli/admin/groups/sync/prune.go
@@ -37,13 +37,13 @@ var (
 		# Prune all orphaned groups
 		oc adm %[1]s --sync-config=/path/to/ldap-sync-config.yaml --confirm
 
-		# Prune all orphaned groups except the ones from the blacklist file
-		oc adm %[1]s --blacklist=/path/to/blacklist.txt --sync-config=/path/to/ldap-sync-config.yaml --confirm
+		# Prune all orphaned groups except the ones from the denylist file
+		oc adm %[1]s --blacklist=/path/to/denylist.txt --sync-config=/path/to/ldap-sync-config.yaml --confirm
 
-		# Prune all orphaned groups from a list of specific groups specified in a whitelist file
-		oc adm %[1]s --whitelist=/path/to/whitelist.txt --sync-config=/path/to/ldap-sync-config.yaml --confirm
+		# Prune all orphaned groups from a list of specific groups specified in an allowlist file
+		oc adm %[1]s --whitelist=/path/to/allowlist.txt --sync-config=/path/to/ldap-sync-config.yaml --confirm
 
-		# Prune all orphaned groups from a list of specific groups specified in a whitelist
+		# Prune all orphaned groups from a list of specific groups specified in a list
 		oc adm %[1]s groups/group_name groups/other_name --sync-config=/path/to/ldap-sync-config.yaml --confirm
 	`)
 )

--- a/pkg/cli/admin/groups/sync/sync.go
+++ b/pkg/cli/admin/groups/sync/sync.go
@@ -54,8 +54,8 @@ var (
 		# Sync all groups except the ones from the blacklist file with an LDAP server
 		oc adm groups sync --blacklist=/path/to/blacklist.txt --sync-config=/path/to/ldap-sync-config.yaml --confirm
 
-		# Sync specific groups specified in a whitelist file with an LDAP server
-		oc adm groups sync --whitelist=/path/to/whitelist.txt --sync-config=/path/to/sync-config.yaml --confirm
+		# Sync specific groups specified in an allowlist file with an LDAP server
+		oc adm groups sync --whitelist=/path/to/allowlist.txt --sync-config=/path/to/sync-config.yaml --confirm
 
 		# Sync all OpenShift groups that have been synced previously with an LDAP server
 		oc adm groups sync --type=openshift --sync-config=/path/to/ldap-sync-config.yaml --confirm

--- a/pkg/cli/admin/migrate/icsp/icsp.go
+++ b/pkg/cli/admin/migrate/icsp/icsp.go
@@ -27,7 +27,7 @@ var (
 	`)
 
 	internalMigrateICSPExample = templates.Examples(`
-	# update the imagecontentsourcepolicy.yaml to new imagedigestmirrorset file under directory mydir
+	# Update the imagecontentsourcepolicy.yaml file to a new imagedigestmirrorset file under the mydir directory
 	oc adm migrate icsp imagecontentsourcepolicy.yaml --dest-dir mydir
 `)
 )
@@ -43,7 +43,7 @@ func NewCmdMigrateICSP(f kcmdutil.Factory, streams genericclioptions.IOStreams) 
 	o := NewMigrateICSPOptions(streams)
 	cmd := &cobra.Command{
 		Use:     "icsp",
-		Short:   "Update imagecontentsourcepolicy file(s) to imagedigestmirrorset file(s).",
+		Short:   "Update imagecontentsourcepolicy file(s) to imagedigestmirrorset file(s)",
 		Long:    internalMigrateICSPLong,
 		Example: internalMigrateICSPExample,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cli/admin/mustgather/mustgather.go
+++ b/pkg/cli/admin/mustgather/mustgather.go
@@ -72,7 +72,7 @@ var (
 		# Gather information using a specific image stream plug-in
 		  oc adm must-gather --image-stream=openshift/must-gather:latest
 
-		# Gather information using a specific image, command, and pod-dir
+		# Gather information using a specific image, command, and pod directory
 		  oc adm must-gather --image=my/image:tag --source-dir=/pod/directory -- myspecial-command.sh
 	`)
 )

--- a/pkg/cli/admin/prune/images/images.go
+++ b/pkg/cli/admin/prune/images/images.go
@@ -95,7 +95,7 @@ var (
 	  # To actually perform the prune operation, the confirm flag must be appended
 	  oc adm prune images --prune-over-size-limit --confirm
 
-	  # Force the insecure http protocol with the particular registry host name
+	  # Force the insecure HTTP protocol with the particular registry host name
 	  oc adm prune images --registry-url=http://registry.example.org --confirm
 
 	  # Force a secure connection with a custom certificate authority to the particular registry host name

--- a/pkg/cli/admin/release/extract.go
+++ b/pkg/cli/admin/release/extract.go
@@ -104,7 +104,7 @@ func NewExtract(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.
 			oc adm release extract --credentials-requests --cloud=aws
 
 			# Use git to check out the source code for the current cluster release to DIR from linux/s390x image
-			# Note: Wildcard filter is not supported. Pass a single os/arch to extract
+			# Note: Wildcard filter is not supported; pass a single os/arch to extract
 			oc adm release extract --git=DIR quay.io/openshift-release-dev/ocp-release:4.11.2 --filter-by-os=linux/s390x
 		`),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cli/admin/release/info.go
+++ b/pkg/cli/admin/release/info.go
@@ -113,7 +113,7 @@ func NewInfo(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Com
 			oc adm release info quay.io/openshift-release-dev/ocp-release:4.11.2 --pullspecs
 
 			# Show information about linux/s390x image
-			# Note: Wildcard filter is not supported. Pass a single os/arch to extract
+			# Note: Wildcard filter is not supported; pass a single os/arch to extract
 			oc adm release info quay.io/openshift-release-dev/ocp-release:4.11.2 --filter-by-os=linux/s390x
 
 		`),

--- a/pkg/cli/admin/release/new.go
+++ b/pkg/cli/admin/release/new.go
@@ -96,7 +96,7 @@ func NewRelease(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.
 			registry.example.com.
 		`),
 		Example: templates.Examples(`
-			# Create a release from the latest origin images and push to a DockerHub repo
+			# Create a release from the latest origin images and push to a DockerHub repository
 			oc adm release new --from-image-stream=4.11 -n origin --to-image docker.io/mycompany/myrepo:latest
 
 			# Create a new release with updated metadata from a previous release

--- a/pkg/cli/admin/upgrade/upgrade.go
+++ b/pkg/cli/admin/upgrade/upgrade.go
@@ -36,7 +36,7 @@ const (
 )
 
 var upgradeExample = templates.Examples(`
-	# Review the available cluster updates
+	# View the update status and available cluster updates
 	oc adm upgrade
 
 	# Update to the latest version

--- a/pkg/cli/image/append/append.go
+++ b/pkg/cli/image/append/append.go
@@ -87,7 +87,7 @@ var (
 		oc image append --from-dir v2 --to myregistry.com/myimage:latest layer.tar.gz
 
 		# Add a new layer to a multi-architecture image for an os/arch that is different from the system's os/arch
-		# Note: Wildcard filter is not supported with append. Pass a single os/arch to append (when --keep-manifest-list is not specified)
+		# Note: Wildcard filter is not supported with append; pass a single os/arch to append (when --keep-manifest-list is not specified)
 		oc image append --from docker.io/library/busybox:latest --filter-by-os=linux/s390x --to myregistry.com/myimage:latest layer.tar.gz
 
 		# Add a new layer to a multi-architecture image for all the os/arch manifests when keep-manifest-list is specified

--- a/pkg/cli/image/extract/extract.go
+++ b/pkg/cli/image/extract/extract.go
@@ -71,7 +71,7 @@ var (
 		oc image extract docker.io/library/busybox:latest --path /:/tmp/busybox
 
 		# Extract the busybox image into the current directory for linux/s390x platform
-		# Note: Wildcard filter is not supported with extract. Pass a single os/arch to extract
+		# Note: Wildcard filter is not supported with extract; pass a single os/arch to extract
 		oc image extract docker.io/library/busybox:latest --filter-by-os=linux/s390x
 
 		# Extract a single file from the image into the current directory

--- a/pkg/cli/importimage/importimage.go
+++ b/pkg/cli/importimage/importimage.go
@@ -52,7 +52,7 @@ var (
 		# Update imported data for all tags in an existing image stream
 		oc import-image mystream --all
 
-		# Update imported data for a tag which points to a manifest list to include the full manifest list
+		# Update imported data for a tag that points to a manifest list to include the full manifest list
 		oc import-image mystream --import-mode=PreserveOriginal
 
 		# Import all tags into a new image stream

--- a/pkg/cli/rsh/rsh.go
+++ b/pkg/cli/rsh/rsh.go
@@ -57,7 +57,7 @@ var (
 		oc rsh dc/docker-registry cat config.yml
 
 		# Open a shell session on the container named 'index' inside a pod of your job
-		oc rsh -c index job/sheduled
+		oc rsh -c index job/scheduled
 	`)
 )
 

--- a/pkg/cli/set/set.go
+++ b/pkg/cli/set/set.go
@@ -86,10 +86,10 @@ var (
 Update existing container image(s) of resources.`)
 
 	setImageExample = ktemplates.Examples(`
-	  # Set a deployment configs's nginx container image to 'nginx:1.9.1', and its busybox container image to 'busybox'.
+	  # Set a deployment config's nginx container image to 'nginx:1.9.1', and its busybox container image to 'busybox'.
 	  oc set image dc/nginx busybox=busybox nginx=nginx:1.9.1
 
-	  # Set a deployment configs's app container image to the image referenced by the imagestream tag 'openshift/ruby:2.3'.
+	  # Set a deployment config's app container image to the image referenced by the imagestream tag 'openshift/ruby:2.3'.
 	  oc set image dc/myapp app=openshift/ruby:2.3 --source=imagestreamtag
 
 	  # Update all deployments' and rc's nginx container's image to 'nginx:1.9.1'
@@ -98,7 +98,7 @@ Update existing container image(s) of resources.`)
 	  # Update image of all containers of daemonset abc to 'nginx:1.9.1'
 	  oc set image daemonset abc *=nginx:1.9.1
 
-	  # Print result (in yaml format) of updating nginx container image from local file, without hitting the server
+	  # Print result (in YAML format) of updating nginx container image from local file, without hitting the server
 	  oc set image -f path/to/file.yaml nginx=nginx:1.9.1 --local -o yaml`)
 )
 

--- a/pkg/cli/set/volume.go
+++ b/pkg/cli/set/volume.go
@@ -75,7 +75,7 @@ var (
 		# /var/lib/myapp
 		oc set volume dc/myapp --add --mount-path=/var/lib/myapp
 
-		# Use an existing persistent volume claim (pvc) to overwrite an existing volume 'v1'
+		# Use an existing persistent volume claim (PVC) to overwrite an existing volume 'v1'
 		oc set volume dc/myapp --add --name=v1 -t pvc --claim-name=pvc1 --overwrite
 
 		# Remove volume 'v1' from deployment config 'myapp'


### PR DESCRIPTION
A few help text updates for grammar/consistency, mainly targeted at content that also shows up in the OCP CLI reference docs.