### PR TITLE
OCPBUGS-18961: pkg/cli/admin/release/extract_tools: Enable ImageRegistry, etc. on 4.13-to-4.14

### DIFF
--- a/pkg/cli/admin/release/extract_tools.go
+++ b/pkg/cli/admin/release/extract_tools.go
@@ -1026,15 +1026,17 @@ func findClusterIncludeConfig(ctx context.Context, restConfig *rest.Config) (man
 		config.Overrides = clusterVersion.Spec.Overrides
 		config.Capabilities = &clusterVersion.Status.Capabilities
 
-		// FIXME: eventually pull in GetImplicitlyEnabledCapabilities from https://github.com/openshift/cluster-version-operator/blob/86e24d66119a73f50282b66a8d6f2e3518aa0e15/pkg/payload/payload.go#L237-L240 for cases where a minor update would implicitly enable some additional capabilities.  For now, 4.13 to 4.14 will always enable MachineAPI.
+		// FIXME: eventually pull in GetImplicitlyEnabledCapabilities from https://github.com/openshift/cluster-version-operator/blob/86e24d66119a73f50282b66a8d6f2e3518aa0e15/pkg/payload/payload.go#L237-L240 for cases where a minor update would implicitly enable some additional capabilities.  For now, 4.13 to 4.14 will always enable MachineAPI, ImageRegistry, etc..
 		currentVersion := clusterVersion.Status.Desired.Version
 		matches := regexp.MustCompile(`^(\d+[.]\d+)[.].*`).FindStringSubmatch(currentVersion)
 		if len(matches) < 2 {
 			return config, fmt.Errorf("failed to parse major.minor version from ClusterVersion status.desired.version %q", currentVersion)
 		} else if matches[1] == "4.13" {
-			machineAPI := configv1.ClusterVersionCapability("MachineAPI")
-			config.Capabilities.EnabledCapabilities = append(config.Capabilities.EnabledCapabilities, machineAPI)
-			config.Capabilities.KnownCapabilities = append(config.Capabilities.KnownCapabilities, machineAPI)
+			build := configv1.ClusterVersionCapability("Build")
+			deploymentConfig := configv1.ClusterVersionCapability("DeploymentConfig")
+			imageRegistry := configv1.ClusterVersionCapability("ImageRegistry")
+			config.Capabilities.EnabledCapabilities = append(config.Capabilities.EnabledCapabilities, configv1.ClusterVersionCapabilityMachineAPI, build, deploymentConfig, imageRegistry)
+			config.Capabilities.KnownCapabilities = append(config.Capabilities.KnownCapabilities, configv1.ClusterVersionCapabilityMachineAPI, build, deploymentConfig, imageRegistry)
 		}
 	}
 


### PR DESCRIPTION
Catching up with [additional 4.14 capabilities][1].  As with `MachineAPI`, all of the new capabilities were enabled in all 4.13 clusters, and because [capabilities cannot be uninstalled][2], that means they'll be enabled, possibly implicitly, after an update to 4.14.  Including them here ensures that we extract the `ImageRegistry` CredentialsRequest in:

```console
$ oc adm release extract --included --credentials-requests --to credentials-requests quay.io/openshift-release-dev/ocp-release:4.14.0...
```

when connecting to a currently-4.13 cluster.  [OTA-1010][3] is tracking a more sustainable long-term approach.

[1]: https://github.com/openshift/cluster-version-operator/pull/950/commits/ba3aeb9ab9d6d20a7355f80db4c47950b307a893#diff-f3e6bd2d0c764f1c28fd5d20520a2224b1f3cb5306500aeefd056a4efc857d34R318-R336
[2]: https://github.com/openshift/enhancements/blob/6cebc13f0672c601ebfae669ea4fc8ca632721b5/enhancements/installer/component-selection.md#capabilities-cannot-be-uninstalled
[3]: https://issues.redhat.com/browse/OTA-1010