### PR TITLE
OCPBUGS-15772: Decouple new-app and set commands scheme from global scheme

### DIFF
--- a/cmd/oc/oc.go
+++ b/cmd/oc/oc.go
@@ -14,8 +14,6 @@ import (
 	"k8s.io/kubectl/pkg/scheme"
 
 	"github.com/openshift/oc/pkg/cli"
-	"github.com/openshift/oc/pkg/cli/set"
-	"github.com/openshift/oc/pkg/helpers/newapp"
 	schemehelper "github.com/openshift/oc/pkg/helpers/scheme"
 	"github.com/openshift/oc/pkg/version"
 
@@ -43,9 +41,8 @@ func main() {
 
 	// the kubectl scheme expects to have all the recognizable external types it needs to consume.  Install those here.
 	// We can't use the "normal" scheme because apply will use that to build stategic merge patches on CustomResources
+	// new-app and set commands don't use this global scheme. Instead they use their own scheme.
 	schemehelper.InstallSchemes(scheme.Scheme)
-	newapp.InstallSchemes()
-	set.InstallSchemes()
 
 	basename := filepath.Base(os.Args[0])
 	command := cli.CommandFor(basename)

--- a/cmd/oc/oc.go
+++ b/cmd/oc/oc.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/openshift/oc/pkg/cli/set"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -46,6 +47,7 @@ func main() {
 	// We can't use the "normal" scheme because apply will use that to build stategic merge patches on CustomResources
 	schemehelper.InstallSchemes(scheme.Scheme)
 	newapp.InstallSchemes()
+	set.InstallSchemes()
 
 	basename := filepath.Base(os.Args[0])
 	command := cli.CommandFor(basename)

--- a/cmd/oc/oc.go
+++ b/cmd/oc/oc.go
@@ -1,14 +1,9 @@
 package main
 
 import (
-	"github.com/openshift/oc/pkg/cli/set"
 	"os"
 	"path/filepath"
 	"runtime"
-
-	"github.com/openshift/oc/pkg/helpers/newapp"
-
-	"k8s.io/kubectl/pkg/scheme"
 
 	"github.com/spf13/pflag"
 
@@ -16,8 +11,11 @@ import (
 	kcli "k8s.io/component-base/cli"
 	"k8s.io/component-base/logs"
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/scheme"
 
 	"github.com/openshift/oc/pkg/cli"
+	"github.com/openshift/oc/pkg/cli/set"
+	"github.com/openshift/oc/pkg/helpers/newapp"
 	schemehelper "github.com/openshift/oc/pkg/helpers/scheme"
 	"github.com/openshift/oc/pkg/version"
 

--- a/cmd/oc/oc_test.go
+++ b/cmd/oc/oc_test.go
@@ -4,6 +4,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/openshift/oc/pkg/helpers/scheme"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -14,7 +16,7 @@ import (
 
 func TestInstallNonCRDSecurity(t *testing.T) {
 	withoutCRDs := runtime.NewScheme()
-	utilruntime.Must(installNonCRDSecurity(withoutCRDs))
+	utilruntime.Must(scheme.InstallNonCRDSecurity(withoutCRDs))
 	nonCRDTypes := gvks(withoutCRDs.AllKnownTypes())
 
 	complete := runtime.NewScheme()

--- a/pkg/cli/newapp/newapp.go
+++ b/pkg/cli/newapp/newapp.go
@@ -36,7 +36,6 @@ import (
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/generate"
 	"k8s.io/kubectl/pkg/polymorphichelpers"
-	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util/templates"
 
 	appsv1 "github.com/openshift/api/apps/v1"
@@ -205,7 +204,7 @@ func (o *ObjectGeneratorOptions) Complete(f kcmdutil.Factory, c *cobra.Command, 
 		return err
 	}
 
-	o.Action.Bulk.Scheme = newAppScheme
+	o.Action.Bulk.Scheme = newAppBulkScheme
 	o.Action.Bulk.Op = bulk.Creator{Client: dynamicClient, RESTMapper: mapper}.Create
 	// Retry is used to support previous versions of the API server that will
 	// consider the presence of an unknown trigger type to be an error.
@@ -443,7 +442,7 @@ func (o *AppOptions) RunNewApp() error {
 			continue
 		}
 
-		obj, err := scheme.Scheme.New(unstructuredObj.GroupVersionKind())
+		obj, err := newapp.NewAppScheme.New(unstructuredObj.GroupVersionKind())
 		if err != nil {
 			return err
 		}
@@ -533,7 +532,7 @@ func getServices(items []runtime.Object) []*corev1.Service {
 	var svc []*corev1.Service
 	for _, i := range items {
 		unstructuredObj := i.(*unstructured.Unstructured)
-		obj, err := scheme.Scheme.New(unstructuredObj.GroupVersionKind())
+		obj, err := newapp.NewAppScheme.New(unstructuredObj.GroupVersionKind())
 		if err != nil {
 			klog.V(1).Info(err)
 			continue
@@ -677,7 +676,7 @@ func CompleteAppConfig(config *newcmd.AppConfig, f kcmdutil.Factory, c *cobra.Co
 		config.Mapper = mapper
 	}
 	if config.Typer == nil {
-		config.Typer = scheme.Scheme
+		config.Typer = newapp.NewAppScheme
 	}
 
 	namespace, _, err := f.ToRawKubeConfigLoader().Namespace()

--- a/pkg/cli/newapp/scheme.go
+++ b/pkg/cli/newapp/scheme.go
@@ -17,12 +17,18 @@ import (
 	"github.com/openshift/api/security"
 	"github.com/openshift/api/template"
 	"github.com/openshift/api/user"
+
+	"github.com/openshift/oc/pkg/helpers/newapp"
 )
 
 // we need a scheme that contains ONLY groupped APIs for newapp
-var newAppBulkScheme = runtime.NewScheme()
+var (
+	newAppBulkScheme = runtime.NewScheme()
+)
 
 func init() {
+	newapp.InstallSchemes()
+
 	utilruntime.Must(api.InstallKube(newAppBulkScheme))
 
 	utilruntime.Must(apps.Install(newAppBulkScheme))

--- a/pkg/cli/newapp/scheme.go
+++ b/pkg/cli/newapp/scheme.go
@@ -17,8 +17,6 @@ import (
 	"github.com/openshift/api/security"
 	"github.com/openshift/api/template"
 	"github.com/openshift/api/user"
-
-	"github.com/openshift/oc/pkg/helpers/newapp"
 )
 
 // we need a scheme that contains ONLY groupped APIs for newapp
@@ -27,8 +25,6 @@ var (
 )
 
 func init() {
-	newapp.InstallSchemes()
-
 	utilruntime.Must(api.InstallKube(newAppBulkScheme))
 
 	utilruntime.Must(apps.Install(newAppBulkScheme))

--- a/pkg/cli/newapp/scheme.go
+++ b/pkg/cli/newapp/scheme.go
@@ -20,21 +20,21 @@ import (
 )
 
 // we need a scheme that contains ONLY groupped APIs for newapp
-var newAppScheme = runtime.NewScheme()
+var newAppBulkScheme = runtime.NewScheme()
 
 func init() {
-	utilruntime.Must(api.InstallKube(newAppScheme))
+	utilruntime.Must(api.InstallKube(newAppBulkScheme))
 
-	utilruntime.Must(apps.Install(newAppScheme))
-	utilruntime.Must(authorization.Install(newAppScheme))
-	utilruntime.Must(build.Install(newAppScheme))
-	utilruntime.Must(image.Install(newAppScheme))
-	utilruntime.Must(network.Install(newAppScheme))
-	utilruntime.Must(oauth.Install(newAppScheme))
-	utilruntime.Must(project.Install(newAppScheme))
-	utilruntime.Must(quota.Install(newAppScheme))
-	utilruntime.Must(route.Install(newAppScheme))
-	utilruntime.Must(security.Install(newAppScheme))
-	utilruntime.Must(template.Install(newAppScheme))
-	utilruntime.Must(user.Install(newAppScheme))
+	utilruntime.Must(apps.Install(newAppBulkScheme))
+	utilruntime.Must(authorization.Install(newAppBulkScheme))
+	utilruntime.Must(build.Install(newAppBulkScheme))
+	utilruntime.Must(image.Install(newAppBulkScheme))
+	utilruntime.Must(network.Install(newAppBulkScheme))
+	utilruntime.Must(oauth.Install(newAppBulkScheme))
+	utilruntime.Must(project.Install(newAppBulkScheme))
+	utilruntime.Must(quota.Install(newAppBulkScheme))
+	utilruntime.Must(route.Install(newAppBulkScheme))
+	utilruntime.Must(security.Install(newAppBulkScheme))
+	utilruntime.Must(template.Install(newAppBulkScheme))
+	utilruntime.Must(user.Install(newAppBulkScheme))
 }

--- a/pkg/cli/rollout/cancel.go
+++ b/pkg/cli/rollout/cancel.go
@@ -170,7 +170,7 @@ func (o CancelOptions) Run() error {
 				return false
 			}
 
-			patches := set.CalculatePatchesExternal([]*resource.Info{{Object: rc, Mapping: mapping}}, func(info *resource.Info) (bool, error) {
+			patches := set.CalculatePatchesExternal(scheme.DefaultJSONEncoder(), []*resource.Info{{Object: rc, Mapping: mapping}}, func(info *resource.Info) (bool, error) {
 				appsutil.SetCancelledByUserReason(rc)
 				return true, nil
 			})

--- a/pkg/cli/rollout/retry.go
+++ b/pkg/cli/rollout/retry.go
@@ -208,7 +208,7 @@ func (o RetryOptions) Run() error {
 			continue
 		}
 
-		patches := set.CalculatePatchesExternal([]*resource.Info{{Object: rc, Mapping: mapping}}, func(info *resource.Info) (bool, error) {
+		patches := set.CalculatePatchesExternal(scheme.DefaultJSONEncoder(), []*resource.Info{{Object: rc, Mapping: mapping}}, func(info *resource.Info) (bool, error) {
 			rc.Annotations[appsv1.DeploymentStatusAnnotation] = string(appsv1.DeploymentStatusNew)
 			delete(rc.Annotations, appsv1.DeploymentStatusReasonAnnotation)
 			delete(rc.Annotations, appsv1.DeploymentCancelledAnnotation)

--- a/pkg/cli/set/buildhook.go
+++ b/pkg/cli/set/buildhook.go
@@ -193,7 +193,7 @@ func (o *BuildHookOptions) Run() error {
 		return fmt.Errorf("no resources found")
 	}
 
-	patches := CalculatePatchesExternal(DefaultJSONEncoder(), infos, func(info *resource.Info) (bool, error) {
+	patches := CalculatePatchesExternal(setCmdJSONEncoder(), infos, func(info *resource.Info) (bool, error) {
 		bc, ok := info.Object.(*buildv1.BuildConfig)
 		if !ok {
 			return false, nil

--- a/pkg/cli/set/buildhook.go
+++ b/pkg/cli/set/buildhook.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/kubectl/pkg/util/templates"
 
 	buildv1 "github.com/openshift/api/build/v1"
-	"k8s.io/kubectl/pkg/scheme"
 )
 
 var (
@@ -75,7 +74,7 @@ type BuildHookOptions struct {
 
 func NewBuildHookOptions(streams genericclioptions.IOStreams) *BuildHookOptions {
 	return &BuildHookOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("hooks updated").WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("hooks updated").WithTypeSetter(setCustomScheme),
 		IOStreams:  streams,
 	}
 }
@@ -167,7 +166,7 @@ func (o *BuildHookOptions) Validate() error {
 
 func (o *BuildHookOptions) Run() error {
 	b := o.Builder().
-		WithScheme(scheme.Scheme, scheme.Scheme.PrioritizedVersionsAllGroups()...).
+		WithScheme(setCustomScheme, setCustomScheme.PrioritizedVersionsAllGroups()...).
 		LocalParam(o.Local).
 		ContinueOnError().
 		NamespaceParam(o.Namespace).DefaultNamespace().

--- a/pkg/cli/set/buildhook.go
+++ b/pkg/cli/set/buildhook.go
@@ -74,7 +74,7 @@ type BuildHookOptions struct {
 
 func NewBuildHookOptions(streams genericclioptions.IOStreams) *BuildHookOptions {
 	return &BuildHookOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("hooks updated").WithTypeSetter(setCustomScheme),
+		PrintFlags: genericclioptions.NewPrintFlags("hooks updated").WithTypeSetter(setCmdScheme),
 		IOStreams:  streams,
 	}
 }
@@ -166,7 +166,7 @@ func (o *BuildHookOptions) Validate() error {
 
 func (o *BuildHookOptions) Run() error {
 	b := o.Builder().
-		WithScheme(setCustomScheme, setCustomScheme.PrioritizedVersionsAllGroups()...).
+		WithScheme(setCmdScheme, setCmdScheme.PrioritizedVersionsAllGroups()...).
 		LocalParam(o.Local).
 		ContinueOnError().
 		NamespaceParam(o.Namespace).DefaultNamespace().
@@ -193,7 +193,7 @@ func (o *BuildHookOptions) Run() error {
 		return fmt.Errorf("no resources found")
 	}
 
-	patches := CalculatePatchesExternal(infos, func(info *resource.Info) (bool, error) {
+	patches := CalculatePatchesExternal(DefaultJSONEncoder(), infos, func(info *resource.Info) (bool, error) {
 		bc, ok := info.Object.(*buildv1.BuildConfig)
 		if !ok {
 			return false, nil

--- a/pkg/cli/set/buildsecret.go
+++ b/pkg/cli/set/buildsecret.go
@@ -226,7 +226,7 @@ func (o *BuildSecretOptions) Run() error {
 		return err
 	}
 
-	patches := CalculatePatchesExternal(DefaultJSONEncoder(), infos, func(info *resource.Info) (bool, error) {
+	patches := CalculatePatchesExternal(setCmdJSONEncoder(), infos, func(info *resource.Info) (bool, error) {
 		bc, ok := info.Object.(*buildv1.BuildConfig)
 		if !ok {
 			return false, nil

--- a/pkg/cli/set/buildsecret.go
+++ b/pkg/cli/set/buildsecret.go
@@ -74,7 +74,7 @@ type BuildSecretOptions struct {
 
 func NewBuildSecretOptions(streams genericclioptions.IOStreams) *BuildSecretOptions {
 	return &BuildSecretOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("secret updated").WithTypeSetter(setCustomScheme),
+		PrintFlags: genericclioptions.NewPrintFlags("secret updated").WithTypeSetter(setCmdScheme),
 		IOStreams:  streams,
 	}
 }
@@ -114,7 +114,7 @@ var supportedBuildTypes = []string{"buildconfigs"}
 
 func (o *BuildSecretOptions) secretFromArg(arg string) (string, error) {
 	builder := o.Builder().
-		WithScheme(setCustomScheme, setCustomScheme.PrioritizedVersionsAllGroups()...).
+		WithScheme(setCmdScheme, setCmdScheme.PrioritizedVersionsAllGroups()...).
 		LocalParam(o.Local).
 		NamespaceParam(o.Namespace).DefaultNamespace().
 		RequireObject(false).
@@ -203,7 +203,7 @@ func (o *BuildSecretOptions) Run() error {
 	}
 
 	b := o.Builder().
-		WithScheme(setCustomScheme, setCustomScheme.PrioritizedVersionsAllGroups()...).
+		WithScheme(setCmdScheme, setCmdScheme.PrioritizedVersionsAllGroups()...).
 		LocalParam(o.Local).
 		ContinueOnError().
 		NamespaceParam(o.Namespace).DefaultNamespace().
@@ -226,7 +226,7 @@ func (o *BuildSecretOptions) Run() error {
 		return err
 	}
 
-	patches := CalculatePatchesExternal(infos, func(info *resource.Info) (bool, error) {
+	patches := CalculatePatchesExternal(DefaultJSONEncoder(), infos, func(info *resource.Info) (bool, error) {
 		bc, ok := info.Object.(*buildv1.BuildConfig)
 		if !ok {
 			return false, nil

--- a/pkg/cli/set/buildsecret.go
+++ b/pkg/cli/set/buildsecret.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util/templates"
 
 	buildv1 "github.com/openshift/api/build/v1"
@@ -75,7 +74,7 @@ type BuildSecretOptions struct {
 
 func NewBuildSecretOptions(streams genericclioptions.IOStreams) *BuildSecretOptions {
 	return &BuildSecretOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("secret updated").WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("secret updated").WithTypeSetter(setCustomScheme),
 		IOStreams:  streams,
 	}
 }
@@ -115,7 +114,7 @@ var supportedBuildTypes = []string{"buildconfigs"}
 
 func (o *BuildSecretOptions) secretFromArg(arg string) (string, error) {
 	builder := o.Builder().
-		WithScheme(scheme.Scheme, scheme.Scheme.PrioritizedVersionsAllGroups()...).
+		WithScheme(setCustomScheme, setCustomScheme.PrioritizedVersionsAllGroups()...).
 		LocalParam(o.Local).
 		NamespaceParam(o.Namespace).DefaultNamespace().
 		RequireObject(false).
@@ -204,7 +203,7 @@ func (o *BuildSecretOptions) Run() error {
 	}
 
 	b := o.Builder().
-		WithScheme(scheme.Scheme, scheme.Scheme.PrioritizedVersionsAllGroups()...).
+		WithScheme(setCustomScheme, setCustomScheme.PrioritizedVersionsAllGroups()...).
 		LocalParam(o.Local).
 		ContinueOnError().
 		NamespaceParam(o.Namespace).DefaultNamespace().

--- a/pkg/cli/set/data.go
+++ b/pkg/cli/set/data.go
@@ -89,7 +89,7 @@ type DataOptions struct {
 
 func NewDataOptions(streams genericclioptions.IOStreams) *DataOptions {
 	return &DataOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("data updated").WithTypeSetter(setCustomScheme),
+		PrintFlags: genericclioptions.NewPrintFlags("data updated").WithTypeSetter(setCmdScheme),
 		IOStreams:  streams,
 	}
 }
@@ -216,7 +216,7 @@ func (o *DataOptions) Validate() error {
 
 func (o *DataOptions) Run() error {
 	b := o.Builder().
-		WithScheme(setCustomScheme, setCustomScheme.PrioritizedVersionsAllGroups()...).
+		WithScheme(setCmdScheme, setCmdScheme.PrioritizedVersionsAllGroups()...).
 		LocalParam(o.Local).
 		ContinueOnError().
 		NamespaceParam(o.Namespace).DefaultNamespace().
@@ -238,7 +238,7 @@ func (o *DataOptions) Run() error {
 
 	allErrs := []error{}
 
-	patches := CalculatePatchesExternal(infos, func(info *resource.Info) (bool, error) {
+	patches := CalculatePatchesExternal(DefaultJSONEncoder(), infos, func(info *resource.Info) (bool, error) {
 		changed := false
 		valid, err := o.UpdateDataForObject(info.Object, func(data map[string][]byte) error {
 			for k, v := range o.SetData {

--- a/pkg/cli/set/data.go
+++ b/pkg/cli/set/data.go
@@ -19,7 +19,6 @@ import (
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -90,7 +89,7 @@ type DataOptions struct {
 
 func NewDataOptions(streams genericclioptions.IOStreams) *DataOptions {
 	return &DataOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("data updated").WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("data updated").WithTypeSetter(setCustomScheme),
 		IOStreams:  streams,
 	}
 }
@@ -217,7 +216,7 @@ func (o *DataOptions) Validate() error {
 
 func (o *DataOptions) Run() error {
 	b := o.Builder().
-		WithScheme(scheme.Scheme, scheme.Scheme.PrioritizedVersionsAllGroups()...).
+		WithScheme(setCustomScheme, setCustomScheme.PrioritizedVersionsAllGroups()...).
 		LocalParam(o.Local).
 		ContinueOnError().
 		NamespaceParam(o.Namespace).DefaultNamespace().

--- a/pkg/cli/set/data.go
+++ b/pkg/cli/set/data.go
@@ -238,7 +238,7 @@ func (o *DataOptions) Run() error {
 
 	allErrs := []error{}
 
-	patches := CalculatePatchesExternal(DefaultJSONEncoder(), infos, func(info *resource.Info) (bool, error) {
+	patches := CalculatePatchesExternal(setCmdJSONEncoder(), infos, func(info *resource.Info) (bool, error) {
 		changed := false
 		valid, err := o.UpdateDataForObject(info.Object, func(data map[string][]byte) error {
 			for k, v := range o.SetData {

--- a/pkg/cli/set/deploymenthook.go
+++ b/pkg/cli/set/deploymenthook.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util/templates"
 
 	appsv1 "github.com/openshift/api/apps/v1"
@@ -89,7 +88,7 @@ type DeploymentHookOptions struct {
 
 func NewDeploymentHookOptions(streams genericclioptions.IOStreams) *DeploymentHookOptions {
 	return &DeploymentHookOptions{
-		PrintFlags:       genericclioptions.NewPrintFlags("hooks updated").WithTypeSetter(scheme.Scheme),
+		PrintFlags:       genericclioptions.NewPrintFlags("hooks updated").WithTypeSetter(setCustomScheme),
 		IOStreams:        streams,
 		FailurePolicyStr: "ignore",
 	}
@@ -216,7 +215,7 @@ func (o *DeploymentHookOptions) Validate() error {
 
 func (o *DeploymentHookOptions) Run() error {
 	b := o.Builder().
-		WithScheme(scheme.Scheme, scheme.Scheme.PrioritizedVersionsAllGroups()...).
+		WithScheme(setCustomScheme, setCustomScheme.PrioritizedVersionsAllGroups()...).
 		LocalParam(o.Local).
 		ContinueOnError().
 		NamespaceParam(o.Namespace).DefaultNamespace().

--- a/pkg/cli/set/deploymenthook.go
+++ b/pkg/cli/set/deploymenthook.go
@@ -239,7 +239,7 @@ func (o *DeploymentHookOptions) Run() error {
 		return err
 	}
 
-	patches := CalculatePatchesExternal(DefaultJSONEncoder(), infos, func(info *resource.Info) (bool, error) {
+	patches := CalculatePatchesExternal(setCmdJSONEncoder(), infos, func(info *resource.Info) (bool, error) {
 		dc, ok := info.Object.(*appsv1.DeploymentConfig)
 		if !ok {
 			return false, nil

--- a/pkg/cli/set/deploymenthook.go
+++ b/pkg/cli/set/deploymenthook.go
@@ -88,7 +88,7 @@ type DeploymentHookOptions struct {
 
 func NewDeploymentHookOptions(streams genericclioptions.IOStreams) *DeploymentHookOptions {
 	return &DeploymentHookOptions{
-		PrintFlags:       genericclioptions.NewPrintFlags("hooks updated").WithTypeSetter(setCustomScheme),
+		PrintFlags:       genericclioptions.NewPrintFlags("hooks updated").WithTypeSetter(setCmdScheme),
 		IOStreams:        streams,
 		FailurePolicyStr: "ignore",
 	}
@@ -215,7 +215,7 @@ func (o *DeploymentHookOptions) Validate() error {
 
 func (o *DeploymentHookOptions) Run() error {
 	b := o.Builder().
-		WithScheme(setCustomScheme, setCustomScheme.PrioritizedVersionsAllGroups()...).
+		WithScheme(setCmdScheme, setCmdScheme.PrioritizedVersionsAllGroups()...).
 		LocalParam(o.Local).
 		ContinueOnError().
 		NamespaceParam(o.Namespace).DefaultNamespace().
@@ -239,7 +239,7 @@ func (o *DeploymentHookOptions) Run() error {
 		return err
 	}
 
-	patches := CalculatePatchesExternal(infos, func(info *resource.Info) (bool, error) {
+	patches := CalculatePatchesExternal(DefaultJSONEncoder(), infos, func(info *resource.Info) (bool, error) {
 		dc, ok := info.Object.(*appsv1.DeploymentConfig)
 		if !ok {
 			return false, nil

--- a/pkg/cli/set/env.go
+++ b/pkg/cli/set/env.go
@@ -118,7 +118,7 @@ type EnvOptions struct {
 
 func NewEnvOptions(streams genericclioptions.IOStreams) *EnvOptions {
 	return &EnvOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("updated").WithTypeSetter(setCustomScheme),
+		PrintFlags: genericclioptions.NewPrintFlags("updated").WithTypeSetter(setCmdScheme),
 		IOStreams:  streams,
 
 		ContainerSelector: "*",
@@ -249,7 +249,7 @@ func (o *EnvOptions) RunEnv() error {
 
 	if len(o.From) != 0 {
 		b := o.Builder().
-			WithScheme(setCustomScheme, setCustomScheme.PrioritizedVersionsAllGroups()...).
+			WithScheme(setCmdScheme, setCmdScheme.PrioritizedVersionsAllGroups()...).
 			LocalParam(o.Local).
 			ContinueOnError().
 			NamespaceParam(o.Namespace).DefaultNamespace().
@@ -314,7 +314,7 @@ func (o *EnvOptions) RunEnv() error {
 	}
 
 	b := o.Builder().
-		WithScheme(setCustomScheme, setCustomScheme.PrioritizedVersionsAllGroups()...).
+		WithScheme(setCmdScheme, setCmdScheme.PrioritizedVersionsAllGroups()...).
 		LocalParam(o.Local).
 		ContinueOnError().
 		NamespaceParam(o.Namespace).DefaultNamespace().

--- a/pkg/cli/set/env.go
+++ b/pkg/cli/set/env.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/polymorphichelpers"
-	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util/templates"
 
 	buildv1 "github.com/openshift/api/build/v1"
@@ -119,7 +118,7 @@ type EnvOptions struct {
 
 func NewEnvOptions(streams genericclioptions.IOStreams) *EnvOptions {
 	return &EnvOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("updated").WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("updated").WithTypeSetter(setCustomScheme),
 		IOStreams:  streams,
 
 		ContainerSelector: "*",
@@ -250,7 +249,7 @@ func (o *EnvOptions) RunEnv() error {
 
 	if len(o.From) != 0 {
 		b := o.Builder().
-			WithScheme(scheme.Scheme, scheme.Scheme.PrioritizedVersionsAllGroups()...).
+			WithScheme(setCustomScheme, setCustomScheme.PrioritizedVersionsAllGroups()...).
 			LocalParam(o.Local).
 			ContinueOnError().
 			NamespaceParam(o.Namespace).DefaultNamespace().
@@ -315,7 +314,7 @@ func (o *EnvOptions) RunEnv() error {
 	}
 
 	b := o.Builder().
-		WithScheme(scheme.Scheme, scheme.Scheme.PrioritizedVersionsAllGroups()...).
+		WithScheme(setCustomScheme, setCustomScheme.PrioritizedVersionsAllGroups()...).
 		LocalParam(o.Local).
 		ContinueOnError().
 		NamespaceParam(o.Namespace).DefaultNamespace().

--- a/pkg/cli/set/imagelookup.go
+++ b/pkg/cli/set/imagelookup.go
@@ -101,7 +101,7 @@ type ImageLookupOptions struct {
 
 func NewImageLookupOptions(streams genericclioptions.IOStreams) *ImageLookupOptions {
 	return &ImageLookupOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("image lookup updated").WithTypeSetter(setCustomScheme),
+		PrintFlags: genericclioptions.NewPrintFlags("image lookup updated").WithTypeSetter(setCmdScheme),
 		IOStreams:  streams,
 		Enabled:    true,
 	}
@@ -177,7 +177,7 @@ func (o *ImageLookupOptions) Validate() error {
 // Run executes the ImageLookupOptions or returns an error.
 func (o *ImageLookupOptions) Run() error {
 	b := o.Builder().
-		WithScheme(setCustomScheme, setCustomScheme.PrioritizedVersionsAllGroups()...).
+		WithScheme(setCmdScheme, setCmdScheme.PrioritizedVersionsAllGroups()...).
 		LocalParam(o.Local).
 		ContinueOnError().
 		NamespaceParam(o.Namespace).DefaultNamespace().
@@ -216,7 +216,7 @@ func (o *ImageLookupOptions) Run() error {
 		return o.printImageLookup(infos)
 	}
 
-	patches := CalculatePatchesExternal(infos, func(info *resource.Info) (bool, error) {
+	patches := CalculatePatchesExternal(DefaultJSONEncoder(), infos, func(info *resource.Info) (bool, error) {
 		switch t := info.Object.(type) {
 		case *imagev1.ImageStream:
 			t.Spec.LookupPolicy.Local = o.Enabled

--- a/pkg/cli/set/imagelookup.go
+++ b/pkg/cli/set/imagelookup.go
@@ -216,7 +216,7 @@ func (o *ImageLookupOptions) Run() error {
 		return o.printImageLookup(infos)
 	}
 
-	patches := CalculatePatchesExternal(DefaultJSONEncoder(), infos, func(info *resource.Info) (bool, error) {
+	patches := CalculatePatchesExternal(setCmdJSONEncoder(), infos, func(info *resource.Info) (bool, error) {
 		switch t := info.Object.(type) {
 		case *imagev1.ImageStream:
 			t.Spec.LookupPolicy.Local = o.Enabled

--- a/pkg/cli/set/imagelookup.go
+++ b/pkg/cli/set/imagelookup.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util/templates"
 
 	imagev1 "github.com/openshift/api/image/v1"
@@ -102,7 +101,7 @@ type ImageLookupOptions struct {
 
 func NewImageLookupOptions(streams genericclioptions.IOStreams) *ImageLookupOptions {
 	return &ImageLookupOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("image lookup updated").WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("image lookup updated").WithTypeSetter(setCustomScheme),
 		IOStreams:  streams,
 		Enabled:    true,
 	}
@@ -178,7 +177,7 @@ func (o *ImageLookupOptions) Validate() error {
 // Run executes the ImageLookupOptions or returns an error.
 func (o *ImageLookupOptions) Run() error {
 	b := o.Builder().
-		WithScheme(scheme.Scheme, scheme.Scheme.PrioritizedVersionsAllGroups()...).
+		WithScheme(setCustomScheme, setCustomScheme.PrioritizedVersionsAllGroups()...).
 		LocalParam(o.Local).
 		ContinueOnError().
 		NamespaceParam(o.Namespace).DefaultNamespace().

--- a/pkg/cli/set/probe.go
+++ b/pkg/cli/set/probe.go
@@ -21,7 +21,6 @@ import (
 	"k8s.io/cli-runtime/pkg/resource"
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/polymorphichelpers"
-	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util/templates"
 )
 
@@ -119,7 +118,7 @@ type ProbeOptions struct {
 
 func NewProbeOptions(streams genericclioptions.IOStreams) *ProbeOptions {
 	return &ProbeOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("probes updated").WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("probes updated").WithTypeSetter(setCustomScheme),
 		IOStreams:  streams,
 
 		ContainerSelector: "*",
@@ -286,7 +285,7 @@ func (o *ProbeOptions) Validate() error {
 
 func (o *ProbeOptions) Run() error {
 	b := o.Builder().
-		WithScheme(scheme.Scheme, scheme.Scheme.PrioritizedVersionsAllGroups()...).
+		WithScheme(setCustomScheme, setCustomScheme.PrioritizedVersionsAllGroups()...).
 		LocalParam(o.Local).
 		ContinueOnError().
 		NamespaceParam(o.Namespace).DefaultNamespace().

--- a/pkg/cli/set/probe.go
+++ b/pkg/cli/set/probe.go
@@ -118,7 +118,7 @@ type ProbeOptions struct {
 
 func NewProbeOptions(streams genericclioptions.IOStreams) *ProbeOptions {
 	return &ProbeOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("probes updated").WithTypeSetter(setCustomScheme),
+		PrintFlags: genericclioptions.NewPrintFlags("probes updated").WithTypeSetter(setCmdScheme),
 		IOStreams:  streams,
 
 		ContainerSelector: "*",
@@ -285,7 +285,7 @@ func (o *ProbeOptions) Validate() error {
 
 func (o *ProbeOptions) Run() error {
 	b := o.Builder().
-		WithScheme(setCustomScheme, setCustomScheme.PrioritizedVersionsAllGroups()...).
+		WithScheme(setCmdScheme, setCmdScheme.PrioritizedVersionsAllGroups()...).
 		LocalParam(o.Local).
 		ContinueOnError().
 		NamespaceParam(o.Namespace).DefaultNamespace().
@@ -305,7 +305,7 @@ func (o *ProbeOptions) Run() error {
 		return err
 	}
 
-	patches := CalculatePatchesExternal(infos, func(info *resource.Info) (bool, error) {
+	patches := CalculatePatchesExternal(DefaultJSONEncoder(), infos, func(info *resource.Info) (bool, error) {
 		transformed := false
 		name := getObjectName(info)
 		_, err := o.UpdatePodSpecForObject(info.Object, func(spec *corev1.PodSpec) error {

--- a/pkg/cli/set/probe.go
+++ b/pkg/cli/set/probe.go
@@ -305,7 +305,7 @@ func (o *ProbeOptions) Run() error {
 		return err
 	}
 
-	patches := CalculatePatchesExternal(DefaultJSONEncoder(), infos, func(info *resource.Info) (bool, error) {
+	patches := CalculatePatchesExternal(setCmdJSONEncoder(), infos, func(info *resource.Info) (bool, error) {
 		transformed := false
 		name := getObjectName(info)
 		_, err := o.UpdatePodSpecForObject(info.Object, func(spec *corev1.PodSpec) error {

--- a/pkg/cli/set/routebackends.go
+++ b/pkg/cli/set/routebackends.go
@@ -92,7 +92,7 @@ type BackendsOptions struct {
 
 func NewBackendsOptions(streams genericclioptions.IOStreams) *BackendsOptions {
 	return &BackendsOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("backends updated").WithTypeSetter(setCustomScheme),
+		PrintFlags: genericclioptions.NewPrintFlags("backends updated").WithTypeSetter(setCmdScheme),
 		IOStreams:  streams,
 	}
 }
@@ -176,7 +176,7 @@ func (o *BackendsOptions) Validate() error {
 // Run executes the BackendOptions or returns an error.
 func (o *BackendsOptions) Run() error {
 	b := o.Builder().
-		WithScheme(setCustomScheme, setCustomScheme.PrioritizedVersionsAllGroups()...).
+		WithScheme(setCmdScheme, setCmdScheme.PrioritizedVersionsAllGroups()...).
 		LocalParam(o.Local).
 		ContinueOnError().
 		NamespaceParam(o.Namespace).DefaultNamespace().
@@ -203,7 +203,7 @@ func (o *BackendsOptions) Run() error {
 		return o.printBackends(infos)
 	}
 
-	patches := CalculatePatchesExternal(infos, func(info *resource.Info) (bool, error) {
+	patches := CalculatePatchesExternal(DefaultJSONEncoder(), infos, func(info *resource.Info) (bool, error) {
 		return UpdateBackendsForObject(info.Object, o.Transform.Apply)
 	})
 	if singleItemImplied && len(patches) == 0 {

--- a/pkg/cli/set/routebackends.go
+++ b/pkg/cli/set/routebackends.go
@@ -18,7 +18,6 @@ import (
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util/templates"
 
 	routev1 "github.com/openshift/api/route/v1"
@@ -93,7 +92,7 @@ type BackendsOptions struct {
 
 func NewBackendsOptions(streams genericclioptions.IOStreams) *BackendsOptions {
 	return &BackendsOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("backends updated").WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("backends updated").WithTypeSetter(setCustomScheme),
 		IOStreams:  streams,
 	}
 }
@@ -177,7 +176,7 @@ func (o *BackendsOptions) Validate() error {
 // Run executes the BackendOptions or returns an error.
 func (o *BackendsOptions) Run() error {
 	b := o.Builder().
-		WithScheme(scheme.Scheme, scheme.Scheme.PrioritizedVersionsAllGroups()...).
+		WithScheme(setCustomScheme, setCustomScheme.PrioritizedVersionsAllGroups()...).
 		LocalParam(o.Local).
 		ContinueOnError().
 		NamespaceParam(o.Namespace).DefaultNamespace().

--- a/pkg/cli/set/routebackends.go
+++ b/pkg/cli/set/routebackends.go
@@ -203,7 +203,7 @@ func (o *BackendsOptions) Run() error {
 		return o.printBackends(infos)
 	}
 
-	patches := CalculatePatchesExternal(DefaultJSONEncoder(), infos, func(info *resource.Info) (bool, error) {
+	patches := CalculatePatchesExternal(setCmdJSONEncoder(), infos, func(info *resource.Info) (bool, error) {
 		return UpdateBackendsForObject(info.Object, o.Transform.Apply)
 	})
 	if singleItemImplied && len(patches) == 0 {

--- a/pkg/cli/set/scheme.go
+++ b/pkg/cli/set/scheme.go
@@ -31,6 +31,6 @@ func init() {
 	utilruntime.Must(route.Install(setCmdScheme))
 }
 
-func DefaultJSONEncoder() runtime.Encoder {
+func setCmdJSONEncoder() runtime.Encoder {
 	return unstructured.NewJSONFallbackEncoder(setCmdCodecs.LegacyCodec(setCmdScheme.PrioritizedVersionsAllGroups()...))
 }

--- a/pkg/cli/set/scheme.go
+++ b/pkg/cli/set/scheme.go
@@ -1,11 +1,13 @@
 package set
 
 import (
-	"github.com/openshift/api"
-	"github.com/openshift/api/route"
-	schemehelper "github.com/openshift/oc/pkg/helpers/scheme"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	"github.com/openshift/api"
+	"github.com/openshift/api/route"
+
+	schemehelper "github.com/openshift/oc/pkg/helpers/scheme"
 )
 
 var setCustomScheme = runtime.NewScheme()
@@ -17,7 +19,7 @@ func InstallSchemes() {
 	// as CRD and there is no benefit installing route
 	// as native object which is normally managed
 	// by openshift-apiserver(microshift has no openshift-apiserver).
-	// But new-app command requires to
+	// But set route-backends command requires to
 	// register route to let some application templates including
 	// route continue working. That's why, we are manually
 	// registering route in here.

--- a/pkg/cli/set/scheme.go
+++ b/pkg/cli/set/scheme.go
@@ -1,0 +1,25 @@
+package set
+
+import (
+	"github.com/openshift/api"
+	"github.com/openshift/api/route"
+	schemehelper "github.com/openshift/oc/pkg/helpers/scheme"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+var setCustomScheme = runtime.NewScheme()
+
+func InstallSchemes() {
+	utilruntime.Must(api.InstallKube(setCustomScheme))
+	schemehelper.InstallSchemes(setCustomScheme)
+	// All the other commands can use route object
+	// as CRD and there is no benefit installing route
+	// as native object which is normally managed
+	// by openshift-apiserver(microshift has no openshift-apiserver).
+	// But new-app command requires to
+	// register route to let some application templates including
+	// route continue working. That's why, we are manually
+	// registering route in here.
+	utilruntime.Must(route.Install(setCustomScheme))
+}

--- a/pkg/cli/set/triggers.go
+++ b/pkg/cli/set/triggers.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util/templates"
 
 	appsv1 "github.com/openshift/api/apps/v1"
@@ -123,7 +122,7 @@ type TriggersOptions struct {
 
 func NewTriggersOptions(streams genericclioptions.IOStreams) *TriggersOptions {
 	return &TriggersOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("triggers updated").WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("triggers updated").WithTypeSetter(setCustomScheme),
 		IOStreams:  streams,
 	}
 }
@@ -281,7 +280,7 @@ func (o *TriggersOptions) Validate() error {
 
 func (o *TriggersOptions) Run() error {
 	b := o.Builder().
-		WithScheme(scheme.Scheme, scheme.Scheme.PrioritizedVersionsAllGroups()...).
+		WithScheme(setCustomScheme, setCustomScheme.PrioritizedVersionsAllGroups()...).
 		LocalParam(o.Local).
 		ContinueOnError().
 		NamespaceParam(o.Namespace).DefaultNamespace().

--- a/pkg/cli/set/triggers.go
+++ b/pkg/cli/set/triggers.go
@@ -122,7 +122,7 @@ type TriggersOptions struct {
 
 func NewTriggersOptions(streams genericclioptions.IOStreams) *TriggersOptions {
 	return &TriggersOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("triggers updated").WithTypeSetter(setCustomScheme),
+		PrintFlags: genericclioptions.NewPrintFlags("triggers updated").WithTypeSetter(setCmdScheme),
 		IOStreams:  streams,
 	}
 }
@@ -280,7 +280,7 @@ func (o *TriggersOptions) Validate() error {
 
 func (o *TriggersOptions) Run() error {
 	b := o.Builder().
-		WithScheme(setCustomScheme, setCustomScheme.PrioritizedVersionsAllGroups()...).
+		WithScheme(setCmdScheme, setCmdScheme.PrioritizedVersionsAllGroups()...).
 		LocalParam(o.Local).
 		ContinueOnError().
 		NamespaceParam(o.Namespace).DefaultNamespace().
@@ -308,7 +308,7 @@ func (o *TriggersOptions) Run() error {
 		o.updateTriggers(triggers)
 		return nil
 	}
-	patches := CalculatePatchesExternal(infos, func(info *resource.Info) (bool, error) {
+	patches := CalculatePatchesExternal(DefaultJSONEncoder(), infos, func(info *resource.Info) (bool, error) {
 		return UpdateTriggersForObject(info.Object, updateTriggerFn)
 	})
 	if singleItemImplied && len(patches) == 0 {

--- a/pkg/cli/set/triggers.go
+++ b/pkg/cli/set/triggers.go
@@ -308,7 +308,7 @@ func (o *TriggersOptions) Run() error {
 		o.updateTriggers(triggers)
 		return nil
 	}
-	patches := CalculatePatchesExternal(DefaultJSONEncoder(), infos, func(info *resource.Info) (bool, error) {
+	patches := CalculatePatchesExternal(setCmdJSONEncoder(), infos, func(info *resource.Info) (bool, error) {
 		return UpdateTriggersForObject(info.Object, updateTriggerFn)
 	})
 	if singleItemImplied && len(patches) == 0 {

--- a/pkg/cli/set/volume.go
+++ b/pkg/cli/set/volume.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/polymorphichelpers"
-	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util/templates"
 )
 
@@ -157,7 +156,7 @@ type AddVolumeOptions struct {
 
 func NewVolumeOptions(streams genericclioptions.IOStreams) *VolumeOptions {
 	return &VolumeOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("volume updated").WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("volume updated").WithTypeSetter(setCustomScheme),
 
 		Containers: "*",
 		AddOpts: &AddVolumeOptions{
@@ -444,7 +443,7 @@ func (a *AddVolumeOptions) Complete() error {
 
 func (o *VolumeOptions) RunVolume() error {
 	b := o.Builder().
-		WithScheme(scheme.Scheme, scheme.Scheme.PrioritizedVersionsAllGroups()...).
+		WithScheme(setCustomScheme, setCustomScheme.PrioritizedVersionsAllGroups()...).
 		LocalParam(o.Local).
 		ContinueOnError().
 		NamespaceParam(o.DefaultNamespace).DefaultNamespace().

--- a/pkg/cli/set/volume.go
+++ b/pkg/cli/set/volume.go
@@ -552,7 +552,7 @@ func (o *VolumeOptions) RunVolume() error {
 
 func (o *VolumeOptions) getVolumeUpdatePatches(infos []*resource.Info, singleItemImplied bool) ([]*Patch, error) {
 	skipped := 0
-	patches := CalculatePatchesExternal(DefaultJSONEncoder(), infos, func(info *resource.Info) (bool, error) {
+	patches := CalculatePatchesExternal(setCmdJSONEncoder(), infos, func(info *resource.Info) (bool, error) {
 		transformed := false
 		ok, err := o.UpdatePodSpecForObject(info.Object, func(spec *corev1.PodSpec) error {
 			var e error

--- a/pkg/cli/set/volume.go
+++ b/pkg/cli/set/volume.go
@@ -156,7 +156,7 @@ type AddVolumeOptions struct {
 
 func NewVolumeOptions(streams genericclioptions.IOStreams) *VolumeOptions {
 	return &VolumeOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("volume updated").WithTypeSetter(setCustomScheme),
+		PrintFlags: genericclioptions.NewPrintFlags("volume updated").WithTypeSetter(setCmdScheme),
 
 		Containers: "*",
 		AddOpts: &AddVolumeOptions{
@@ -443,7 +443,7 @@ func (a *AddVolumeOptions) Complete() error {
 
 func (o *VolumeOptions) RunVolume() error {
 	b := o.Builder().
-		WithScheme(setCustomScheme, setCustomScheme.PrioritizedVersionsAllGroups()...).
+		WithScheme(setCmdScheme, setCmdScheme.PrioritizedVersionsAllGroups()...).
 		LocalParam(o.Local).
 		ContinueOnError().
 		NamespaceParam(o.DefaultNamespace).DefaultNamespace().
@@ -552,7 +552,7 @@ func (o *VolumeOptions) RunVolume() error {
 
 func (o *VolumeOptions) getVolumeUpdatePatches(infos []*resource.Info, singleItemImplied bool) ([]*Patch, error) {
 	skipped := 0
-	patches := CalculatePatchesExternal(infos, func(info *resource.Info) (bool, error) {
+	patches := CalculatePatchesExternal(DefaultJSONEncoder(), infos, func(info *resource.Info) (bool, error) {
 		transformed := false
 		ok, err := o.UpdatePodSpecForObject(info.Object, func(spec *corev1.PodSpec) error {
 			var e error

--- a/pkg/helpers/newapp/app/templatelookup.go
+++ b/pkg/helpers/newapp/app/templatelookup.go
@@ -6,16 +6,17 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/openshift/oc/pkg/helpers/newapp"
-
-	templatev1 "github.com/openshift/api/template/v1"
-	templatev1typedclient "github.com/openshift/client-go/template/clientset/versioned/typed/template/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/klog/v2"
+
+	templatev1 "github.com/openshift/api/template/v1"
+	templatev1typedclient "github.com/openshift/client-go/template/clientset/versioned/typed/template/v1"
+
+	"github.com/openshift/oc/pkg/helpers/newapp"
 )
 
 // TemplateSearcher resolves stored template arguments into template objects

--- a/pkg/helpers/newapp/app/templatelookup.go
+++ b/pkg/helpers/newapp/app/templatelookup.go
@@ -6,16 +6,16 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/openshift/oc/pkg/helpers/newapp"
+
+	templatev1 "github.com/openshift/api/template/v1"
+	templatev1typedclient "github.com/openshift/client-go/template/clientset/versioned/typed/template/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/klog/v2"
-	"k8s.io/kubectl/pkg/scheme"
-
-	templatev1 "github.com/openshift/api/template/v1"
-	templatev1typedclient "github.com/openshift/client-go/template/clientset/versioned/typed/template/v1"
 )
 
 // TemplateSearcher resolves stored template arguments into template objects
@@ -124,7 +124,7 @@ func (r *TemplateFileSearcher) Search(precise bool, terms ...string) (ComponentM
 
 		var isSingleItemImplied bool
 		obj, err := r.Builder.
-			WithScheme(scheme.Scheme, scheme.Scheme.PrioritizedVersionsAllGroups()...).
+			WithScheme(newapp.NewAppScheme, newapp.NewAppScheme.PrioritizedVersionsAllGroups()...).
 			NamespaceParam(r.Namespace).RequireNamespace().
 			FilenameParam(false, &resource.FilenameOptions{Recursive: false, Filenames: terms}).
 			Do().

--- a/pkg/helpers/newapp/cmd/newapp.go
+++ b/pkg/helpers/newapp/cmd/newapp.go
@@ -10,7 +10,19 @@ import (
 	"strings"
 
 	docker "github.com/fsouza/go-dockerclient"
+
 	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
+	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
 	appsv1 "github.com/openshift/api/apps/v1"
@@ -35,17 +47,6 @@ import (
 	"github.com/openshift/oc/pkg/helpers/newapp/jenkinsfile"
 	"github.com/openshift/oc/pkg/helpers/newapp/source"
 	"github.com/openshift/oc/pkg/helpers/template/templateprocessorclient"
-	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
-	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
-	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	kutilerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/cli-runtime/pkg/resource"
-	"k8s.io/client-go/kubernetes"
 )
 
 const (

--- a/pkg/helpers/newapp/cmd/newapp.go
+++ b/pkg/helpers/newapp/cmd/newapp.go
@@ -13,19 +13,6 @@ import (
 	v1 "k8s.io/api/apps/v1"
 	"k8s.io/klog/v2"
 
-	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
-	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
-	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	kutilerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/cli-runtime/pkg/resource"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/kubectl/pkg/scheme"
-
 	appsv1 "github.com/openshift/api/apps/v1"
 	authv1 "github.com/openshift/api/authorization/v1"
 	buildv1 "github.com/openshift/api/build/v1"
@@ -48,6 +35,17 @@ import (
 	"github.com/openshift/oc/pkg/helpers/newapp/jenkinsfile"
 	"github.com/openshift/oc/pkg/helpers/newapp/source"
 	"github.com/openshift/oc/pkg/helpers/template/templateprocessorclient"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
+	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/client-go/kubernetes"
 )
 
 const (
@@ -863,7 +861,7 @@ func templateObjectsToAppObjects(objs []runtime.RawExtension) (app.Objects, erro
 			continue
 		}
 
-		obj, err := runtime.Decode(scheme.Codecs.UniversalDeserializer(), raw.Raw)
+		obj, err := runtime.Decode(newapp.NewAppCodecs.UniversalDeserializer(), raw.Raw)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/helpers/newapp/scheme.go
+++ b/pkg/helpers/newapp/scheme.go
@@ -15,7 +15,7 @@ var NewAppScheme = runtime.NewScheme()
 
 var NewAppCodecs = serializer.NewCodecFactory(NewAppScheme)
 
-func InstallSchemes() {
+func init() {
 	utilruntime.Must(api.InstallKube(NewAppScheme))
 	schemehelper.InstallSchemes(NewAppScheme)
 	// All the other commands can use route object
@@ -27,8 +27,4 @@ func InstallSchemes() {
 	// route continue working. That's why, we are manually
 	// registering route in here.
 	utilruntime.Must(route.Install(NewAppScheme))
-}
-
-func init() {
-	InstallSchemes()
 }

--- a/pkg/helpers/newapp/scheme.go
+++ b/pkg/helpers/newapp/scheme.go
@@ -28,3 +28,7 @@ func InstallSchemes() {
 	// registering route in here.
 	utilruntime.Must(route.Install(NewAppScheme))
 }
+
+func init() {
+	InstallSchemes()
+}

--- a/pkg/helpers/newapp/scheme.go
+++ b/pkg/helpers/newapp/scheme.go
@@ -1,0 +1,28 @@
+package newapp
+
+import (
+	"github.com/openshift/api"
+	"github.com/openshift/api/route"
+	schemehelper "github.com/openshift/oc/pkg/helpers/scheme"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+var NewAppScheme = runtime.NewScheme()
+
+var NewAppCodecs = serializer.NewCodecFactory(NewAppScheme)
+
+func InstallSchemes() {
+	utilruntime.Must(api.InstallKube(NewAppScheme))
+	schemehelper.InstallSchemes(NewAppScheme)
+	// All the other commands can use route object
+	// as CRD and there is no benefit installing route
+	// as native object which is normally managed
+	// by openshift-apiserver(microshift has no openshift-apiserver).
+	// But new-app command requires to
+	// register route to let some application templates including
+	// route continue working. That's why, we are manually
+	// registering route in here.
+	utilruntime.Must(route.Install(NewAppScheme))
+}

--- a/pkg/helpers/newapp/scheme.go
+++ b/pkg/helpers/newapp/scheme.go
@@ -1,12 +1,14 @@
 package newapp
 
 import (
-	"github.com/openshift/api"
-	"github.com/openshift/api/route"
-	schemehelper "github.com/openshift/oc/pkg/helpers/scheme"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	"github.com/openshift/api"
+	"github.com/openshift/api/route"
+
+	schemehelper "github.com/openshift/oc/pkg/helpers/scheme"
 )
 
 var NewAppScheme = runtime.NewScheme()

--- a/pkg/helpers/scheme/scheme.go
+++ b/pkg/helpers/scheme/scheme.go
@@ -1,22 +1,23 @@
 package scheme
 
 import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	"github.com/openshift/api/apps"
 	"github.com/openshift/api/authorization"
 	"github.com/openshift/api/build"
 	"github.com/openshift/api/image"
 	"github.com/openshift/api/oauth"
 	"github.com/openshift/api/project"
-	"github.com/openshift/api/template"
-	"github.com/openshift/api/user"
-	"github.com/openshift/oc/pkg/helpers/legacy"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-
 	quotav1 "github.com/openshift/api/quota/v1"
 	securityv1 "github.com/openshift/api/security/v1"
+	"github.com/openshift/api/template"
+	"github.com/openshift/api/user"
+
+	"github.com/openshift/oc/pkg/helpers/legacy"
 )
 
 func InstallSchemes(scheme *apimachineryruntime.Scheme) {
@@ -26,14 +27,14 @@ func InstallSchemes(scheme *apimachineryruntime.Scheme) {
 	utilruntime.Must(image.Install(scheme))
 	utilruntime.Must(oauth.Install(scheme))
 	utilruntime.Must(project.Install(scheme))
-	utilruntime.Must(installNonCRDQuota(scheme))
-	utilruntime.Must(installNonCRDSecurity(scheme))
+	utilruntime.Must(InstallNonCRDQuota(scheme))
+	utilruntime.Must(InstallNonCRDSecurity(scheme))
 	utilruntime.Must(template.Install(scheme))
 	utilruntime.Must(user.Install(scheme))
 	legacy.InstallExternalLegacyAll(scheme)
 }
 
-func installNonCRDSecurity(scheme *apimachineryruntime.Scheme) error {
+func InstallNonCRDSecurity(scheme *apimachineryruntime.Scheme) error {
 	scheme.AddKnownTypes(securityv1.GroupVersion,
 		&securityv1.PodSecurityPolicySubjectReview{},
 		&securityv1.PodSecurityPolicySelfSubjectReview{},
@@ -48,7 +49,7 @@ func installNonCRDSecurity(scheme *apimachineryruntime.Scheme) error {
 	return nil
 }
 
-func installNonCRDQuota(scheme *apimachineryruntime.Scheme) error {
+func InstallNonCRDQuota(scheme *apimachineryruntime.Scheme) error {
 	scheme.AddKnownTypes(securityv1.GroupVersion,
 		&quotav1.AppliedClusterResourceQuota{},
 		&quotav1.AppliedClusterResourceQuotaList{},

--- a/pkg/helpers/scheme/scheme.go
+++ b/pkg/helpers/scheme/scheme.go
@@ -1,0 +1,61 @@
+package scheme
+
+import (
+	"github.com/openshift/api/apps"
+	"github.com/openshift/api/authorization"
+	"github.com/openshift/api/build"
+	"github.com/openshift/api/image"
+	"github.com/openshift/api/oauth"
+	"github.com/openshift/api/project"
+	"github.com/openshift/api/template"
+	"github.com/openshift/api/user"
+	"github.com/openshift/oc/pkg/helpers/legacy"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	quotav1 "github.com/openshift/api/quota/v1"
+	securityv1 "github.com/openshift/api/security/v1"
+)
+
+func InstallSchemes(scheme *apimachineryruntime.Scheme) {
+	utilruntime.Must(apps.Install(scheme))
+	utilruntime.Must(authorization.Install(scheme))
+	utilruntime.Must(build.Install(scheme))
+	utilruntime.Must(image.Install(scheme))
+	utilruntime.Must(oauth.Install(scheme))
+	utilruntime.Must(project.Install(scheme))
+	utilruntime.Must(installNonCRDQuota(scheme))
+	utilruntime.Must(installNonCRDSecurity(scheme))
+	utilruntime.Must(template.Install(scheme))
+	utilruntime.Must(user.Install(scheme))
+	legacy.InstallExternalLegacyAll(scheme)
+}
+
+func installNonCRDSecurity(scheme *apimachineryruntime.Scheme) error {
+	scheme.AddKnownTypes(securityv1.GroupVersion,
+		&securityv1.PodSecurityPolicySubjectReview{},
+		&securityv1.PodSecurityPolicySelfSubjectReview{},
+		&securityv1.PodSecurityPolicyReview{},
+		&securityv1.RangeAllocation{},
+		&securityv1.RangeAllocationList{},
+	)
+	if err := corev1.AddToScheme(scheme); err != nil {
+		return err
+	}
+	metav1.AddToGroupVersion(scheme, securityv1.GroupVersion)
+	return nil
+}
+
+func installNonCRDQuota(scheme *apimachineryruntime.Scheme) error {
+	scheme.AddKnownTypes(securityv1.GroupVersion,
+		&quotav1.AppliedClusterResourceQuota{},
+		&quotav1.AppliedClusterResourceQuotaList{},
+	)
+	if err := corev1.AddToScheme(scheme); err != nil {
+		return err
+	}
+	metav1.AddToGroupVersion(scheme, quotav1.GroupVersion)
+	return nil
+}


### PR DESCRIPTION
Currently, route schema is registered for all commands in oc to
use it as native resource. Route is managed by openshift-apiserver and
up to this now, it works without any problem as well as vendoring
is happening in oc.

However, microshift does not have openshift-apiserver and that's why,
some commands behave differently whether object is native or CRD such
as `oc edit route`, `oc patch route`, etc. and these commands are failing on microshift.

To make `oc edit route` working on microshift, we have to remove registration
of routes.openshift.io and the rest of commands should work without any
problem embracing routes.openshift.io as CRD except that the `oc new-app`
and `oc set route-backends` commands. `oc new-app` must register Routes 
because there are templates creating route resources. 
In order to keep route templates working in
oc new-app command, this PR adds route.openshift.io registration just
for oc new-app and oc set route-backends and removes from the others.