### PR TITLE
OCPBUGS-20342: Reflect container's exit code for long running tasks not attached to terminal

### DIFF
--- a/pkg/cli/debug/debug.go
+++ b/pkg/cli/debug/debug.go
@@ -633,7 +633,29 @@ func (o *DebugOptions) RunDebug() error {
 		case err != nil:
 			return err
 		case !o.Attach.Stdin:
-			return o.getLogs(pod)
+			if err = o.getLogs(pod); err != nil {
+				return err
+			}
+			lastWatchEvent, err := watchtools.UntilWithSync(ctx, lw, &corev1.Pod{}, preconditionFunc, conditions.PodDone)
+			if err != nil {
+				if kapierrors.IsNotFound(err) {
+					return nil
+				}
+				return err
+			}
+
+			resultPod, ok := lastWatchEvent.Object.(*corev1.Pod)
+			if ok {
+				for _, s := range append(append([]corev1.ContainerStatus{}, resultPod.Status.InitContainerStatuses...), resultPod.Status.ContainerStatuses...) {
+					if s.Name != o.ContainerName {
+						continue
+					}
+					if s.State.Terminated != nil && s.State.Terminated.ExitCode != 0 {
+						return conditions.ErrNonZeroExitCode
+					}
+				}
+			}
+			return nil
 		default:
 			if !o.Quiet {
 				// TODO this doesn't do us much good for remote debugging sessions, but until we get a local port


### PR DESCRIPTION
In `oc debug`, there are 2 types of tasks whose are not attached to terminal;

* short lived ones are handled directly and their exit codes are retrieved from the terminated pod's status(e.g. `oc debug node/worker -- /bash/bin -c "echo TEST"`).
* long lived ones are watched as long as they send logs to the client(e.g. `oc debug node/worker -- /bash/bin -c "sleep 5"`).

However, there is not exit code handler mechanism for the long lived ones, whenever logs are done, `oc debug` returns.

The problem is there is no clear boundaries between short lived and long lived ones. A `oc debug` command execution can fall into short lived and in another execution it can fall into long lived. Determination is done by informer's event retrieval periods and that creates undeterministic behavior.

To overcome this undeterministic behavior, this PR adds exit code retrieval for long lived tasks. This will ensure that command is either short lived or long lived, in any case it will return the correct exit code.