### PR TITLE
OCPBUGS-20474: Set ImportPolicy to PreserveOriginal to honor --keep-manifest-list when mirroring a payload to an image stream

### DIFF
--- a/pkg/cli/admin/release/mirror.go
+++ b/pkg/cli/admin/release/mirror.go
@@ -681,6 +681,10 @@ func (o *MirrorOptions) Run(ctx context.Context) error {
 		hasErrors := make(map[string]error)
 		maxPerIteration := 12
 
+		importMode := imagev1.ImportModeLegacy
+		if o.KeepManifestList {
+			importMode = imagev1.ImportModePreserveOriginal
+		}
 		for retries := 4; (len(remaining) > 0 || len(hasErrors) > 0) && retries > 0; {
 			if len(remaining) == 0 {
 				for _, mapping := range mappings {
@@ -711,6 +715,9 @@ func (o *MirrorOptions) Run(ctx context.Context) error {
 						},
 						To: &corev1.LocalObjectReference{
 							Name: mapping.Name,
+						},
+						ImportPolicy: imagev1.TagImportPolicy{
+							ImportMode: importMode,
 						},
 					})
 					if len(isi.Spec.Images) > maxPerIteration {


### PR DESCRIPTION
When mirroring a multiarch payload via `oc adm release mirror --from=... --to-image-stream=release --keep-manifest-list=true`, the ImageStreamTags are created with the default ImportPolicy.ImportMode (Legacy). Therefore, the release is not mirrored as multiarch/manifest-list, but will be mirrored as a single-arch manifest depending on the architecture of the cluster's node running the internal registry.