### PR TITLE
Add tls-server-name when property exists in kubeconfig

### DIFF
--- a/pkg/helpers/kubeconfig/smart_merge.go
+++ b/pkg/helpers/kubeconfig/smart_merge.go
@@ -75,6 +75,10 @@ func CreateConfig(namespace, userName string, clientCfg *restclient.Config) (*cl
 	cluster := clientcmdapi.NewCluster()
 	cluster.Server = clientCfg.Host
 
+	if len(clientCfg.TLSClientConfig.ServerName) > 0 {
+		cluster.TLSServerName = clientCfg.TLSClientConfig.ServerName
+	}
+
 	if clientCfg.Proxy != nil {
 		req, err := http.NewRequest("", clientCfg.Host, nil)
 		if err != nil {


### PR DESCRIPTION
Ran into #1457 today when using tsh, kubectl, and oc. I was able to track this down and this patch was able to fix the missing field issue.