### PR TITLE
OCPBUGS-15776: mcs cert: account for environments that use IP directly

### DIFF
--- a/pkg/cli/admin/ocpcertificates/regeneratemco/command.go
+++ b/pkg/cli/admin/ocpcertificates/regeneratemco/command.go
@@ -33,7 +33,7 @@ const (
 	newMCSCASecret = "machine-config-server-ca"
 	userDataKey    = "userData"
 
-	// mcoManagedWorkerSecret is the unused, MCO-managed stub ignition for workers
+	// mcoManagedWorkerSecret is the MCO-managed stub ignition for workers, used only in BareMetal IPI
 	mcoManagedWorkerSecret = "worker-user-data-managed"
 	// mcoManagedMasterSecret is the unused, MCO-managed stub ignition for masters
 	mcoManagedMasterSecret = "master-user-data-managed"

--- a/pkg/cli/admin/ocpcertificates/regeneratemco/command.go
+++ b/pkg/cli/admin/ocpcertificates/regeneratemco/command.go
@@ -21,17 +21,20 @@ const (
 	keyExpiry  = caExpiry
 	keyRefresh = caRefresh
 
-	mcoNamespace   = "openshift-machine-config-operator"
-	mapiNamespace  = "openshift-machine-api"
-	controllerName = "OCMachineConfigServerRotator"
-	mcsName        = "machine-config-server"
+	mcoNamespace        = "openshift-machine-config-operator"
+	mapiNamespace       = "openshift-machine-api"
+	kubeSystemNamespace = "kube-system"
+	controllerName      = "OCMachineConfigServerRotator"
+	mcsName             = "machine-config-server"
 
 	// mcsTlsSecretName is created by the installer and is not owned by default
 	mcsTlsSecretName = mcsName + "-tls"
 
 	// newMCSCASecret is the location of the CA after rotation
-	newMCSCASecret = "machine-config-server-ca"
-	userDataKey    = "userData"
+	newMCSCASecret  = "machine-config-server-ca"
+	userDataKey     = "userData"
+	rootCAConfigmap = "root-ca"
+	rootCACertKey   = "ca.crt"
 
 	// mcoManagedWorkerSecret is the MCO-managed stub ignition for workers, used only in BareMetal IPI
 	mcoManagedWorkerSecret = "worker-user-data-managed"

--- a/pkg/cli/admin/ocpcertificates/regeneratemco/rotatecerts.go
+++ b/pkg/cli/admin/ocpcertificates/regeneratemco/rotatecerts.go
@@ -131,15 +131,30 @@ func getServerIPsFromInfra(cfg *configv1.Infrastructure) []string {
 	}
 	switch cfg.Status.PlatformStatus.Type {
 	case configv1.BareMetalPlatformType:
-		return cfg.Status.PlatformStatus.BareMetal.APIServerInternalIPs
+		if cfg.Status.PlatformStatus.BareMetal.APIServerInternalIPs != nil {
+			return cfg.Status.PlatformStatus.BareMetal.APIServerInternalIPs
+		}
+		return []string{cfg.Status.PlatformStatus.BareMetal.APIServerInternalIP}
 	case configv1.OvirtPlatformType:
-		return cfg.Status.PlatformStatus.Ovirt.APIServerInternalIPs
+		if cfg.Status.PlatformStatus.Ovirt.APIServerInternalIPs != nil {
+			return cfg.Status.PlatformStatus.Ovirt.APIServerInternalIPs
+		}
+		return []string{cfg.Status.PlatformStatus.Ovirt.APIServerInternalIP}
 	case configv1.OpenStackPlatformType:
-		return cfg.Status.PlatformStatus.OpenStack.APIServerInternalIPs
+		if cfg.Status.PlatformStatus.OpenStack.APIServerInternalIPs != nil {
+			return cfg.Status.PlatformStatus.OpenStack.APIServerInternalIPs
+		}
+		return []string{cfg.Status.PlatformStatus.OpenStack.APIServerInternalIP}
 	case configv1.VSpherePlatformType:
-		return cfg.Status.PlatformStatus.VSphere.APIServerInternalIPs
+		if cfg.Status.PlatformStatus.VSphere.APIServerInternalIPs != nil {
+			return cfg.Status.PlatformStatus.VSphere.APIServerInternalIPs
+		}
+		return []string{cfg.Status.PlatformStatus.VSphere.APIServerInternalIP}
 	case configv1.NutanixPlatformType:
-		return cfg.Status.PlatformStatus.Nutanix.APIServerInternalIPs
+		if cfg.Status.PlatformStatus.Nutanix.APIServerInternalIPs != nil {
+			return cfg.Status.PlatformStatus.Nutanix.APIServerInternalIPs
+		}
+		return []string{cfg.Status.PlatformStatus.Nutanix.APIServerInternalIP}
 	default:
 		return []string{}
 	}

--- a/pkg/cli/admin/ocpcertificates/regeneratemco/updatesecrets.go
+++ b/pkg/cli/admin/ocpcertificates/regeneratemco/updatesecrets.go
@@ -47,7 +47,7 @@ func (o *RegenerateMCOOptions) updateSecrets(ctx context.Context) error {
 		return fmt.Errorf("cannot list MAO secrets: %w", err)
 	}
 	for _, secret := range secretList.Items {
-		// These two are managed by the MCO but unused. Skip them since the MCO will write them back.
+		// These two are managed by and only used for BareMetal IPI. Skip them since the MCO will write them back.
 		if secret.Name == mcoManagedWorkerSecret || secret.Name == mcoManagedMasterSecret {
 			continue
 		}

--- a/pkg/cli/admin/ocpcertificates/regeneratemco/updatesecrets.go
+++ b/pkg/cli/admin/ocpcertificates/regeneratemco/updatesecrets.go
@@ -6,8 +6,11 @@ import (
 	"encoding/json"
 	"fmt"
 
+	configv1 "github.com/openshift/api/config/v1"
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/vincent-petithory/dataurl"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -99,6 +102,34 @@ func (o *RegenerateMCOOptions) updateSecrets(ctx context.Context) error {
 		}
 
 		fmt.Fprintf(o.IOStreams.Out, "Successfully modified user-data secret %s\n", secret.Name)
+	}
+
+	// For Baremetal IPI, the worker-user-data-managed machineset is being used for scaling,
+	// so we need to do update the source (root-ca configmap) which will also cause all nodes to reboot.
+	oconfig, err := configclient.NewForConfig(clientConfig)
+	if err != nil {
+		return err
+	}
+	cfg, err := oconfig.ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("unable to get cluster infrastructure resource: %w", err)
+	}
+	if cfg.Status.Platform == configv1.BareMetalPlatformType {
+		kubeSystemRootCA, err := clientset.CoreV1().ConfigMaps(kubeSystemNamespace).Get(ctx, rootCAConfigmap, metav1.GetOptions{})
+		if err != nil {
+			if errors.IsNotFound(err) {
+				fmt.Fprintf(o.IOStreams.Out, "Could not find configmap %s/%s on platform %s, skipping. This may cause issues when scaling nodes.", kubeSystemNamespace, rootCAConfigmap, configv1.BareMetalPlatformType)
+				return nil
+			}
+			return fmt.Errorf("unable to get configmap %s/%s: %w", kubeSystemNamespace, rootCAConfigmap, err)
+		}
+
+		kubeSystemRootCA.Data[rootCACertKey] = string(caCert)
+		_, err = clientset.CoreV1().ConfigMaps(kubeSystemNamespace).Update(ctx, kubeSystemRootCA, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("could not update configmap %s: %w", rootCAConfigmap, err)
+		}
+		fmt.Fprintf(o.IOStreams.Out, "Successfully updated configmap %s/%s, nodes will now reboot.\n", kubeSystemNamespace, rootCAConfigmap)
 	}
 
 	return nil


### PR DESCRIPTION
In some cases, the MCS endpoint refers to the apiserver IP directly instead of the api-int url. Update the cert generation to account for this, otherwise we fail for those platforms.

Also update the kube-system root-ca cert for BM IPI, since BM IPI is the only platform that uses the MCO-generated and managed secret