### PR TITLE
pkg/cli/admin/update: Add tech-preview 'oc adm upgrade status'

### DIFF
--- a/pkg/cli/admin/upgrade/status/status.go
+++ b/pkg/cli/admin/upgrade/status/status.go
@@ -1,0 +1,107 @@
+// Package status displays the status of current cluster version updates.
+package status
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configv1client "github.com/openshift/client-go/config/clientset/versioned"
+)
+
+const (
+	// clusterStatusFailing is set on the ClusterVersion status when a cluster
+	// cannot reach the desired state.
+	clusterStatusFailing = configv1.ClusterStatusConditionType("Failing")
+)
+
+func newOptions(streams genericiooptions.IOStreams) *options {
+	return &options{
+		IOStreams: streams,
+	}
+}
+
+func New(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
+	o := newOptions(streams)
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Display the status of current cluster version updates.",
+		Run: func(cmd *cobra.Command, args []string) {
+			kcmdutil.CheckErr(o.Complete(f, cmd, args))
+			kcmdutil.CheckErr(o.Run(cmd.Context()))
+		},
+	}
+
+	return cmd
+}
+
+type options struct {
+	genericiooptions.IOStreams
+
+	Client configv1client.Interface
+}
+
+func (o *options) Complete(f kcmdutil.Factory, cmd *cobra.Command, args []string) error {
+	if len(args) > 0 {
+		return kcmdutil.UsageErrorf(cmd, "positional arguments given")
+	}
+
+	cfg, err := f.ToRESTConfig()
+	if err != nil {
+		return err
+	}
+	client, err := configv1client.NewForConfig(cfg)
+	if err != nil {
+		return err
+	}
+	o.Client = client
+	return nil
+}
+
+func (o *options) Run(ctx context.Context) error {
+	cv, err := o.Client.ConfigV1().ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("no cluster version information available - you must be connected to an OpenShift version 4 server to fetch the current version")
+		}
+		return err
+	}
+
+	progressing := findClusterOperatorStatusCondition(cv.Status.Conditions, configv1.OperatorProgressing)
+	if progressing == nil {
+		return fmt.Errorf("no current %s info, see `oc describe clusterversion` for more details.\n", configv1.OperatorProgressing)
+	}
+
+	if progressing.Status != configv1.ConditionTrue {
+		fmt.Fprintf(o.Out, "The cluster version is not updating (%s=%s).\n\n  Reason: %s\n  Message: %s\n", progressing.Type, progressing.Status, progressing.Reason, strings.ReplaceAll(progressing.Message, "\n", "\n  "))
+		return nil
+	}
+
+	fmt.Fprintf(o.Out, "An update is in progress: %s\n", progressing.Message)
+
+	if c := findClusterOperatorStatusCondition(cv.Status.Conditions, clusterStatusFailing); c != nil {
+		if c.Status != configv1.ConditionFalse {
+			fmt.Fprintf(o.Out, "\n%s=%s:\n\n  Reason: %s\n  Message: %s\n\n", c.Type, c.Status, c.Reason, strings.ReplaceAll(c.Message, "\n", "\n  "))
+		}
+	} else {
+		fmt.Fprintf(o.ErrOut, "warning: No current %s info, see `oc describe clusterversion` for more details.\n", clusterStatusFailing)
+	}
+
+	return nil
+}
+
+func findClusterOperatorStatusCondition(conditions []configv1.ClusterOperatorStatusCondition, name configv1.ClusterStatusConditionType) *configv1.ClusterOperatorStatusCondition {
+	for i := range conditions {
+		if conditions[i].Type == name {
+			return &conditions[i]
+		}
+	}
+	return nil
+}

--- a/pkg/cli/admin/upgrade/upgrade.go
+++ b/pkg/cli/admin/upgrade/upgrade.go
@@ -26,6 +26,7 @@ import (
 	imagereference "github.com/openshift/library-go/pkg/image/reference"
 
 	"github.com/openshift/oc/pkg/cli/admin/upgrade/channel"
+	"github.com/openshift/oc/pkg/cli/admin/upgrade/status"
 )
 
 const (
@@ -110,6 +111,10 @@ func New(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command 
 	flags.BoolVar(&o.AllowUpgradeWithWarnings, "allow-upgrade-with-warnings", o.AllowUpgradeWithWarnings, "Upgrade regardless of client-side guard failures, such as upgrades in progress or failing clusters.")
 	flags.BoolVar(&o.IncludeNotRecommended, "include-not-recommended", o.IncludeNotRecommended, "Display additional updates which are not recommended based on your cluster configuration.")
 	flags.BoolVar(&o.AllowNotRecommended, "allow-not-recommended", o.AllowNotRecommended, "Allows upgrade to a version when it is supported but not recommended for updates.")
+
+	if kcmdutil.FeatureGate("OC_ENABLE_CMD_UPGRADE_STATUS").IsEnabled() {
+		cmd.AddCommand(status.New(f, streams))
+	}
 
 	cmd.AddCommand(channel.New(f, streams))
 

--- a/pkg/cli/admin/upgrade/upgrade.go
+++ b/pkg/cli/admin/upgrade/upgrade.go
@@ -135,6 +135,8 @@ type Options struct {
 }
 
 func (o *Options) Complete(f kcmdutil.Factory, cmd *cobra.Command, args []string) error {
+	kcmdutil.RequireNoArguments(cmd, args)
+
 	if o.Clear && (len(o.ToImage) > 0 || len(o.To) > 0 || o.ToLatestAvailable || o.ToMultiArch) {
 		return fmt.Errorf("--clear may not be specified with any other flags")
 	}


### PR DESCRIPTION
Initial scaffolding, based on the existing code for status rendering in `oc adm upgrade`.  I'm gating the new subcommand behind an `OC_ENABLE_CMD_UPGRADE_STATUS` feature gate to avoid surprising users with a volatile command while the implementation settles down.

```console
$ ./oc adm upgrade  status
error: unknown command "status"
See 'oc adm upgrade -h' for help and examples
$ OC_ENABLE_CMD_UPGRADE_STATUS=true ./oc adm upgrade --help
...
Available Commands:
  channel       Set or clear the update channel
  status        Display the status of current cluster version updates.
...
$ OC_ENABLE_CMD_UPGRADE_STATUS=true ./oc adm upgrade status
The cluster version is not updating (Progressing=False).

  Reason:
  Message: Cluster version is 4.13.10
```