### PR TITLE
handle the error case of node retrieval while waiting for reboot

### DIFF
--- a/pkg/cli/admin/waitfornodereboot/wait_for_node_reboot.go
+++ b/pkg/cli/admin/waitfornodereboot/wait_for_node_reboot.go
@@ -163,7 +163,8 @@ func (r *WaitForNodeRebootRuntime) waitForNodes(ctx context.Context, nodes []*co
 			continue
 		case err != nil:
 			fmt.Fprintf(r.ErrOut, "nodes/%v failed getting current: %v\n", nodeName, err)
-			remainingNodes = append(remainingNodes, currNode)
+			// this must requeue the node we have because the currNode from the API is empty.
+			remainingNodes = append(remainingNodes, nodes[i])
 			continue
 		}
 


### PR DESCRIPTION
Fixes

```
nodes/ failed getting current: resource name may not be empty
nodes/ip-10-0-242-72.us-west-1.compute.internal failed getting current: an error on the server ("read tcp 10.130.4.51:41854->13.56.72.38:6443: read: connection reset by peer") has prevented the request from succeeding (get nodes ip-10-0-242-72.us-west-1.compute.internal)
5 of 7 nodes rebooted, 0 rebooting to desired level: 2023-06-20T15:06:22-07:00

nodes/ failed getting current: resource name may not be empty
nodes/ failed getting current: resource name may not be empty
5 of 7 nodes rebooted, 0 rebooting to desired level: 2023-06-20T15:06:52-07:00
```

/assign @stlaz 