### PR TITLE
tweaks needed for wait

### DIFF
--- a/pkg/cli/clusteroperator/waitforstable/command.go
+++ b/pkg/cli/clusteroperator/waitforstable/command.go
@@ -112,6 +112,8 @@ func (o WaitForStableOptions) Run(ctx context.Context) error {
 	previouslyUnstableOperators := sets.NewString()
 	operatorInstabilityStartTime := map[string]time.Time{}
 	waitErr := wait.PollImmediateUntilWithContext(ctx, o.waitInterval, func(waitCtx context.Context) (bool, error) {
+		defer fmt.Fprintln(o.Out)
+
 		operators, err := o.configClient.ClusterOperators().List(waitCtx, metav1.ListOptions{})
 		if err != nil {
 			fmt.Fprintf(o.ErrOut, "failed to list clusteroperators: %v", err)


### PR DESCRIPTION
A running PR for today that will gain commits as I find things worthy of updates.


```
[deads@fedora oc]$ oc adm ocp-certificates regenerate-top-level -n openshift-kube-apiserver-operator secrets kube-apiserver-to-kubelet-signer kube-control-plane-signer  loadbalancer-serving-signer  localhost-serving-signer next-bound-service-account-signing-key service-network-serving-signer
secret/kube-apiserver-to-kubelet-signer regeneration set
secret/kube-control-plane-signer regeneration set
secret/loadbalancer-serving-signer regeneration set
secret/localhost-serving-signer regeneration set
secret/service-network-serving-signer regeneration set
[deads@fedora oc]$ oc adm clusteroperator wait-for-stable-cluster --minumum-stable-period=60s
All clusteroperators became stable at 2023-06-13T10:05:27-04:00
clusteroperators/openshift-controller-manager is unavailable and progressing at 2023-06-13T10:05:38-04:00
clusteroperators/openshift-controller-manager is still unavailable and progressing after 9.941062178s
clusteroperators/openshift-controller-manager is still progressing after 20.190692187s
clusteroperators/kube-scheduler became progressing at 2023-06-13T10:06:08-04:00
clusteroperators/openshift-controller-manager is still progressing after 30.018460745s
clusteroperators/kube-controller-manager became progressing at 2023-06-13T10:06:18-04:00
clusteroperators/kube-scheduler is still progressing after 9.997427216s
clusteroperators/openshift-controller-manager is still progressing after 40.015887961s

```