### PR TITLE
Updating content type variable name for CLI docs generation

### DIFF
--- a/hack/clibyexample/template
+++ b/hack/clibyexample/template
@@ -2,7 +2,7 @@
 // This template is for non-admin (not 'oc adm ...') commands
 // Uses 'source,bash' for proper syntax highlighting for comments in examples
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="openshift-cli-developer_{context}"]
 = OpenShift CLI (oc) developer commands
 

--- a/hack/clibyexample/template-admin
+++ b/hack/clibyexample/template-admin
@@ -2,7 +2,7 @@
 // This template is for admin ('oc adm ...') commands
 // Uses 'source,bash' for proper syntax highlighting for comments in examples
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="openshift-cli-admin_{context}"]
 = OpenShift CLI (oc) administrator commands
 


### PR DESCRIPTION
Per https://github.com/redhat-documentation/modular-docs/issues/203, documentation changed the content type variable we need to use from `:_content-type:` to `:_mod-docs-content-type:`.

This PR fixes that in the templates that are used when auto-generating the CLI reference docs.