### PR TITLE
OCPBUGS-17711: Revert "pkg/cli/admin/release/extract: Add --included and --install-config"

### DIFF
--- a/pkg/cli/admin/release/extract.go
+++ b/pkg/cli/admin/release/extract.go
@@ -21,7 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/client-go/rest"
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/templates"
 
@@ -76,7 +75,7 @@ func NewExtract(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.
 			must be installed on the cluster for a given version.
 
 			The --tools and --command flags allow you to extract the appropriate client binaries
-			for your operating system to disk. --tools will create archive files containing the
+			for	your operating system to disk. --tools will create archive files containing the
 			current OS tools (or, if --command-os is set to '*', all OS versions). Specifying
 			--command for either 'oc' or 'openshift-install' will extract the binaries directly.
 			You may pass a PGP private key file with --signing-key which will create an ASCII
@@ -87,14 +86,6 @@ func NewExtract(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.
 			The --credentials-requests flag filters extracted manifests to only cloud credential
 			requests. The --cloud flag further filters credential requests to a specific cloud.
 			Valid values for --cloud include alibabacloud, aws, azure, gcp, ibmcloud, nutanix, openstack, ovirt, powervs, and vsphere.
-
-			The --included flag filters extracted manifests to those that are expected to be included
-			with the cluster.  Filters are cumulative, so '--credentials-requests --included' will
-			only include cloud credential requests which are expected to be included with the cluster.
-			If --install-config is set, it will be used to determine the expected cluster configuration,
-			otherwise the command will interrogate your current cluster to determine its configuration.
-			This command is most accurate when the version of the extracting client matches the version
-			of the cluster under consideration.
 
 			Instead of extracting the manifests, you can specify --git=DIR to perform a Git
 			checkout of the source code that comprises the release. A warning will be printed
@@ -120,7 +111,7 @@ func NewExtract(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.
 		Run: func(cmd *cobra.Command, args []string) {
 			kcmdutil.CheckErr(o.Complete(f, cmd, args))
 			kcmdutil.CheckErr(o.Validate())
-			kcmdutil.CheckErr(o.Run(cmd.Context()))
+			kcmdutil.CheckErr(o.Run())
 		},
 	}
 	flags := cmd.Flags()
@@ -142,11 +133,8 @@ func NewExtract(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.
 	flags.StringVar(&o.CommandOperatingSystem, "command-os", o.CommandOperatingSystem, "Override which operating system command is extracted (mac, windows, linux) or can be specified with arch(linux/arm64, mac/amd64). You map specify '*' to extract all tool archives.")
 	flags.StringVar(&o.FileDir, "dir", o.FileDir, "The directory on disk that file:// images will be copied under.")
 
-	flags.BoolVar(&o.Included, "included", o.Included, "Exclude manifests that are not expected to be included in the cluster.")
-	flags.StringVar(&o.InstallConfig, "install-config", o.InstallConfig, "Path to an install-config file, as consumed by the openshift-install command.  Works only in combination with --included.")
-
-	flags.BoolVar(&o.CredentialsRequests, "credentials-requests", o.CredentialsRequests, "Exclude manifests which are not credential requests.")
-	flags.StringVar(&o.Cloud, "cloud", o.Cloud, "Exclude credential requests which are not relevant to the given cloud provider.  Works only in combination with --credentials-requests.")
+	flags.BoolVar(&o.CredentialsRequests, "credentials-requests", o.CredentialsRequests, "Extract credential request manifests only")
+	flags.StringVar(&o.Cloud, "cloud", o.Cloud, "Specify the cloud for which credential request manifests should be extracted. Works only in combination with --credentials-requests.")
 
 	flags.StringVarP(&o.Output, "output", "o", o.Output, "Output format. Supports 'commit' when used with '--git'.")
 	return cmd
@@ -158,9 +146,6 @@ type ExtractOptions struct {
 	SecurityOptions imagemanifest.SecurityOptions
 	FilterOptions   imagemanifest.FilterOptions
 	ParallelOptions imagemanifest.ParallelOptions
-
-	// RESTConfig is a REST client configuration for connecting to a cluster if neccessary.
-	RESTConfig *rest.Config
 
 	ICSPFile string
 
@@ -174,16 +159,7 @@ type ExtractOptions struct {
 	CommandOperatingSystem string
 	SigningKey             string
 
-	// Included, if true, results in only included manifests getting extracted.
-	// For example, manifests associated with optional capabilities will be excluded unless
-	// the cluster configuration enables that capability.
-	Included bool
-
-	// InstallConfig is the path to an install-config file, as
-	// consumed by the openshift-install command.
-	InstallConfig string
-
-	// CredentialsRequests, if true, results in only credential request manifests getting extracted.
+	// CredentialsRequests if true, results in only credential request manifests getting extracted.
 	// If Cloud is specified, then only the credential requests for that cloud are extracted.
 	CredentialsRequests bool
 	Cloud               string
@@ -220,9 +196,6 @@ func (o *ExtractOptions) Complete(f kcmdutil.Factory, cmd *cobra.Command, args [
 		return fmt.Errorf("you may only specify a single image via --from or argument")
 	}
 	o.From = args[0]
-	if o.RESTConfig, err = f.ToRESTConfig(); err != nil {
-		return err
-	}
 
 	return o.FilterOptions.Complete(cmd.Flags())
 }
@@ -231,7 +204,7 @@ func (o *ExtractOptions) Validate() error {
 	return o.FilterOptions.Validate()
 }
 
-func (o *ExtractOptions) Run(ctx context.Context) error {
+func (o *ExtractOptions) Run() error {
 	sources := 0
 	if o.Tools {
 		sources++
@@ -253,12 +226,8 @@ func (o *ExtractOptions) Run(ctx context.Context) error {
 		return fmt.Errorf("--output is only supported with --git")
 	}
 
-	if len(o.InstallConfig) > 0 && !o.Included {
-		return fmt.Errorf("--install-config is only supported with --included")
-	}
-
-	if len(o.Cloud) > 0 && !o.CredentialsRequests && !o.Included {
-		return fmt.Errorf("--cloud is only supported with --credentials-requests or --included")
+	if !o.CredentialsRequests && len(o.Cloud) > 0 {
+		return fmt.Errorf("--cloud is only supported with --credentials-requests")
 	}
 	if len(o.Cloud) > 0 {
 		if _, ok := credRequestCloudProviderSpecKindMapping[o.Cloud]; !ok {
@@ -341,33 +310,8 @@ func (o *ExtractOptions) Run(ctx context.Context) error {
 	if o.ExtractManifests {
 		expectedProviderSpecKind := credRequestCloudProviderSpecKindMapping[o.Cloud]
 
-		include := func(m *manifest.Manifest) error { return nil } // default to including everything
-		if o.Included {
-			context := "connected cluster"
-			inclusionConfig := manifestInclusionConfiguration{}
-			if o.InstallConfig == "" {
-				inclusionConfig, err = findClusterIncludeConfig(ctx, o.RESTConfig)
-			} else {
-				inclusionConfig, err = findClusterIncludeConfigFromInstallConfig(ctx, o.InstallConfig)
-				context = o.InstallConfig
-			}
-			if err != nil {
-				return err
-			}
-			if inclusionConfig.Platform != nil {
-				if o.Cloud != "" && *inclusionConfig.Platform != o.Cloud {
-					return fmt.Errorf("--cloud %q set, but %s has %q", o.Cloud, context, *inclusionConfig.Platform)
-				}
-				var ok bool
-				if expectedProviderSpecKind, ok = credRequestCloudProviderSpecKindMapping[*inclusionConfig.Platform]; !ok {
-					return fmt.Errorf("unrecognized platform for CredentialsRequests: %q", *inclusionConfig.Platform)
-				}
-			}
-			include = newIncluder(inclusionConfig)
-		}
-
 		tarEntryCallbacks = append(tarEntryCallbacks, func(hdr *tar.Header, _ extract.LayerInfo, r io.Reader) (bool, error) {
-			if hdr.Name == "image-references" && !o.CredentialsRequests {
+			if hdr.Name == "image-references" {
 				buf := &bytes.Buffer{}
 				if _, err := io.Copy(buf, r); err != nil {
 					return false, fmt.Errorf("unable to load image-references from release payload: %w", err)
@@ -395,7 +339,7 @@ func (o *ExtractOptions) Run(ctx context.Context) error {
 					return true, err
 				}
 				return true, nil
-			} else if hdr.Name == "release-metadata" && !o.CredentialsRequests {
+			} else if hdr.Name == "release-metadata" {
 				out := o.Out
 				if o.Directory != "" {
 					out, err = os.Create(filepath.Join(o.Directory, hdr.Name))
@@ -418,15 +362,6 @@ func (o *ExtractOptions) Run(ctx context.Context) error {
 			if err != nil {
 				manifestErrs = append(manifestErrs, errors.Wrapf(err, "error parsing %s", hdr.Name))
 				return true, nil
-			}
-
-			for i := len(ms) - 1; i >= 0; i-- {
-				if o.Included && o.CredentialsRequests && ms[i].GVK == credentialsRequestGVK && len(ms[i].Obj.GetAnnotations()) == 0 {
-					klog.V(4).Infof("Including %s for manual CredentialsRequests, despite lack of annotations", ms[i].String())
-				} else if err := include(&ms[i]); err != nil {
-					klog.V(4).Infof("Excluding %s: %s", ms[i].String(), err)
-					ms = append(ms[:i], ms[i+1:]...)
-				}
 			}
 
 			o.Manifests = append(o.Manifests, ms...)

--- a/pkg/cli/admin/release/extract_tools.go
+++ b/pkg/cli/admin/release/extract_tools.go
@@ -6,7 +6,6 @@ import (
 	"bufio"
 	"bytes"
 	"compress/gzip"
-	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -15,7 +14,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"sort"
 	"strings"
@@ -28,23 +26,14 @@ import (
 
 	"k8s.io/klog/v2"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	appsv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
-	"k8s.io/client-go/rest"
-	"k8s.io/utils/pointer"
-	"sigs.k8s.io/yaml"
 
 	"github.com/MakeNowJust/heredoc"
-	configv1 "github.com/openshift/api/config/v1"
-	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	imagereference "github.com/openshift/library-go/pkg/image/reference"
-	"github.com/openshift/library-go/pkg/manifest"
 	"github.com/openshift/oc/pkg/cli/admin/internal/codesign"
 	"github.com/openshift/oc/pkg/cli/image/extract"
 	"github.com/openshift/oc/pkg/cli/image/imagesource"
-	"github.com/openshift/oc/pkg/version"
 )
 
 // extractTarget describes how a file in the release image can be extracted to disk.
@@ -67,41 +56,6 @@ type extractTarget struct {
 
 	Mapping extract.Mapping
 }
-
-// installConfig is a stub for loading what we need from install-configs without having to vendor all of github.com/openshift/installer/pkg/types.
-type installConfig struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata"`
-	Platform          map[string]interface{}                   `json:"platform"`
-	Capabilities      *configv1.ClusterVersionCapabilitiesSpec `json:"capabilities,omitempty"`
-	FeatureSet        configv1.FeatureSet                      `json:"featureSet,omitempty"`
-}
-
-// manifestInclusionConfiguration configures manifest inclusion, so
-// callers can opt in to new filtering options instead of having to
-// update existing call-sites, even if they do not need a new
-// filtering option.
-type manifestInclusionConfiguration struct {
-	// ExcludeIdentifier, if non-nil, excludes manifests that match the exclusion identifier.
-	ExcludeIdentifier *string
-
-	// RequiredFeatureSet, if non-nil, excludes manifests unless they match the desired feature set.
-	RequiredFeatureSet *string
-
-	// Profile, if non-nil, excludes manifests unless they match the cluster profile.
-	Profile *string
-
-	// Capabilities, if non-nil, excludes manifests unless they match the enabled cluster capabilities.
-	Capabilities *configv1.ClusterVersionCapabilitiesStatus
-
-	// Overrides excludes manifests for overridden resources.
-	Overrides []configv1.ComponentOverride
-
-	// Platform, if non-nil, excludes CredentialsRequests manifests unless they match the infrastructure platform.
-	Platform *string
-}
-
-type includer func(m *manifest.Manifest) error
 
 // extractTools extracts all referenced commands as archives in the target dir.
 func (o *ExtractOptions) extractTools() error {
@@ -952,123 +906,5 @@ func copyAndReplace(errorOutput io.Writer, w io.Writer, r io.Reader, bufferSize 
 		// can search for matches that span buffers
 		copy(buf[:writeTo], buf[writeTo:end])
 		offset = end - writeTo
-	}
-}
-
-func findClusterIncludeConfigFromInstallConfig(ctx context.Context, installConfigPath string) (manifestInclusionConfiguration, error) {
-	config := manifestInclusionConfiguration{}
-
-	clientVersion, reportedVersion, err := version.ExtractVersion()
-	if err != nil {
-		return config, err
-	}
-	if reportedVersion == "" {
-		reportedVersion = clientVersion.String()
-	}
-
-	installConfigBytes, err := os.ReadFile(installConfigPath)
-	if err != nil {
-		return config, err
-	}
-
-	data := installConfig{}
-
-	if err := yaml.Unmarshal(installConfigBytes, &data); err != nil {
-		return config, fmt.Errorf("failed to parse %s: %w", installConfigPath, err)
-	}
-
-	if data.APIVersion != "v1" {
-		return config, fmt.Errorf("unrecognized %s API version: %q (expected %q)", installConfigPath, data.APIVersion, "v1")
-	}
-
-	config.RequiredFeatureSet = pointer.String(string(data.FeatureSet))
-	config.Profile = pointer.String(manifest.DefaultClusterProfile) // assumption, but there's no install-config data about profile to give us more insight
-	for key := range data.Platform {
-		config.Platform = pointer.String(key)
-	}
-
-	if data.Capabilities != nil {
-		config.Capabilities = &configv1.ClusterVersionCapabilitiesStatus{}
-		if enabled, ok := configv1.ClusterVersionCapabilitySets[data.Capabilities.BaselineCapabilitySet]; !ok {
-			return config, fmt.Errorf("unrecognized baselineCapabilitySet %q", data.Capabilities.BaselineCapabilitySet)
-		} else {
-			if data.Capabilities.BaselineCapabilitySet == configv1.ClusterVersionCapabilitySetCurrent {
-				klog.Infof("If the eventual cluster will not be the same minor version as this %s 'oc', the actual %s capability set may differ.", reportedVersion, data.Capabilities.BaselineCapabilitySet)
-			}
-			config.Capabilities.EnabledCapabilities = append(config.Capabilities.EnabledCapabilities, enabled...)
-		}
-		config.Capabilities.EnabledCapabilities = append(config.Capabilities.EnabledCapabilities, data.Capabilities.AdditionalEnabledCapabilities...)
-
-		klog.Infof("If the eventual cluster will not be the same minor version as this %s 'oc', the known capability sets may differ.", reportedVersion)
-		config.Capabilities.KnownCapabilities = configv1.KnownClusterVersionCapabilities
-	}
-
-	return config, nil
-}
-
-func findClusterIncludeConfig(ctx context.Context, restConfig *rest.Config) (manifestInclusionConfiguration, error) {
-	config := manifestInclusionConfiguration{}
-
-	client, err := configv1client.NewForConfig(restConfig)
-	if err != nil {
-		return config, err
-	}
-
-	if featureGate, err := client.FeatureGates().Get(ctx, "cluster", metav1.GetOptions{}); err != nil {
-		return config, err
-	} else {
-		config.RequiredFeatureSet = pointer.String(string(featureGate.Spec.FeatureSet))
-	}
-
-	if clusterVersion, err := client.ClusterVersions().Get(ctx, "version", metav1.GetOptions{}); err != nil {
-		return config, err
-	} else {
-		config.Overrides = clusterVersion.Spec.Overrides
-		config.Capabilities = &clusterVersion.Status.Capabilities
-
-		// FIXME: eventually pull in GetImplicitlyEnabledCapabilities from https://github.com/openshift/cluster-version-operator/blob/86e24d66119a73f50282b66a8d6f2e3518aa0e15/pkg/payload/payload.go#L237-L240 for cases where a minor update would implicitly enable some additional capabilities.  For now, 4.13 to 4.14 will always enable MachineAPI.
-		currentVersion := clusterVersion.Status.Desired.Version
-		matches := regexp.MustCompile(`^(\d+[.]\d+)[.].*`).FindStringSubmatch(currentVersion)
-		if len(matches) < 2 {
-			return config, fmt.Errorf("failed to parse major.minor version from ClusterVersion status.desired.version %q", currentVersion)
-		} else if matches[1] == "4.13" {
-			machineAPI := configv1.ClusterVersionCapability("MachineAPI")
-			config.Capabilities.EnabledCapabilities = append(config.Capabilities.EnabledCapabilities, machineAPI)
-			config.Capabilities.KnownCapabilities = append(config.Capabilities.KnownCapabilities, machineAPI)
-		}
-	}
-
-	if infrastructure, err := client.Infrastructures().Get(ctx, "cluster", metav1.GetOptions{}); err != nil {
-		return config, err
-	} else if infrastructure.Status.PlatformStatus == nil {
-		return config, fmt.Errorf("cluster infrastructure does not declare status.platformStatus: %v", infrastructure.Status)
-	} else {
-		config.Platform = pointer.String(strings.ToLower(string(infrastructure.Status.PlatformStatus.Type)))
-	}
-
-	appsClient, err := appsv1client.NewForConfig(restConfig)
-	if err != nil {
-		return config, err
-	}
-
-	if deployment, err := appsClient.Deployments("openshift-cluster-version").Get(ctx, "cluster-version-operator", metav1.GetOptions{}); err != nil {
-		return config, err
-	} else {
-		for _, container := range deployment.Spec.Template.Spec.Containers {
-			for _, env := range container.Env {
-				if env.Name == "CLUSTER_PROFILE" {
-					config.Profile = pointer.String(env.Value)
-					break
-				}
-			}
-		}
-	}
-
-	return config, nil
-}
-
-func newIncluder(config manifestInclusionConfiguration) includer {
-	return func(m *manifest.Manifest) error {
-		return m.Include(config.ExcludeIdentifier, config.RequiredFeatureSet, config.Profile, config.Capabilities, config.Overrides)
 	}
 }

--- a/pkg/cli/admin/release/mirror.go
+++ b/pkg/cli/admin/release/mirror.go
@@ -152,7 +152,7 @@ func NewMirror(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.C
 		Run: func(cmd *cobra.Command, args []string) {
 			kcmdutil.CheckErr(o.Complete(cmd, f, args))
 			kcmdutil.CheckErr(o.Validate())
-			kcmdutil.CheckErr(o.Run(cmd.Context()))
+			kcmdutil.CheckErr(o.Run())
 		},
 	}
 	flags := cmd.Flags()
@@ -410,7 +410,7 @@ func (o *MirrorOptions) handleSignatures(context context.Context, signaturesByDi
 	return nil
 }
 
-func (o *MirrorOptions) Run(ctx context.Context) error {
+func (o *MirrorOptions) Run() error {
 	var recreateRequired bool
 	var hasPrefix bool
 	var targetFn func(name string) imagesource.TypedImageReference
@@ -524,7 +524,7 @@ func (o *MirrorOptions) Run(ctx context.Context) error {
 		}
 		extractOpts.FileDir = o.FromDir
 		extractOpts.From = o.From
-		if err := extractOpts.Run(ctx); err != nil {
+		if err := extractOpts.Run(); err != nil {
 			return fmt.Errorf("unable to retrieve release image info: %v", err)
 		}
 

--- a/pkg/cli/admin/release/new.go
+++ b/pkg/cli/admin/release/new.go
@@ -113,7 +113,7 @@ func NewRelease(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.
 		Run: func(cmd *cobra.Command, args []string) {
 			kcmdutil.CheckErr(o.Complete(f, cmd, args))
 			kcmdutil.CheckErr(o.Validate())
-			kcmdutil.CheckErr(o.Run(cmd.Context()))
+			kcmdutil.CheckErr(o.Run())
 		},
 	}
 	flags := cmd.Flags()
@@ -311,7 +311,7 @@ func (o *NewOptions) cleanup() {
 	o.cleanupFns = nil
 }
 
-func (o *NewOptions) Run(ctx context.Context) error {
+func (o *NewOptions) Run() error {
 	defer o.cleanup()
 
 	// check parameters
@@ -717,7 +717,7 @@ func (o *NewOptions) Run(ctx context.Context) error {
 	}
 
 	if len(o.Mirror) > 0 {
-		if err := o.mirrorImages(ctx, is); err != nil {
+		if err := o.mirrorImages(is); err != nil {
 			return err
 		}
 	}
@@ -1084,7 +1084,7 @@ func (o *NewOptions) extractManifests(is *imageapi.ImageStream, name string, met
 	return nil
 }
 
-func (o *NewOptions) mirrorImages(ctx context.Context, is *imageapi.ImageStream) error {
+func (o *NewOptions) mirrorImages(is *imageapi.ImageStream) error {
 	klog.V(4).Infof("Mirroring release contents to %s", o.Mirror)
 	copied := is.DeepCopy()
 	opts := NewMirrorOptions(genericclioptions.IOStreams{Out: o.Out, ErrOut: o.ErrOut})
@@ -1096,7 +1096,7 @@ func (o *NewOptions) mirrorImages(ctx context.Context, is *imageapi.ImageStream)
 	opts.SecurityOptions = o.SecurityOptions
 	opts.KeepManifestList = o.KeepManifestList
 
-	if err := opts.Run(ctx); err != nil {
+	if err := opts.Run(); err != nil {
 		return err
 	}
 

--- a/pkg/cli/admin/release/new_test.go
+++ b/pkg/cli/admin/release/new_test.go
@@ -1,7 +1,6 @@
 package release
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -14,8 +13,6 @@ import (
 )
 
 func TestMirrorImages(t *testing.T) {
-	ctx := context.Background()
-
 	tests := []struct {
 		is                  *imageapi.ImageStream
 		expectedWarningMsgs []string
@@ -71,7 +68,7 @@ func TestMirrorImages(t *testing.T) {
 
 	for _, tt := range tests {
 		options := NewNewOptions(ioStream)
-		err := options.mirrorImages(ctx, tt.is)
+		err := options.mirrorImages(tt.is)
 
 		if err != nil {
 			if len(tt.expectedErr) == 0 {


### PR DESCRIPTION
This reverts commit 9ec4f46e2fa3110f558900d5c482fb3b448bbc5d.

We suspect that https://github.com/openshift/oc/pull/1521 has broken all
Metal jobs, an example of a failure:
https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_cluster-baremetal-operator/355/pull-ci-openshift-cluster-baremetal-operator-master-e2e-metal-ipi-ovn-ipv6/1691359315740332032.

After the change, "oc adm extract" expects KUBECONFIG to be present, but at the point
when we call it, there is no cluster.
