### PR TITLE
OCPBUGS-16009: reboot: set ignition version to 3.1

### DIFF
--- a/pkg/cli/admin/rebootmachineconfigpool/restart-template.json
+++ b/pkg/cli/admin/rebootmachineconfigpool/restart-template.json
@@ -12,7 +12,7 @@
           "tls": {}
         },
         "timeouts": {},
-        "version": "3.2.0"
+        "version": "3.1.0"
       },
       "storage": {
         "files": [


### PR DESCRIPTION
The oldest version we want to run the cert rotation command on is 4.6, which has support only up to ignition spec 3.1 (3.2+ was introduced in 4.7)

Update the template to use 3.1 since it should be supported for all versions we want to run the procedure on.