### PR TITLE
OCPBUGS-16735: Truncate existing files when writing from inspect

### DIFF
--- a/pkg/cli/admin/inspect/writer.go
+++ b/pkg/cli/admin/inspect/writer.go
@@ -51,7 +51,7 @@ func (r *resourceWriterReadCloser) Close() error {
 type simpleFileWriter struct{}
 
 func (f *simpleFileWriter) Write(filepath string, src fileWriterSource) error {
-	dest, err := os.OpenFile(filepath, os.O_RDWR|os.O_CREATE, 0755)
+	dest, err := os.OpenFile(filepath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
oc adm inspect generated files sometime have the leading "---" and some time do not. This depends on the order of objects collected. This by itself is not an issue.

However this becomes an issue when combined with multiple invocations of oc adm inspect and collecting data to the same directory like must-gather does.

If an object is collected multiple times then the second time oc might overwrite the original file improperly and leave 4 bytes of the original content behind.

This is happening when not writing the "---\n" in the second invocation as this makes the content 4B shorter and the original tailing 4B are left in the file intact.

This garbage confuses YAML parsers.