### PR TITLE
OTA-559: pkg/cli/admin/release/extract: Add --included and --install-config

### DIFF
--- a/pkg/cli/admin/release/extract.go
+++ b/pkg/cli/admin/release/extract.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/rest"
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/templates"
 
@@ -75,7 +76,7 @@ func NewExtract(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.
 			must be installed on the cluster for a given version.
 
 			The --tools and --command flags allow you to extract the appropriate client binaries
-			for	your operating system to disk. --tools will create archive files containing the
+			for your operating system to disk. --tools will create archive files containing the
 			current OS tools (or, if --command-os is set to '*', all OS versions). Specifying
 			--command for either 'oc' or 'openshift-install' will extract the binaries directly.
 			You may pass a PGP private key file with --signing-key which will create an ASCII
@@ -86,6 +87,14 @@ func NewExtract(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.
 			The --credentials-requests flag filters extracted manifests to only cloud credential
 			requests. The --cloud flag further filters credential requests to a specific cloud.
 			Valid values for --cloud include alibabacloud, aws, azure, gcp, ibmcloud, nutanix, openstack, ovirt, powervs, and vsphere.
+
+			The --included flag filters extracted manifests to those that are expected to be included
+			with the cluster.  Filters are cumulative, so '--credentials-requests --included' will
+			only include cloud credential requests which are expected to be included with the cluster.
+			If --install-config is set, it will be used to determine the expected cluster configuration,
+			otherwise the command will interrogate your current cluster to determine its configuration.
+			This command is most accurate when the version of the extracting client matches the version
+			of the cluster under consideration.
 
 			Instead of extracting the manifests, you can specify --git=DIR to perform a Git
 			checkout of the source code that comprises the release. A warning will be printed
@@ -111,7 +120,7 @@ func NewExtract(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.
 		Run: func(cmd *cobra.Command, args []string) {
 			kcmdutil.CheckErr(o.Complete(f, cmd, args))
 			kcmdutil.CheckErr(o.Validate())
-			kcmdutil.CheckErr(o.Run())
+			kcmdutil.CheckErr(o.Run(cmd.Context()))
 		},
 	}
 	flags := cmd.Flags()
@@ -133,8 +142,11 @@ func NewExtract(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.
 	flags.StringVar(&o.CommandOperatingSystem, "command-os", o.CommandOperatingSystem, "Override which operating system command is extracted (mac, windows, linux) or can be specified with arch(linux/arm64, mac/amd64). You map specify '*' to extract all tool archives.")
 	flags.StringVar(&o.FileDir, "dir", o.FileDir, "The directory on disk that file:// images will be copied under.")
 
-	flags.BoolVar(&o.CredentialsRequests, "credentials-requests", o.CredentialsRequests, "Extract credential request manifests only")
-	flags.StringVar(&o.Cloud, "cloud", o.Cloud, "Specify the cloud for which credential request manifests should be extracted. Works only in combination with --credentials-requests.")
+	flags.BoolVar(&o.Included, "included", o.Included, "Exclude manifests that are not expected to be included in the cluster.")
+	flags.StringVar(&o.InstallConfig, "install-config", o.InstallConfig, "Path to an install-config file, as consumed by the openshift-install command.  Works only in combination with --included.")
+
+	flags.BoolVar(&o.CredentialsRequests, "credentials-requests", o.CredentialsRequests, "Exclude manifests which are not credential requests.")
+	flags.StringVar(&o.Cloud, "cloud", o.Cloud, "Exclude credential requests which are not relevant to the given cloud provider.  Works only in combination with --credentials-requests.")
 
 	flags.StringVarP(&o.Output, "output", "o", o.Output, "Output format. Supports 'commit' when used with '--git'.")
 	return cmd
@@ -146,6 +158,9 @@ type ExtractOptions struct {
 	SecurityOptions imagemanifest.SecurityOptions
 	FilterOptions   imagemanifest.FilterOptions
 	ParallelOptions imagemanifest.ParallelOptions
+
+	// RESTConfig is a REST client configuration for connecting to a cluster if neccessary.
+	RESTConfig *rest.Config
 
 	ICSPFile string
 
@@ -159,7 +174,16 @@ type ExtractOptions struct {
 	CommandOperatingSystem string
 	SigningKey             string
 
-	// CredentialsRequests if true, results in only credential request manifests getting extracted.
+	// Included, if true, results in only included manifests getting extracted.
+	// For example, manifests associated with optional capabilities will be excluded unless
+	// the cluster configuration enables that capability.
+	Included bool
+
+	// InstallConfig is the path to an install-config file, as
+	// consumed by the openshift-install command.
+	InstallConfig string
+
+	// CredentialsRequests, if true, results in only credential request manifests getting extracted.
 	// If Cloud is specified, then only the credential requests for that cloud are extracted.
 	CredentialsRequests bool
 	Cloud               string
@@ -196,6 +220,9 @@ func (o *ExtractOptions) Complete(f kcmdutil.Factory, cmd *cobra.Command, args [
 		return fmt.Errorf("you may only specify a single image via --from or argument")
 	}
 	o.From = args[0]
+	if o.RESTConfig, err = f.ToRESTConfig(); err != nil {
+		return err
+	}
 
 	return o.FilterOptions.Complete(cmd.Flags())
 }
@@ -204,7 +231,7 @@ func (o *ExtractOptions) Validate() error {
 	return o.FilterOptions.Validate()
 }
 
-func (o *ExtractOptions) Run() error {
+func (o *ExtractOptions) Run(ctx context.Context) error {
 	sources := 0
 	if o.Tools {
 		sources++
@@ -226,8 +253,12 @@ func (o *ExtractOptions) Run() error {
 		return fmt.Errorf("--output is only supported with --git")
 	}
 
-	if !o.CredentialsRequests && len(o.Cloud) > 0 {
-		return fmt.Errorf("--cloud is only supported with --credentials-requests")
+	if len(o.InstallConfig) > 0 && !o.Included {
+		return fmt.Errorf("--install-config is only supported with --included")
+	}
+
+	if len(o.Cloud) > 0 && !o.CredentialsRequests && !o.Included {
+		return fmt.Errorf("--cloud is only supported with --credentials-requests or --included")
 	}
 	if len(o.Cloud) > 0 {
 		if _, ok := credRequestCloudProviderSpecKindMapping[o.Cloud]; !ok {
@@ -310,8 +341,33 @@ func (o *ExtractOptions) Run() error {
 	if o.ExtractManifests {
 		expectedProviderSpecKind := credRequestCloudProviderSpecKindMapping[o.Cloud]
 
+		include := func(m *manifest.Manifest) error { return nil } // default to including everything
+		if o.Included {
+			context := "connected cluster"
+			inclusionConfig := manifestInclusionConfiguration{}
+			if o.InstallConfig == "" {
+				inclusionConfig, err = findClusterIncludeConfig(ctx, o.RESTConfig)
+			} else {
+				inclusionConfig, err = findClusterIncludeConfigFromInstallConfig(ctx, o.InstallConfig)
+				context = o.InstallConfig
+			}
+			if err != nil {
+				return err
+			}
+			if inclusionConfig.Platform != nil {
+				if o.Cloud != "" && *inclusionConfig.Platform != o.Cloud {
+					return fmt.Errorf("--cloud %q set, but %s has %q", o.Cloud, context, *inclusionConfig.Platform)
+				}
+				var ok bool
+				if expectedProviderSpecKind, ok = credRequestCloudProviderSpecKindMapping[*inclusionConfig.Platform]; !ok {
+					return fmt.Errorf("unrecognized platform for CredentialsRequests: %q", *inclusionConfig.Platform)
+				}
+			}
+			include = newIncluder(inclusionConfig)
+		}
+
 		tarEntryCallbacks = append(tarEntryCallbacks, func(hdr *tar.Header, _ extract.LayerInfo, r io.Reader) (bool, error) {
-			if hdr.Name == "image-references" {
+			if hdr.Name == "image-references" && !o.CredentialsRequests {
 				buf := &bytes.Buffer{}
 				if _, err := io.Copy(buf, r); err != nil {
 					return false, fmt.Errorf("unable to load image-references from release payload: %w", err)
@@ -339,7 +395,7 @@ func (o *ExtractOptions) Run() error {
 					return true, err
 				}
 				return true, nil
-			} else if hdr.Name == "release-metadata" {
+			} else if hdr.Name == "release-metadata" && !o.CredentialsRequests {
 				out := o.Out
 				if o.Directory != "" {
 					out, err = os.Create(filepath.Join(o.Directory, hdr.Name))
@@ -362,6 +418,15 @@ func (o *ExtractOptions) Run() error {
 			if err != nil {
 				manifestErrs = append(manifestErrs, errors.Wrapf(err, "error parsing %s", hdr.Name))
 				return true, nil
+			}
+
+			for i := len(ms) - 1; i >= 0; i-- {
+				if o.Included && o.CredentialsRequests && ms[i].GVK == credentialsRequestGVK && len(ms[i].Obj.GetAnnotations()) == 0 {
+					klog.V(4).Infof("Including %s for manual CredentialsRequests, despite lack of annotations", ms[i].String())
+				} else if err := include(&ms[i]); err != nil {
+					klog.V(4).Infof("Excluding %s: %s", ms[i].String(), err)
+					ms = append(ms[:i], ms[i+1:]...)
+				}
 			}
 
 			o.Manifests = append(o.Manifests, ms...)

--- a/pkg/cli/admin/release/mirror.go
+++ b/pkg/cli/admin/release/mirror.go
@@ -152,7 +152,7 @@ func NewMirror(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.C
 		Run: func(cmd *cobra.Command, args []string) {
 			kcmdutil.CheckErr(o.Complete(cmd, f, args))
 			kcmdutil.CheckErr(o.Validate())
-			kcmdutil.CheckErr(o.Run())
+			kcmdutil.CheckErr(o.Run(cmd.Context()))
 		},
 	}
 	flags := cmd.Flags()
@@ -410,7 +410,7 @@ func (o *MirrorOptions) handleSignatures(context context.Context, signaturesByDi
 	return nil
 }
 
-func (o *MirrorOptions) Run() error {
+func (o *MirrorOptions) Run(ctx context.Context) error {
 	var recreateRequired bool
 	var hasPrefix bool
 	var targetFn func(name string) imagesource.TypedImageReference
@@ -524,7 +524,7 @@ func (o *MirrorOptions) Run() error {
 		}
 		extractOpts.FileDir = o.FromDir
 		extractOpts.From = o.From
-		if err := extractOpts.Run(); err != nil {
+		if err := extractOpts.Run(ctx); err != nil {
 			return fmt.Errorf("unable to retrieve release image info: %v", err)
 		}
 

--- a/pkg/cli/admin/release/new.go
+++ b/pkg/cli/admin/release/new.go
@@ -113,7 +113,7 @@ func NewRelease(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.
 		Run: func(cmd *cobra.Command, args []string) {
 			kcmdutil.CheckErr(o.Complete(f, cmd, args))
 			kcmdutil.CheckErr(o.Validate())
-			kcmdutil.CheckErr(o.Run())
+			kcmdutil.CheckErr(o.Run(cmd.Context()))
 		},
 	}
 	flags := cmd.Flags()
@@ -311,7 +311,7 @@ func (o *NewOptions) cleanup() {
 	o.cleanupFns = nil
 }
 
-func (o *NewOptions) Run() error {
+func (o *NewOptions) Run(ctx context.Context) error {
 	defer o.cleanup()
 
 	// check parameters
@@ -717,7 +717,7 @@ func (o *NewOptions) Run() error {
 	}
 
 	if len(o.Mirror) > 0 {
-		if err := o.mirrorImages(is); err != nil {
+		if err := o.mirrorImages(ctx, is); err != nil {
 			return err
 		}
 	}
@@ -1084,7 +1084,7 @@ func (o *NewOptions) extractManifests(is *imageapi.ImageStream, name string, met
 	return nil
 }
 
-func (o *NewOptions) mirrorImages(is *imageapi.ImageStream) error {
+func (o *NewOptions) mirrorImages(ctx context.Context, is *imageapi.ImageStream) error {
 	klog.V(4).Infof("Mirroring release contents to %s", o.Mirror)
 	copied := is.DeepCopy()
 	opts := NewMirrorOptions(genericclioptions.IOStreams{Out: o.Out, ErrOut: o.ErrOut})
@@ -1096,7 +1096,7 @@ func (o *NewOptions) mirrorImages(is *imageapi.ImageStream) error {
 	opts.SecurityOptions = o.SecurityOptions
 	opts.KeepManifestList = o.KeepManifestList
 
-	if err := opts.Run(); err != nil {
+	if err := opts.Run(ctx); err != nil {
 		return err
 	}
 

--- a/pkg/cli/admin/release/new_test.go
+++ b/pkg/cli/admin/release/new_test.go
@@ -1,6 +1,7 @@
 package release
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -13,6 +14,8 @@ import (
 )
 
 func TestMirrorImages(t *testing.T) {
+	ctx := context.Background()
+
 	tests := []struct {
 		is                  *imageapi.ImageStream
 		expectedWarningMsgs []string
@@ -68,7 +71,7 @@ func TestMirrorImages(t *testing.T) {
 
 	for _, tt := range tests {
 		options := NewNewOptions(ioStream)
-		err := options.mirrorImages(tt.is)
+		err := options.mirrorImages(ctx, tt.is)
 
 		if err != nil {
 			if len(tt.expectedErr) == 0 {


### PR DESCRIPTION
There are many manifests in release images.  CredentialsRequests, Deployments, ClusterOperators, etc., etc.  There are increasingly complicated conditions on whether the cluster-version operator reconciles or ignores a manifest, including [cluster profiles, cluster capabilities, and feature sets][1].  To make it easier for users to see the manifests that actually matter for their cluster, this commit adds `--included`, which uses [the same `Manifest.Include` logic used by the cluster-version operator][2].  As long as we keep the vendored copies of library-go close-ish between `oc` and the CVO, this will allow users to just get the manifests that apply to their cluster.  For example:

* You have enabled `TechPreviewNoUpgrade`, so here's [a CredentialsRequest for the `openshift-cluster-api` namespace][3], or
* You have not enabled `TechPreviewNoUpgrade`, so I'll filter out this CredentialsRequest for the `openshift-cluster-api namespace`.

This should work fairly well as long as `oc` can reach the cluster to retrieve the same configuration data that the cluster-version operator is using to make its decisions, although there is a risk of drift between the separate code bases.  It gets trickier when we need to run before the cluster exists.  For those cases, we have `--install-config`, and `oc` can get some information reliably from there (enabled capability (sets), cloud provider, etc.) but not others (known capabilities, cluster profile, etc.)  We may need to circle back later with additional flags for these properties, so the user can explicitly pass in the information that we cannot figure out from the install-config alone.

[1]: https://github.com/openshift/enhancements/blob/fb6021978e149e4cd12a223134a148172eff51ad/dev-guide/cluster-version-operator/dev/operators.md#manifest-inclusion-annotations
[2]: https://github.com/openshift/cluster-version-operator/blob/4eb9433f345cc551c7d31996ee441d649f677b4e/pkg/cvo/sync_worker.go#L963
[3]: https://github.com/openshift/cluster-capi-operator/blob/1593e40d6422e46473beee2f4419514a0418da1c/manifests/0000_30_cluster-api_00_credentials-request.yaml#L9-L15