### PR TITLE
OCPBUGS-17925: pkg/cli/admin/prune/images: omit not found error for deployment configs

### DIFF
--- a/pkg/cli/admin/prune/images/images.go
+++ b/pkg/cli/admin/prune/images/images.go
@@ -270,9 +270,11 @@ func (o PruneImagesOptions) Validate() error {
 	return nil
 }
 
-var errNoRegistryURLPathAllowed = errors.New("no path after <host>[:<port>] is allowed")
-var errNoRegistryURLQueryAllowed = errors.New("no query arguments are allowed after <host>[:<port>]")
-var errRegistryURLHostEmpty = errors.New("no host name specified")
+var (
+	errNoRegistryURLPathAllowed  = errors.New("no path after <host>[:<port>] is allowed")
+	errNoRegistryURLQueryAllowed = errors.New("no query arguments are allowed after <host>[:<port>]")
+	errRegistryURLHostEmpty      = errors.New("no host name specified")
+)
 
 // validateRegistryURL returns error if the given input is not a valid registry URL. The url may be prefixed
 // with http:// or https:// schema. It may not contain any path or query after the host:[port].
@@ -355,7 +357,7 @@ func (o PruneImagesOptions) Run() error {
 	}
 
 	allDCs, err := o.AppsClient.DeploymentConfigs(o.Namespace).List(context.TODO(), metav1.ListOptions{})
-	if err != nil {
+	if err != nil && !kerrors.IsNotFound(err) {
 		return err
 	}
 


### PR DESCRIPTION
Allows the pruner to run on clusters without the DeploymentConfig capability.