### PR TITLE
Adding "configMap" on the supported types of volumes (comments) 

### DIFF
--- a/pkg/cli/set/volume.go
+++ b/pkg/cli/set/volume.go
@@ -285,7 +285,7 @@ func (a *AddVolumeOptions) Validate() error {
 				return errors.New("must provide --claim-name or --claim-size (to create a new claim) for --type=pvc")
 			}
 		default:
-			return errors.New("invalid volume type. Supported types: emptyDir, hostPath, secret, persistentVolumeClaim")
+			return errors.New("invalid volume type. Supported types: emptyDir, hostPath, secret, persistentVolumeClaim, configMap")
 		}
 	} else if len(a.Path) > 0 || len(a.SecretName) > 0 || len(a.ClaimName) > 0 {
 		return errors.New("--path|--secret-name|--claim-name are only valid for --type option")


### PR DESCRIPTION
When trying to set new volume, if the type does not match, the command failed with a comment. 
ConfigMap is missing in the comment on the different types of volumes supported