### PR TITLE
The latest tags are openshift-clients-*.

### DIFF
--- a/vendor/github.com/openshift/build-machinery-go/make/lib/golang.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/lib/golang.mk
@@ -50,7 +50,7 @@ GO_TEST_FLAGS ?=-race
 
 GO_LD_EXTRAFLAGS ?=
 
-SOURCE_GIT_TAG ?=$(shell git describe --long --tags --abbrev=7 --match 'v[0-9]*' || echo 'v0.0.0-unknown-$(SOURCE_GIT_COMMIT)')
+SOURCE_GIT_TAG ?=$(shell git describe --long --tags --abbrev=7 --match 'openshift-clients-[0-9]*' | sed 's/^openshift-clients-/v/' | grep . || echo 'v0.0.0-unknown-$(SOURCE_GIT_COMMIT)')
 SOURCE_GIT_COMMIT ?=$(shell git rev-parse --short "HEAD^{commit}" 2>/dev/null)
 SOURCE_GIT_TREE_STATE ?=$(shell ( ( [ ! -d ".git/" ] || git diff --quiet ) && echo 'clean' ) || echo 'dirty')
 


### PR DESCRIPTION
Avoid 4.2.0 being considered the current version.

We force the output to the vX.Y.Z format because that's what the rest of the code assumes.