### PR TITLE
OCPBUGS-20063: regeneratemco: explicitly check for PlatformStatus field

### DIFF
--- a/pkg/cli/admin/ocpcertificates/regeneratemco/rotatecerts.go
+++ b/pkg/cli/admin/ocpcertificates/regeneratemco/rotatecerts.go
@@ -131,26 +131,41 @@ func getServerIPsFromInfra(cfg *configv1.Infrastructure) []string {
 	}
 	switch cfg.Status.PlatformStatus.Type {
 	case configv1.BareMetalPlatformType:
+		if cfg.Status.PlatformStatus.BareMetal == nil {
+			return []string{}
+		}
 		if cfg.Status.PlatformStatus.BareMetal.APIServerInternalIPs != nil {
 			return cfg.Status.PlatformStatus.BareMetal.APIServerInternalIPs
 		}
 		return []string{cfg.Status.PlatformStatus.BareMetal.APIServerInternalIP}
 	case configv1.OvirtPlatformType:
+		if cfg.Status.PlatformStatus.Ovirt == nil {
+			return []string{}
+		}
 		if cfg.Status.PlatformStatus.Ovirt.APIServerInternalIPs != nil {
 			return cfg.Status.PlatformStatus.Ovirt.APIServerInternalIPs
 		}
 		return []string{cfg.Status.PlatformStatus.Ovirt.APIServerInternalIP}
 	case configv1.OpenStackPlatformType:
+		if cfg.Status.PlatformStatus.OpenStack == nil {
+			return []string{}
+		}
 		if cfg.Status.PlatformStatus.OpenStack.APIServerInternalIPs != nil {
 			return cfg.Status.PlatformStatus.OpenStack.APIServerInternalIPs
 		}
 		return []string{cfg.Status.PlatformStatus.OpenStack.APIServerInternalIP}
 	case configv1.VSpherePlatformType:
+		if cfg.Status.PlatformStatus.VSphere == nil {
+			return []string{}
+		}
 		if cfg.Status.PlatformStatus.VSphere.APIServerInternalIPs != nil {
 			return cfg.Status.PlatformStatus.VSphere.APIServerInternalIPs
 		}
 		return []string{cfg.Status.PlatformStatus.VSphere.APIServerInternalIP}
 	case configv1.NutanixPlatformType:
+		if cfg.Status.PlatformStatus.Nutanix == nil {
+			return []string{}
+		}
 		if cfg.Status.PlatformStatus.Nutanix.APIServerInternalIPs != nil {
 			return cfg.Status.PlatformStatus.Nutanix.APIServerInternalIPs
 		}


### PR DESCRIPTION
It turns out that cfg.Status.PlatformStatus.$PLATFORM can be nil, so add this check to not panic.

If the IP field doesn't exist we will go add the api-int url so this should otherwise not be a problem.