### PR TITLE
trustpurge: don't proceed if trustbundle changes affect trust

### DIFF
--- a/pkg/cli/admin/ocpcertificates/certregen/rootregen.go
+++ b/pkg/cli/admin/ocpcertificates/certregen/rootregen.go
@@ -25,9 +25,7 @@ type RootsRegen struct {
 
 // split here for convenience of unit testing
 func (o *RootsRegen) forceRegenerationOnSecret(objPrinter *objectPrinter, kubeClient kubernetes.Interface, secret *corev1.Secret, dryRun bool) error {
-	if len(secret.Annotations[certrotation.CertificateIssuer]) == 0 ||
-		len(secret.Annotations[certrotation.CertificateNotBeforeAnnotation]) == 0 ||
-		isRevisioned(secret.ObjectMeta) {
+	if !IsPlatformCertSecret(secret) {
 		// TODO this should return an error if the name was specified.
 		// otherwise, not for this command.
 		return nil

--- a/pkg/cli/admin/ocpcertificates/trustpurge/command.go
+++ b/pkg/cli/admin/ocpcertificates/trustpurge/command.go
@@ -99,6 +99,8 @@ func (o *RemoveOldTrustOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&o.DryRun, "dry-run", o.DryRun, "Set to true to use server-side dry run.")
 	cmd.Flags().StringVar(&o.CreatedBefore, "created-before", o.CreatedBefore, "Only remove CA certificates that were created before this date.  Format: 2023-06-05T14:44:06Z")
 	cmd.Flags().StringSliceVar(&o.ExcludeBundles, "exclude-bundles", o.ExcludeBundles, "CA bundles to exclude from trust pruning. Can be specified multiple times. Format: namespace/name")
+
+	cmd.MarkFlagRequired("created-before")
 }
 
 func (o *RemoveOldTrustOptions) ToRuntime(args []string) (*RemoveOldTrustRuntime, error) {
@@ -133,8 +135,9 @@ func (o *RemoveOldTrustOptions) ToRuntime(args []string) (*RemoveOldTrustRuntime
 		ResourceFinder: builder,
 		KubeClient:     kubeClient,
 
-		dryRun:         o.DryRun,
-		excludeBundles: exclude,
+		dryRun:            o.DryRun,
+		excludeBundles:    exclude,
+		cachedSecretCerts: map[string][]*cachedSecretCert{},
 
 		Printer:   printer,
 		IOStreams: o.IOStreams,

--- a/pkg/cli/admin/ocpcertificates/trustpurge/command.go
+++ b/pkg/cli/admin/ocpcertificates/trustpurge/command.go
@@ -29,13 +29,13 @@ var (
 
 	removeOldTrustExample = templates.Examples(`
 		# Remove all known trust bundles in the cluster
-		oc adm certificates remove-old-trust -A --all
+		oc adm ocp-certificates remove-old-trust configmaps -A --all
 
 		# Remove a trust bundled contained in a particular config map
-		oc adm certificates remove-old-trust -n openshift-config-managed kube-apiserver-aggregator-client-ca
+		oc adm ocp-certificates remove-old-trust -n openshift-config-managed configmaps/kube-apiserver-aggregator-client-ca
 
 		#  Remove only CA certificates created before a certain date from all trust bundles
-		oc amd certificates remove-old-trust --created-before 2023-06-05T14:44:06Z
+		oc adm ocp-certificates remove-old-trust configmaps -A --all --created-before 2023-06-05T14:44:06Z
 	`)
 )
 


### PR DESCRIPTION
I'm basing the protected trust change on trust to certificates retrievable with label selector `auth.openshift.io/managed-certificate-type=target` so that we don't have to traverse all secrets.

Example invocation that would wipe the whole trust from affected CMs:
```
$ oc adm ocp-certificates remove-old-trust configmaps --created-before 2023-06-15T00:00:00Z -A --all --dry-run
configmap/kube-apiserver-aggregator-client-ca trust purged
configmap/kube-apiserver-to-kubelet-client-ca trust purged
configmap/kube-control-plane-signer-ca trust purged
configmap/node-system-admin-ca trust purged
configmap/aggregator-client-ca trust purged
configmap/csr-controller-signer-ca trust purged
configmap/aggregator-client-ca trust purged
failed to apply changes to openshift-kube-apiserver-operator/loadbalancer-serving-ca: secrets only trusted by the old bundle: [openshift-kube-apiserver/external-loadbalancer-serving-certkey openshift-kube-apiserver/internal-loadbalancer-serving-certkey]
failed to apply changes to openshift-kube-apiserver-operator/localhost-recovery-serving-ca: secrets only trusted by the old bundle: [openshift-kube-apiserver/localhost-recovery-serving-certkey]
failed to apply changes to openshift-kube-apiserver-operator/localhost-serving-ca: secrets only trusted by the old bundle: [openshift-kube-apiserver/localhost-serving-cert-certkey]
failed to apply changes to openshift-kube-apiserver-operator/service-network-serving-ca: secrets only trusted by the old bundle: [openshift-kube-apiserver/service-network-serving-certkey]
failed to apply changes to openshift-ovn-kubernetes/ovn-ca: secrets only trusted by the old bundle: [openshift-ovn-kubernetes/ovn-cert]
failed to apply changes to openshift-ovn-kubernetes/signer-ca: secrets only trusted by the old bundle: [openshift-ovn-kubernetes/signer-cert]
```

TODO:
- [x] fix unit tests