### PR TITLE
OCPBUGS-20181: Use quay redis image instead docker mysql

### DIFF
--- a/pkg/helpers/newapp/newapptest/newapp_test.go
+++ b/pkg/helpers/newapp/newapptest/newapp_test.go
@@ -665,7 +665,7 @@ func TestNewAppRunAll(t *testing.T) {
 			name: "emptyDir volumes",
 			config: &cmd.AppConfig{
 				ComponentInputs: cmd.ComponentInputs{
-					DockerImages: []string{"mysql"},
+					DockerImages: []string{"quay.io/centos7/redis-5-centos7"},
 				},
 
 				Resolvers: cmd.Resolvers{
@@ -693,14 +693,14 @@ func TestNewAppRunAll(t *testing.T) {
 			},
 
 			expected: map[string][]string{
-				"imageStream":  {"mysql"},
-				"deployment":   {"mysql"},
-				"service":      {"mysql"},
-				"volumeMounts": {"mysql-volume-1"},
+				"imageStream":  {"redis-5-centos7"},
+				"deployment":   {"redis-5-centos7"},
+				"service":      {"redis-5-centos7"},
+				"volumeMounts": {"redis-5-centos7-volume-1"},
 			},
-			expectedName: "mysql",
+			expectedName: "redis-5-centos7",
 			expectedVolumes: map[string]string{
-				"mysql-volume-1": "EmptyDir",
+				"redis-5-centos7-volume-1": "EmptyDir",
 			},
 			expectedErr: nil,
 		},


### PR DESCRIPTION
docker mysql image frequently fails and causes unit test job's failure. This PR uses quay redis image instead docker image for the sake of unit test job's stability.