### PR TITLE
login: improve usage message for --web option

### DIFF
--- a/pkg/cli/login/login.go
+++ b/pkg/cli/login/login.go
@@ -46,7 +46,7 @@ var (
 		oc login localhost:8443 --username=myuser --password=mypass
 
 		# Log in to the given server through a browser
-		oc login --web --callback-port 8280 localhost:8443
+		oc login localhost:8443 --web --callback-port 8280
 	`)
 )
 
@@ -87,7 +87,7 @@ func NewCmdLogin(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra
 	cmds.Flags().StringVarP(&o.Username, "username", "u", o.Username, "Username for server")
 	cmds.Flags().StringVarP(&o.Password, "password", "p", o.Password, "Password for server")
 
-	cmds.Flags().BoolVarP(&o.WebLogin, "web", "w", o.WebLogin, "Login with web browser")
+	cmds.Flags().BoolVarP(&o.WebLogin, "web", "w", o.WebLogin, "Login with web browser. Starts a local HTTP callback server to perform the OAuth2 Authorization Code Grant flow. Use with caution on multi-user systems, as the server's port will be open to all users.")
 	cmds.Flags().Int32VarP(&o.CallbackPort, "callback-port", "c", o.CallbackPort, "Port for the callback server when using --web. Defaults to a random open port")
 	return cmds
 }


### PR DESCRIPTION
This PR adds more informative text in the usage doc of `oc login --web` flag.