### PR TITLE
WRKLDS-537: oc adm release info: Add --first-parent to git log for simplification

### DIFF
--- a/pkg/cli/admin/release/git.go
+++ b/pkg/cli/admin/release/git.go
@@ -173,7 +173,7 @@ func mergeLogForRepo(g gitInterface, repo string, from, to string) ([]MergeCommi
 		return nil, nil
 	}
 
-	args := []string{"log", "--merges", "--topo-order", "-z", "--pretty=format:%H %P%x1E%ct%x1E%s%x1E%b", fmt.Sprintf("%s..%s", from, to)}
+	args := []string{"log", "--merges", "--topo-order", "--first-parent", "-z", "--pretty=format:%H %P%x1E%ct%x1E%s%x1E%b", fmt.Sprintf("%s..%s", from, to)}
 	out, err := g.exec(args...)
 	if err != nil {
 		// retry once if there's a chance we haven't fetched the latest commits


### PR DESCRIPTION
Currently, `oc adm release info` changelog associates bump PRs to incorrect PR numbers, when the repository is a fork of an upstream repository. This PR eliminates these incorrect PR numbers by adding `--first-parent` to git log and only
shows the actual PR which already includes the diff.

`--first-parent` will only be added to merge commits and squash merges continue as is.

<details>
<summary>Output won't be changed for typical PRs</summary>

Output is identical with https://amd64.ocp.releases.ci.openshift.org/releasestream/4.15.0-0.nightly/release/4.15.0-0.nightly-2023-09-27-150522

```sh
$ ./oc adm release info registry.ci.openshift.org/ocp/release:4.15.0-0.nightly-2023-09-27-150522 --changelog='/tmp/test_changelog' --changes-from=registry.ci.openshift.org/ocp/release:4.15.0-0.nightly-2023-09-27-073353
# 4.15.0-0.nightly-2023-09-27-150522

Created: 2023-09-27 15:07:30 +0000 UTC

Image Digest: `sha256:a3007713977019f58219877abcca1290ec5fd54651595893fd8506a5fe07a42b`


## Changes from 4.15.0-0.nightly-2023-09-27-073353

### Components

* Kubernetes 1.28.2
* Red Hat Enterprise Linux CoreOS 415.92.202309261919-0


### Rebuilt images without code change

* [machine-os-images](https://github.com/openshift/machine-os-images) git [8b90bb90](https://github.com/openshift/machine-os-images/commit/8b90bb9087c4ed0211ddca436da2c01a68c1ba0c) `sha256:3ddba9831d78636430d5cbc9ae4cb90a08e92f4d1781d40e699ac7a601b04ec9`

### [baremetal-installer, installer, installer-artifacts](https://github.com/openshift/installer/tree/f214c968ff9e9b6670b4a546f70a4cd218733770)

* [OCPBUGS-19093](https://issues.redhat.com/browse/OCPBUGS-19093), [OCPBUGS-19688](https://issues.redhat.com/browse/OCPBUGS-19688): Allow agent-tui to use serial console [#7526](https://github.com/openshift/installer/pull/7526)
* Tweaks to validateRendezvousIPNotWorker [#7437](https://github.com/openshift/installer/pull/7437)
* [Full changelog](https://github.com/openshift/installer/compare/4ce62d15df6b6d5850225796dfb1445688ec2b8e...f214c968ff9e9b6670b4a546f70a4cd218733770)

### [cloud-credential-operator](https://github.com/openshift/cloud-credential-operator/tree/286b3c5f727b1b14b6e99455f72af57133c6f32d)

* [OCPBUGS-18246](https://issues.redhat.com/browse/OCPBUGS-18246): Add networkResourceGroupName parameter for Azure [#597](https://github.com/openshift/cloud-credential-operator/pull/597)
* [Full changelog](https://github.com/openshift/cloud-credential-operator/compare/2c3298b1bb3aca9d7ebcde541b49dcef039e108a...286b3c5f727b1b14b6e99455f72af57133c6f32d)

### [cluster-monitoring-operator](https://github.com/openshift/cluster-monitoring-operator/tree/f70961525e29746a34a2f17a08685267e3aea359)

* chore: fix imports order [#2098](https://github.com/openshift/cluster-monitoring-operator/pull/2098)
* [Full changelog](https://github.com/openshift/cluster-monitoring-operator/compare/1f4c82b34cb9d82e11cfe4869d914a113f4cc919...f70961525e29746a34a2f17a08685267e3aea359)

### [cluster-node-tuning-operator](https://github.com/openshift/cluster-node-tuning-operator/tree/d698198261be6bc86f1b67134cfc848c0cb1c58e)

* [OCPBUGS-18783](https://issues.redhat.com/browse/OCPBUGS-18783): e2e: perfprof: enhance the scheduling domain tests (#791) [#791](https://github.com/openshift/cluster-node-tuning-operator/pull/791)
* [Full changelog](https://github.com/openshift/cluster-node-tuning-operator/compare/4ca8e91f224f6937100d6f4d7d2a254cd40ca166...d698198261be6bc86f1b67134cfc848c0cb1c58e)

### [console](https://github.com/openshift/console/tree/010c28af7755920d266469cd6e869948cd6ff398)

* [OCPBUGS-14322](https://issues.redhat.com/browse/OCPBUGS-14322): fix ResourceLog permissions when impersonating [#13196](https://github.com/openshift/console/pull/13196)
* [Full changelog](https://github.com/openshift/console/compare/1e8d1ab7b6440b6ea96f72cb2dec1209aa314dcd...010c28af7755920d266469cd6e869948cd6ff398)

### [machine-config-operator](https://github.com/openshift/machine-config-operator/tree/d136bfa5e476a67aeed117d1858c5036f099fb86)

* Improve kubelet error log [#3914](https://github.com/openshift/machine-config-operator/pull/3914)
* [Full changelog](https://github.com/openshift/machine-config-operator/compare/ff7ef2ec8ddbdf4f5758ee8f3ba3fea2d364e581...d136bfa5e476a67aeed117d1858c5036f099fb86)

### [tests](https://github.com/openshift/origin/tree/47ffece46a02f17e887cb431130198f06def6302)

* Bump openshift/kubernetes to get vSphere fix [#28278](https://github.com/openshift/origin/pull/28278)
* Force using mirrored images in disruption tests [#28258](https://github.com/openshift/origin/pull/28258)
* [Full changelog](https://github.com/openshift/origin/compare/1e388c33867fb146b21bbf3e178b6e1d7dd9ae6c...47ffece46a02f17e887cb431130198f06def6302)

### [vsphere-csi-driver, vsphere-csi-driver-syncer](https://github.com/openshift/vmware-vsphere-csi-driver/tree/f0b840bd88e884e7371633d7795066648059de77)

* [OCPBUGS-19198](https://issues.redhat.com/browse/OCPBUGS-19198): Updating ose-vmware-vsphere-csi-driver images to be consistent with ART [#87](https://github.com/openshift/vmware-vsphere-csi-driver/pull/87)
* [Full changelog](https://github.com/openshift/vmware-vsphere-csi-driver/compare/ebc2f372718ad8b442b99a005773e6d8da5549a6...f0b840bd88e884e7371633d7795066648059de77)

### [vsphere-csi-driver-operator](https://github.com/openshift/vmware-vsphere-csi-driver-operator/tree/2018ce60b979553bf210f3b93c6f6687949468f8)

* [OCPBUGS-19198](https://issues.redhat.com/browse/OCPBUGS-19198): Updating ose-vmware-vsphere-csi-driver-operator images to be consistent with ART [#170](https://github.com/openshift/vmware-vsphere-csi-driver-operator/pull/170)
* [Full changelog](https://github.com/openshift/vmware-vsphere-csi-driver-operator/compare/a8c196e8cc6061b60af066a490966608c26b19ce...2018ce60b979553bf210f3b93c6f6687949468f8)


```
</details>

<details>
<summary>Output will be simplified for bump PRs</summary>

Output is identical with https://amd64.ocp.releases.ci.openshift.org/releasestream/4.15.0-0.nightly/release/4.15.0-0.nightly-2023-09-27-015804 for typical PRs and simpler for bump PRs (please see ` [baremetal-operator]` section)

```sh
$ ./oc adm release info registry.ci.openshift.org/ocp/release:4.15.0-0.nightly-2023-09-27-015804 --changelog='/tmp/test_changelog' --changes-from=registry.ci.openshift.org/ocp/release:4.15.0-0.nightly-2023-09-17-045811
# 4.15.0-0.nightly-2023-09-27-015804

Created: 2023-09-27 02:00:14 +0000 UTC

Image Digest: `sha256:6ea741cdf4259e591671a05bec20cb61197522b6955bf4f1c174fa8441834684`


## Changes from 4.15.0-0.nightly-2023-09-17-045811

### Components

* Kubernetes 1.28.2
* Red Hat Enterprise Linux CoreOS upgraded from 415.92.202309161058-0 to 415.92.202309261919-0


### [agent-installer-api-server](https://github.com/openshift/assisted-service/tree/431b5fea359f04c9d3041e1e052054365f3bd2f1)

* Bump OCP versions: 4.14 (#5512) [#5512](https://github.com/openshift/assisted-service/pull/5512)
* NO-ISSUE: Fix email domain for event uploader (#5511) [#5511](https://github.com/openshift/assisted-service/pull/5511)
* Update RHTAP references (#5510) [#5510](https://github.com/openshift/assisted-service/pull/5510)
* Update RHTAP references (#5508) [#5508](https://github.com/openshift/assisted-service/pull/5508)
* Bump OCP versions: 4.12, 4.13 (#5506) [#5506](https://github.com/openshift/assisted-service/pull/5506)
* [MGMT-15808](https://issues.redhat.com/browse/MGMT-15808): change base image to stream9 (#5497) [#5497](https://github.com/openshift/assisted-service/pull/5497)
* [MGMT-15559](https://issues.redhat.com/browse/MGMT-15559): Change detached annotation condition in non-converged flow (#5445) [#5445](https://github.com/openshift/assisted-service/pull/5445)
* [MGMT-15732](https://issues.redhat.com/browse/MGMT-15732): Fix unbound variable (#5493) [#5493](https://github.com/openshift/assisted-service/pull/5493)
* Update RHTAP references (#5492) [#5492](https://github.com/openshift/assisted-service/pull/5492)
* Bump OCP versions: 4.14, 4.11 (#5496) [#5496](https://github.com/openshift/assisted-service/pull/5496)
* [Full changelog](https://github.com/openshift/assisted-service/compare/60d8a476e616069062e47e113b581c21daf6c775...431b5fea359f04c9d3041e1e052054365f3bd2f1)

### [agent-installer-csr-approver, agent-installer-orchestrator](https://github.com/openshift/assisted-installer/tree/15a57d1c7a455961f538b7a35455b643d66efa50)

* [MGMT-15810](https://issues.redhat.com/browse/MGMT-15810): change base image to stream9 (#725) [#725](https://github.com/openshift/assisted-installer/pull/725)
* NO-ISSUE: fix dependabot ingored packages (#724) [#724](https://github.com/openshift/assisted-installer/pull/724)
* [Full changelog](https://github.com/openshift/assisted-installer/compare/9fd99e3861fc32b8a608bb0c81344435e32ad004...15a57d1c7a455961f538b7a35455b643d66efa50)

### [agent-installer-node-agent](https://github.com/openshift/assisted-installer-agent/tree/8850b6c0d74750c403ae0675757affe54b24de72)

* Updating ose-agent-installer-node-agent images to be consistent with ART (#603) [#603](https://github.com/openshift/assisted-installer-agent/pull/603)
* [OCPBUGS-16482](https://issues.redhat.com/browse/OCPBUGS-16482): bump golangci-lint to v1.53.1 (#591) [#591](https://github.com/openshift/assisted-installer-agent/pull/591)
* NO-ISSUE: fix lint target and code (#605) [#605](https://github.com/openshift/assisted-installer-agent/pull/605)
* [Full changelog](https://github.com/openshift/assisted-installer-agent/compare/275856c5c80e0d3d32c8ff5aaf767b08ff3732c9...8850b6c0d74750c403ae0675757affe54b24de72)

### [agent-installer-utils](https://github.com/openshift/agent-installer-utils/tree/8bc5db751e3e53224235f50a0508aeeab52f6bc3)

* [OCPBUGS-19219](https://issues.redhat.com/browse/OCPBUGS-19219): Updating ose-agent-installer-utils images to be consistent with ART [#29](https://github.com/openshift/agent-installer-utils/pull/29)
* [Full changelog](https://github.com/openshift/agent-installer-utils/compare/ad8537697818870b53b6262041f0dfa78a3b41c2...8bc5db751e3e53224235f50a0508aeeab52f6bc3)

### [alibaba-cloud-csi-driver](https://github.com/openshift/alibaba-cloud-csi-driver/tree/e61daf0a5d4940b8c0fad2d3b1a0081d1ee6c250)

* [OCPBUGS-19199](https://issues.redhat.com/browse/OCPBUGS-19199): Updating ose-alibaba-cloud-csi-driver images to be consistent with ART [#33](https://github.com/openshift/alibaba-cloud-csi-driver/pull/33)
* [Full changelog](https://github.com/openshift/alibaba-cloud-csi-driver/compare/92be21f26e64b8320a10a0f324d52f482a2acbfa...e61daf0a5d4940b8c0fad2d3b1a0081d1ee6c250)

### [alibaba-disk-csi-driver-operator](https://github.com/openshift/alibaba-disk-csi-driver-operator/tree/22a88049be4dbe244059a710853ce09e872d9899)

* [STOR-1276](https://issues.redhat.com/browse/STOR-1276): Enable support for mounting volumes with SELinux context [#57](https://github.com/openshift/alibaba-disk-csi-driver-operator/pull/57)
* [OCPBUGS-19111](https://issues.redhat.com/browse/OCPBUGS-19111): Updating ose-alibaba-disk-csi-driver-operator images to be consistent with ART [#61](https://github.com/openshift/alibaba-disk-csi-driver-operator/pull/61)
* [Full changelog](https://github.com/openshift/alibaba-disk-csi-driver-operator/compare/5a9bbe6a145b8d8f1e1df977cd44d748cf0990d2...22a88049be4dbe244059a710853ce09e872d9899)

### [apiserver-network-proxy](https://github.com/openshift/apiserver-network-proxy/tree/f1e6d94ca51afe169bc038acb0b06cedea16d617)

* [OCPBUGS-19266](https://issues.redhat.com/browse/OCPBUGS-19266): Updating ose-apiserver-network-proxy images to be consistent with ART [#33](https://github.com/openshift/apiserver-network-proxy/pull/33)
* [Full changelog](https://github.com/openshift/apiserver-network-proxy/compare/15cd4347b9384fac3d93029c6426dc15b964f557...f1e6d94ca51afe169bc038acb0b06cedea16d617)

### [aws-cluster-api-controllers](https://github.com/openshift/cluster-api-provider-aws/tree/78c1a04f0a1c6ccb4a3ff96c2e5d569db794ad6d)

* [OCPBUGS-19185](https://issues.redhat.com/browse/OCPBUGS-19185): Updating ose-aws-cluster-api-controllers images to be consistent with ART [#477](https://github.com/openshift/cluster-api-provider-aws/pull/477)
* [Full changelog](https://github.com/openshift/cluster-api-provider-aws/compare/fb2b2e6126061513b2441091a1523f3214305431...78c1a04f0a1c6ccb4a3ff96c2e5d569db794ad6d)

### [aws-ebs-csi-driver](https://github.com/openshift/aws-ebs-csi-driver/tree/e22422e50888ae0058453a024518983442a58178)

* [OCPBUGS-19101](https://issues.redhat.com/browse/OCPBUGS-19101): Updating ose-aws-ebs-csi-driver images to be consistent with ART [#235](https://github.com/openshift/aws-ebs-csi-driver/pull/235)
* [Full changelog](https://github.com/openshift/aws-ebs-csi-driver/compare/b0eaa31073158d843b972a16c9a53a5b517a4178...e22422e50888ae0058453a024518983442a58178)

### [aws-ebs-csi-driver-operator](https://github.com/openshift/aws-ebs-csi-driver-operator/tree/2a52a756262bb537a59431c05683c556981ea9a8)

* Bump k8s.io/apiextensions-apiserver from 0.27.4 to 0.28.2 [#269](https://github.com/openshift/aws-ebs-csi-driver-operator/pull/269)
* [OCPBUGS-19157](https://issues.redhat.com/browse/OCPBUGS-19157): Updating ose-aws-ebs-csi-driver-operator images to be consistent with ART [#268](https://github.com/openshift/aws-ebs-csi-driver-operator/pull/268)
* [Full changelog](https://github.com/openshift/aws-ebs-csi-driver-operator/compare/a5bac21655fe994247d5fcb7a66bf271437b68a8...2a52a756262bb537a59431c05683c556981ea9a8)

### [aws-pod-identity-webhook](https://github.com/openshift/aws-pod-identity-webhook/tree/63af97636016c8e08687b91a56c97a170d7bb98c)

* [OCPBUGS-19264](https://issues.redhat.com/browse/OCPBUGS-19264): Updating ose-aws-pod-identity-webhook images to be consistent with ART [#167](https://github.com/openshift/aws-pod-identity-webhook/pull/167)
* [CCO-429](https://issues.redhat.com/browse/CCO-429): Rebase master [#166](https://github.com/openshift/aws-pod-identity-webhook/pull/166)
* [Full changelog](https://github.com/openshift/aws-pod-identity-webhook/compare/ed5ae281ece6092735140617c486e5822ce5b7b6...63af97636016c8e08687b91a56c97a170d7bb98c)

### [azure-cloud-controller-manager, azure-cloud-node-manager](https://github.com/openshift/cloud-provider-azure/tree/1148bff65e313929c4c954f7ee26a78f9f4863dc)

* [OCPBUGS-19265](https://issues.redhat.com/browse/OCPBUGS-19265): Updating ose-azure-cloud-node-manager images to be consistent with ART [#85](https://github.com/openshift/cloud-provider-azure/pull/85)
* [Full changelog](https://github.com/openshift/cloud-provider-azure/compare/cca9a841e807dd87708b82562fc5f376ed2f274c...1148bff65e313929c4c954f7ee26a78f9f4863dc)

### [azure-cluster-api-controllers](https://github.com/openshift/cluster-api-provider-azure/tree/2aec6b9229c3866a8e3ebc7b5ff6735729a237e7)

* [OCPBUGS-19147](https://issues.redhat.com/browse/OCPBUGS-19147): Updating ose-azure-cluster-api-controllers images to be consistent with ART [#282](https://github.com/openshift/cluster-api-provider-azure/pull/282)
* [Full changelog](https://github.com/openshift/cluster-api-provider-azure/compare/c015df41ed16a1eccd1ec60b77c96b4334a5bcb2...2aec6b9229c3866a8e3ebc7b5ff6735729a237e7)

### [azure-disk-csi-driver](https://github.com/openshift/azure-disk-csi-driver/tree/b901768ffacdca1d5bc39fc7d86c9631ac1b8f4e)

* [OCPBUGS-19172](https://issues.redhat.com/browse/OCPBUGS-19172): Updating ose-azure-disk-csi-driver images to be consistent with ART [#50](https://github.com/openshift/azure-disk-csi-driver/pull/50)
* [Full changelog](https://github.com/openshift/azure-disk-csi-driver/compare/9fa4016e0a53f4e218db6ea006d562784193fad3...b901768ffacdca1d5bc39fc7d86c9631ac1b8f4e)

### [azure-disk-csi-driver-operator](https://github.com/openshift/azure-disk-csi-driver-operator/tree/a6a9cbb91dccf9b8b295bfae7858200d1aa64992)

* simplify workload identity feature enablement [#92](https://github.com/openshift/azure-disk-csi-driver-operator/pull/92)
* update readme [#94](https://github.com/openshift/azure-disk-csi-driver-operator/pull/94)
* [OCPBUGS-19172](https://issues.redhat.com/browse/OCPBUGS-19172): Updating ose-azure-disk-csi-driver-operator images to be consistent with ART [#98](https://github.com/openshift/azure-disk-csi-driver-operator/pull/98)
* [Full changelog](https://github.com/openshift/azure-disk-csi-driver-operator/compare/4db2f8aac33abbc600b72a82ebe205581a998a7b...a6a9cbb91dccf9b8b295bfae7858200d1aa64992)

### [azure-file-csi-driver](https://github.com/openshift/azure-file-csi-driver/tree/b389bf8c8de379a8df0a6fbc957925573eff25ba)

* [OCPBUGS-19110](https://issues.redhat.com/browse/OCPBUGS-19110): Updating azure-file-csi-driver images to be consistent with ART [#34](https://github.com/openshift/azure-file-csi-driver/pull/34)
* [Full changelog](https://github.com/openshift/azure-file-csi-driver/compare/5112d391f1b121d8b59c478fe2505e44440441fb...b389bf8c8de379a8df0a6fbc957925573eff25ba)

### [azure-file-csi-driver-operator](https://github.com/openshift/azure-file-csi-driver-operator/tree/a172a65bfe4c76036a5f82ed9fe07aeeb4d9b7d9)

* simplify workload identity feature enablement [#69](https://github.com/openshift/azure-file-csi-driver-operator/pull/69)
* [OCPBUGS-19170](https://issues.redhat.com/browse/OCPBUGS-19170): Updating azure-file-csi-driver-operator images to be consistent with ART [#74](https://github.com/openshift/azure-file-csi-driver-operator/pull/74)
* [Full changelog](https://github.com/openshift/azure-file-csi-driver-operator/compare/8597fbd31f45dd1e387faa220eeb1a86ae618405...a172a65bfe4c76036a5f82ed9fe07aeeb4d9b7d9)


### [baremetal-installer, installer, installer-artifacts](https://github.com/openshift/installer/tree/8d96bbad2ce977aa7e6fbb5733923563881e0d4e)

* [OCPBUGS-19376](https://issues.redhat.com/browse/OCPBUGS-19376): GCP default value for service account [#7519](https://github.com/openshift/installer/pull/7519)
* [MULTIARCH-3701](https://issues.redhat.com/browse/MULTIARCH-3701): Enable ppc64le for agent installer [#7366](https://github.com/openshift/installer/pull/7366)
* pkg/asset/installconfig/powervs: fix dropped error [#7419](https://github.com/openshift/installer/pull/7419)
* [OCPBUGS-19699](https://issues.redhat.com/browse/OCPBUGS-19699): Remove warning about CPUPartitioning [#7527](https://github.com/openshift/installer/pull/7527)
* [OCPBUGS-18187](https://issues.redhat.com/browse/OCPBUGS-18187): Increase bootstrap timeout for vSphere platform by 30 mins [#7518](https://github.com/openshift/installer/pull/7518)
* [OCPBUGS-18830](https://issues.redhat.com/browse/OCPBUGS-18830): AWS terraform bootstrap destroy will not refresh state [#7491](https://github.com/openshift/installer/pull/7491)
* [OCPBUGS-12707](https://issues.redhat.com/browse/OCPBUGS-12707): always write AWS cloud.conf [#7514](https://github.com/openshift/installer/pull/7514)
* [AGENT-710](https://issues.redhat.com/browse/AGENT-710): Use invoker for bootstrap template generation [#7508](https://github.com/openshift/installer/pull/7508)
* [OCPBUGS-18876](https://issues.redhat.com/browse/OCPBUGS-18876): Pass CPUPartitioning via install-config overrides if set [#7513](https://github.com/openshift/installer/pull/7513)
* OpenStack: fix IPv6 docs [#7482](https://github.com/openshift/installer/pull/7482)
* [OCPBUGS-18945](https://issues.redhat.com/browse/OCPBUGS-18945): update RHCOS 4.15 bootimage metadata to 415.92.202309161058-0 [#7499](https://github.com/openshift/installer/pull/7499)
* LICENSE: Update [#7502](https://github.com/openshift/installer/pull/7502)
* [OCPBUGS-19286](https://issues.redhat.com/browse/OCPBUGS-19286): Updating ose-installer-artifacts images to be consistent with ART [#7496](https://github.com/openshift/installer/pull/7496)
* [SPLAT-1170](https://issues.redhat.com/browse/SPLAT-1170): enable cloud controller manager type to be defined [#7457](https://github.com/openshift/installer/pull/7457)
* OpenStack: Set external network for cloud-provider [#7411](https://github.com/openshift/installer/pull/7411)
* [OCPBUGS-17724](https://issues.redhat.com/browse/OCPBUGS-17724): Graceful fail for AWS getUser on destroy [#7429](https://github.com/openshift/installer/pull/7429)
* AGENT: publish services diagrams [#7323](https://github.com/openshift/installer/pull/7323)
* [OCPBUGS-19149](https://issues.redhat.com/browse/OCPBUGS-19149): Updating ose-baremetal-installer images to be consistent with ART [#7494](https://github.com/openshift/installer/pull/7494)
* [OCPBUGS-19130](https://issues.redhat.com/browse/OCPBUGS-19130): Updating ose-installer images to be consistent with ART [#7493](https://github.com/openshift/installer/pull/7493)
* [OCPBUGS-17218](https://issues.redhat.com/browse/OCPBUGS-17218): Warn when firewall rull missing. [#7417](https://github.com/openshift/installer/pull/7417)
* [OSASINFRA-3236](https://issues.redhat.com/browse/OSASINFRA-3236): deps: Bump gophercloud to v1.6.0 [#7208](https://github.com/openshift/installer/pull/7208)
* [OCPBUGS-19037](https://issues.redhat.com/browse/OCPBUGS-19037): Handle agent tui failure gracefully [#7490](https://github.com/openshift/installer/pull/7490)
* [Full changelog](https://github.com/openshift/installer/compare/7f49fee68faee3f4def8e0cbbf4c27efc3488859...8d96bbad2ce977aa7e6fbb5733923563881e0d4e)

### [baremetal-machine-controllers](https://github.com/openshift/cluster-api-provider-baremetal/tree/43617f25e9edcb5ee73d76d54495755bc7ec89e6)

* [OCPBUGS-19178](https://issues.redhat.com/browse/OCPBUGS-19178): Updating baremetal-machine-controller images to be consistent with ART [#196](https://github.com/openshift/cluster-api-provider-baremetal/pull/196)
* [Full changelog](https://github.com/openshift/cluster-api-provider-baremetal/compare/fa79a768cc7ceddc7c013851522387ab92c633f5...43617f25e9edcb5ee73d76d54495755bc7ec89e6)

### [baremetal-operator](https://github.com/openshift/baremetal-operator/tree/30b6d278b5fd793d067fd07e8117e84108aeb63f)

* [OCPBUGS-19191](https://issues.redhat.com/browse/OCPBUGS-19191): Updating ose-baremetal-operator images to be consistent with ART [#302](https://github.com/openshift/baremetal-operator/pull/302)
* Merge upstream [#301](https://github.com/openshift/baremetal-operator/pull/301)
* [Full changelog](https://github.com/openshift/baremetal-operator/compare/8119b0408ce90f7f44af9531dde396803ef8429d...30b6d278b5fd793d067fd07e8117e84108aeb63f)


```

</details>

