### PR TITLE
pkg/cli/admin/upgrade/status: Add update duration

### DIFF
--- a/pkg/cli/admin/upgrade/status/status.go
+++ b/pkg/cli/admin/upgrade/status/status.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -84,7 +85,7 @@ func (o *options) Run(ctx context.Context) error {
 		return nil
 	}
 
-	fmt.Fprintf(o.Out, "An update is in progress: %s\n", progressing.Message)
+	fmt.Fprintf(o.Out, "An update is in progress for %s: %s\n", time.Since(progressing.LastTransitionTime.Time).Round(time.Second), progressing.Message)
 
 	if c := findClusterOperatorStatusCondition(cv.Status.Conditions, clusterStatusFailing); c != nil {
 		if c.Status != configv1.ConditionFalse {


### PR DESCRIPTION
As a cluster admin, I want to understand how the update is going, relative to [my expectations around duration][1].  If it's waiting on the Kube API server 5 minutes into the update, that's expected.  If it's waiting on the Kube API server an hour into the update, that's unexpected.  There is not a lot of information here, but while it is a small amount of context, it only consumes a few characters.

```console
$ OC_ENABLE_CMD_UPGRADE_STATUS=true ./oc adm upgrade status
An update is in progress for 44m40s: Working towards 4.13.17: 683 of 843 done (81% complete), waiting on network
```

[1]: https://docs.openshift.com/container-platform/4.14/updating/understanding_updates/understanding-openshift-update-duration.html