### PR TITLE
OCPBUGS-23071: Mention inspection completion in the error message

### DIFF
--- a/pkg/cli/admin/inspect/inspect.go
+++ b/pkg/cli/admin/inspect/inspect.go
@@ -273,7 +273,7 @@ func (o *InspectOptions) Run() error {
 
 	fmt.Fprintf(o.Out, "Wrote inspect data to %s.\n", o.DestDir)
 	if len(allErrs) > 0 {
-		return fmt.Errorf("errors occurred while gathering data:\n    %v", errors.NewAggregate(allErrs))
+		return fmt.Errorf("inspection completed with the errors occurred while gathering data:\n    %v", errors.NewAggregate(allErrs))
 	}
 
 	return nil


### PR DESCRIPTION
When error occurs during inspection, current message `errors occurred while gathering data` may mislead
users about that the command short cuts inspection process and exits. However, in reality, command prints all the logs
in aggregated format after completing the inspection.

This PR basically just adds `inspection completed` message ahead of the error logs to emphasize to user that
inspection is completed in best effort and the rest is the errors we get.