### PR TITLE
Add profiling functionality and flags in oc

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -177,9 +177,12 @@ func NewOcCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 		Run:   runHelp,
 		PersistentPreRunE: func(*cobra.Command, []string) error {
 			rest.SetDefaultWarningHandler(warningHandler)
-			return nil
+			return initProfiling()
 		},
 		PersistentPostRunE: func(*cobra.Command, []string) error {
+			if err := flushProfiling(); err != nil {
+				return err
+			}
 			if warningsAsErrors {
 				count := warningHandler.WarningCount()
 				switch count {
@@ -196,6 +199,9 @@ func NewOcCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 	}
 
 	flags := cmds.PersistentFlags()
+
+	addProfilingFlags(flags)
+
 	flags.BoolVar(&warningsAsErrors, "warnings-as-errors", warningsAsErrors, "Treat warnings received from the server as errors and exit with a non-zero exit code")
 
 	kubeConfigFlags := genericclioptions.NewConfigFlags(true).WithDiscoveryBurst(350).WithDiscoveryQPS(50.0)

--- a/pkg/cli/profiling.go
+++ b/pkg/cli/profiling.go
@@ -1,0 +1,90 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"runtime"
+	"runtime/pprof"
+
+	"github.com/spf13/pflag"
+)
+
+var (
+	profileName   string
+	profileOutput string
+)
+
+func addProfilingFlags(flags *pflag.FlagSet) {
+	flags.StringVar(&profileName, "profile", "none", "Name of profile to capture. One of (none|cpu|heap|goroutine|threadcreate|block|mutex)")
+	flags.StringVar(&profileOutput, "profile-output", "profile.pprof", "Name of the file to write the profile to")
+}
+
+func initProfiling() error {
+	var (
+		f   *os.File
+		err error
+	)
+	switch profileName {
+	case "none":
+		return nil
+	case "cpu":
+		f, err = os.Create(profileOutput)
+		if err != nil {
+			return err
+		}
+		err = pprof.StartCPUProfile(f)
+		if err != nil {
+			return err
+		}
+	// Block and mutex profiles need a call to Set{Block,Mutex}ProfileRate to
+	// output anything. We choose to sample all events.
+	case "block":
+		runtime.SetBlockProfileRate(1)
+	case "mutex":
+		runtime.SetMutexProfileFraction(1)
+	default:
+		// Check the profile name is valid.
+		if profile := pprof.Lookup(profileName); profile == nil {
+			return fmt.Errorf("unknown profile '%s'", profileName)
+		}
+	}
+
+	// If the command is interrupted before the end (ctrl-c), flush the
+	// profiling files
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	go func() {
+		<-c
+		f.Close()
+		flushProfiling()
+		os.Exit(0)
+	}()
+
+	return nil
+}
+
+func flushProfiling() error {
+	switch profileName {
+	case "none":
+		return nil
+	case "cpu":
+		pprof.StopCPUProfile()
+	case "heap":
+		runtime.GC()
+		fallthrough
+	default:
+		profile := pprof.Lookup(profileName)
+		if profile == nil {
+			return nil
+		}
+		f, err := os.Create(profileOutput)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		profile.WriteTo(f, 0)
+	}
+
+	return nil
+}


### PR DESCRIPTION
To preserve the feature parity between oc and kubectl, this commit takes the profiling functionality in kubectl into the oc
as detected by @atiratree in https://github.com/openshift/oc/pull/1420#issuecomment-1544777587