### PR TITLE
OCPBUGS-9340: pkg/cli/admin/upgrade: Warn on unrecognized subcommands

### DIFF
--- a/pkg/cli/admin/upgrade/upgrade.go
+++ b/pkg/cli/admin/upgrade/upgrade.go
@@ -135,6 +135,8 @@ type Options struct {
 }
 
 func (o *Options) Complete(f kcmdutil.Factory, cmd *cobra.Command, args []string) error {
+	kcmdutil.RequireNoArguments(cmd, args)
+
 	if o.Clear && (len(o.ToImage) > 0 || len(o.To) > 0 || o.ToLatestAvailable || o.ToMultiArch) {
 		return fmt.Errorf("--clear may not be specified with any other flags")
 	}


### PR DESCRIPTION
Avoid confusion like we had with `oc adm upgrade channel`, where folks running older `oc` (where `channel` didn't exist) had the command no-op and exit 0.  With this change, that sort of thing will give:

```console
$ oc adm upgrade does-not-exist
error: unknown command "does-not-exist"
See 'oc adm upgrade -h' for help and examples
```