### PR TITLE
allow running a command while the kubelet is off

### DIFF
--- a/pkg/cli/clusteroperator/restartkubelet/command.go
+++ b/pkg/cli/clusteroperator/restartkubelet/command.go
@@ -37,6 +37,8 @@ var (
 type RestartKubeletOptions struct {
 	PerNodePodOptions *pernodepod.PerNodePodOptions
 
+	CommandWhileKubeletIsOff string
+
 	genericclioptions.IOStreams
 }
 
@@ -80,6 +82,8 @@ func NewCmdRestartKubelet(restClientGetter genericclioptions.RESTClientGetter, s
 // AddFlags registers flags for a cli
 func (o *RestartKubeletOptions) AddFlags(cmd *cobra.Command) {
 	o.PerNodePodOptions.AddFlags(cmd)
+
+	cmd.Flags().StringVar(&o.CommandWhileKubeletIsOff, "command", o.CommandWhileKubeletIsOff, "command to run after the kubelet stops, before the kubelet starts.")
 }
 
 func (o *RestartKubeletOptions) ToRuntime(args []string) (*RestartKubeletRuntime, error) {
@@ -88,6 +92,7 @@ func (o *RestartKubeletOptions) ToRuntime(args []string) (*RestartKubeletRuntime
 		return nil, err
 	}
 	return &RestartKubeletRuntime{
-		PerNodePodRuntime: perNodePodRuntime,
+		PerNodePodRuntime:        perNodePodRuntime,
+		CommandWhileKubeletIsOff: o.CommandWhileKubeletIsOff,
 	}, nil
 }

--- a/pkg/cli/clusteroperator/restartkubelet/command.go
+++ b/pkg/cli/clusteroperator/restartkubelet/command.go
@@ -46,7 +46,7 @@ func NewRestartKubelet(restClientGetter genericclioptions.RESTClientGetter, stre
 	return &RestartKubeletOptions{
 		PerNodePodOptions: pernodepod.NewPerNodePodOptions(
 			"openshift-restart-kubelet-",
-			"copied to node",
+			"restarted kubelet",
 			restClientGetter,
 			streams,
 		),

--- a/pkg/cli/clusteroperator/restartkubelet/restart-pod-template.yaml
+++ b/pkg/cli/clusteroperator/restartkubelet/restart-pod-template.yaml
@@ -18,6 +18,7 @@ spec:
             chroot $ROOT systemctl stop kubelet
           done
           sleep 5
+          # optional command
           while ! pgrep kubelet >/dev/null ; do
             chroot $ROOT systemctl start kubelet
           done

--- a/pkg/cli/clusteroperator/restartkubelet/restart_kubelet.go
+++ b/pkg/cli/clusteroperator/restartkubelet/restart_kubelet.go
@@ -3,6 +3,7 @@ package restartkubelet
 import (
 	"context"
 	_ "embed"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -19,16 +20,19 @@ var (
 
 type RestartKubeletRuntime struct {
 	PerNodePodRuntime *pernodepod.PerNodePodRuntime
+
+	CommandWhileKubeletIsOff string
 }
 
 func (r *RestartKubeletRuntime) Run(ctx context.Context) error {
-	return r.PerNodePodRuntime.Run(ctx, nil, createPod)
+	return r.PerNodePodRuntime.Run(ctx, nil, r.createPod)
 }
 
-func createPod(ctx context.Context, namespaceName, nodeName, imagePullSpec string) (*corev1.Pod, error) {
+func (r *RestartKubeletRuntime) createPod(ctx context.Context, namespaceName, nodeName, imagePullSpec string) (*corev1.Pod, error) {
 	restartObj := pod.DeepCopy()
 	restartObj.Namespace = namespaceName
 	restartObj.Spec.NodeName = nodeName
 	restartObj.Spec.Containers[0].Image = imagePullSpec
+	restartObj.Spec.Containers[0].Command[2] = strings.ReplaceAll(restartObj.Spec.Containers[0].Command[2], "# optional command", r.CommandWhileKubeletIsOff)
 	return restartObj, nil
 }


### PR DESCRIPTION
`oc adm clusteroperator restart-kubelet nodes --all --parallelism=2 --command='rm -f /host-root/var/lib/kubelet/kubeconfig'`

this should allow us to quickly snip some files.

/assign @rphillips 