### PR TITLE
NO-JIRA: Migrate from deprecated ioutils to relevant libraries

### DIFF
--- a/pkg/cli/admin/catalog/mirror.go
+++ b/pkg/cli/admin/catalog/mirror.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -295,7 +294,7 @@ func (o *MirrorCatalogOptions) Complete(cmd *cobra.Command, args []string) error
 	}
 
 	if o.IndexPath == "" {
-		tmpdir, err := ioutil.TempDir("", "")
+		tmpdir, err := os.MkdirTemp("", "")
 		if err != nil {
 			return err
 		}
@@ -695,7 +694,7 @@ func WriteManifests(out io.Writer, source, dest imagesource.TypedImageReference,
 			return nil
 		}
 
-		if err := ioutil.WriteFile(filepath.Join(dir, "imageDigestMirrorSet.yaml"), aggregateIDMSs(idmss), os.ModePerm); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, "imageDigestMirrorSet.yaml"), aggregateIDMSs(idmss), os.ModePerm); err != nil {
 			return fmt.Errorf("error writing ImageDigestMirrorSet")
 		}
 
@@ -704,7 +703,7 @@ func WriteManifests(out io.Writer, source, dest imagesource.TypedImageReference,
 			return err
 		}
 
-		if err := ioutil.WriteFile(filepath.Join(dir, "imageContentSourcePolicy.yaml"), aggregateICSPs(icsps), os.ModePerm); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, "imageContentSourcePolicy.yaml"), aggregateICSPs(icsps), os.ModePerm); err != nil {
 			return fmt.Errorf("error writing ImageContentSourcePolicy")
 		}
 
@@ -712,7 +711,7 @@ func WriteManifests(out io.Writer, source, dest imagesource.TypedImageReference,
 		if err != nil {
 			return err
 		}
-		if err := ioutil.WriteFile(filepath.Join(dir, "catalogSource.yaml"), catalogSource, os.ModePerm); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, "catalogSource.yaml"), catalogSource, os.ModePerm); err != nil {
 			return fmt.Errorf("error writing CatalogSource")
 		}
 	}

--- a/pkg/cli/admin/groups/examples/examples_test.go
+++ b/pkg/cli/admin/groups/examples/examples_test.go
@@ -2,7 +2,7 @@ package examples
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
@@ -25,7 +25,7 @@ func TestLDAPSyncConfigFixtures(t *testing.T) {
 	fixtures = append(fixtures, "rfc2307/sync-config-tolerating.yaml")
 
 	for _, fixture := range fixtures {
-		yamlConfig, err := ioutil.ReadFile("./../../../../../testdata/ldap/" + fixture)
+		yamlConfig, err := os.ReadFile("./../../../../../testdata/ldap/" + fixture)
 		if err != nil {
 			t.Errorf("could not read fixture at %q: %v", fixture, err)
 			continue

--- a/pkg/cli/admin/groups/sync/sync.go
+++ b/pkg/cli/admin/groups/sync/sync.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/go-ldap/ldap/v3"
@@ -253,7 +253,7 @@ func buildNameList(args []string, file string) ([]string, error) {
 }
 
 func decodeSyncConfigFromFile(configFile string) (*legacyconfigv1.LDAPSyncConfig, error) {
-	yamlConfig, err := ioutil.ReadFile(configFile)
+	yamlConfig, err := os.ReadFile(configFile)
 	if err != nil {
 		return nil, fmt.Errorf("could not read file %s: %v", configFile, err)
 	}
@@ -301,7 +301,7 @@ func openshiftGroupNamesOnlyList(list []string) ([]string, error) {
 
 // readLines interprets a file as plaintext and returns a string array of the lines of text in the file
 func readLines(path string) ([]string, error) {
-	bytes, err := ioutil.ReadFile(path)
+	bytes, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("could not open file %s: %v", path, err)
 	}

--- a/pkg/cli/admin/inspect/inspect.go
+++ b/pkg/cli/admin/inspect/inspect.go
@@ -3,7 +3,6 @@ package inspect
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path"
@@ -380,7 +379,7 @@ func (o *InspectOptions) ensureDirectoryViable() error {
 	if !baseDirInfo.IsDir() {
 		return fmt.Errorf("%q exists and is a file", o.DestDir)
 	}
-	files, err := ioutil.ReadDir(o.DestDir)
+	files, err := os.ReadDir(o.DestDir)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/admin/inspect/inspect_test.go
+++ b/pkg/cli/admin/inspect/inspect_test.go
@@ -2,7 +2,6 @@ package inspect
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -26,7 +25,7 @@ func TestDirectoryViable(t *testing.T) {
 		{
 			name: "ensure empty directory is viable",
 			dirName: func() (string, error) {
-				tmpDir, err := ioutil.TempDir(os.TempDir(), "must-gather-inspect-")
+				tmpDir, err := os.MkdirTemp(os.TempDir(), "must-gather-inspect-")
 				if err != nil {
 					return "", err
 				}
@@ -37,11 +36,11 @@ func TestDirectoryViable(t *testing.T) {
 		{
 			name: "ensure non-empty directory not viable",
 			dirName: func() (string, error) {
-				tmpDir, err := ioutil.TempDir(os.TempDir(), "must-gather-inspect-")
+				tmpDir, err := os.MkdirTemp(os.TempDir(), "must-gather-inspect-")
 				if err != nil {
 					return "", err
 				}
-				_, err = ioutil.TempFile(tmpDir, "must-gather-inspect-file-")
+				_, err = os.MkdirTemp(tmpDir, "must-gather-inspect-file-")
 				return tmpDir, err
 			},
 			expectedErr: fmt.Errorf("exists and is not empty"),
@@ -50,11 +49,11 @@ func TestDirectoryViable(t *testing.T) {
 		{
 			name: "ensure non-empty directory viable with data override",
 			dirName: func() (string, error) {
-				tmpDir, err := ioutil.TempDir(os.TempDir(), "must-gather-inspect-")
+				tmpDir, err := os.MkdirTemp(os.TempDir(), "must-gather-inspect-")
 				if err != nil {
 					return "", err
 				}
-				_, err = ioutil.TempFile(tmpDir, "must-gather-inspect-file-")
+				_, err = os.MkdirTemp(tmpDir, "must-gather-inspect-file-")
 				return tmpDir, err
 			},
 			allowOverride: true,

--- a/pkg/cli/admin/migrate/icsp/icsp.go
+++ b/pkg/cli/admin/migrate/icsp/icsp.go
@@ -2,7 +2,6 @@ package icsp
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -133,7 +132,7 @@ func (o *MigrateICSPOptions) ensureDirectoryViable() error {
 	if !baseDirInfo.IsDir() {
 		return fmt.Errorf("%q exists and is a file", o.DestDir)
 	}
-	if _, err = ioutil.ReadDir(o.DestDir); err != nil {
+	if _, err = os.ReadDir(o.DestDir); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/cli/admin/prune/auth/cluster_role_test.go
+++ b/pkg/cli/admin/prune/auth/cluster_role_test.go
@@ -1,7 +1,7 @@
 package auth
 
 import (
-	"io/ioutil"
+	"io"
 	"reflect"
 	"testing"
 
@@ -73,7 +73,7 @@ func TestClusterRoleReaper(t *testing.T) {
 			return true, nil, nil
 		})
 
-		err := reapForClusterRole(tc.RbacV1(), tc.RbacV1(), "", test.role.Name, ioutil.Discard)
+		err := reapForClusterRole(tc.RbacV1(), tc.RbacV1(), "", test.role.Name, io.Discard)
 		if err != nil {
 			t.Errorf("%s: unexpected error: %v", test.name, err)
 		}
@@ -141,7 +141,7 @@ func TestClusterRoleReaperAgainstNamespacedBindings(t *testing.T) {
 			return true, nil, nil
 		})
 
-		err := reapForClusterRole(tc.RbacV1(), tc.RbacV1(), "", test.role.Name, ioutil.Discard)
+		err := reapForClusterRole(tc.RbacV1(), tc.RbacV1(), "", test.role.Name, io.Discard)
 		if err != nil {
 			t.Errorf("%s: unexpected error: %v", test.name, err)
 		}

--- a/pkg/cli/admin/prune/auth/group_test.go
+++ b/pkg/cli/admin/prune/auth/group_test.go
@@ -2,7 +2,7 @@ package auth
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"reflect"
 	"testing"
 
@@ -158,7 +158,7 @@ func TestGroupReaper(t *testing.T) {
 			securityFake.Fake.PrependReactor("update", "*", kreactor)
 			securityFake.Fake.PrependReactor("delete", "*", kreactor)
 
-			err := reapForGroup(authFake, securityFake.SecurityContextConstraints(), test.group, ioutil.Discard)
+			err := reapForGroup(authFake, securityFake.SecurityContextConstraints(), test.group, io.Discard)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}

--- a/pkg/cli/admin/prune/auth/role_test.go
+++ b/pkg/cli/admin/prune/auth/role_test.go
@@ -1,7 +1,7 @@
 package auth
 
 import (
-	"io/ioutil"
+	"io"
 	"reflect"
 	"testing"
 
@@ -96,7 +96,7 @@ func TestRoleReaper(t *testing.T) {
 			return true, nil, nil
 		})
 
-		err := reapForRole(tc.RbacV1(), test.role.Namespace, test.role.Name, ioutil.Discard)
+		err := reapForRole(tc.RbacV1(), test.role.Namespace, test.role.Name, io.Discard)
 		if err != nil {
 			t.Errorf("%s: unexpected error: %v", test.name, err)
 		}

--- a/pkg/cli/admin/prune/auth/user_test.go
+++ b/pkg/cli/admin/prune/auth/user_test.go
@@ -2,7 +2,7 @@ package auth
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"reflect"
 	"testing"
 
@@ -243,7 +243,7 @@ func TestUserReaper(t *testing.T) {
 			securityFake.Fake.PrependReactor("update", "*", kreactor)
 			securityFake.Fake.PrependReactor("delete", "*", kreactor)
 
-			err := reapForUser(userFake, authFake, oauthFake, securityFake.SecurityContextConstraints(), test.user, ioutil.Discard)
+			err := reapForUser(userFake, authFake, oauthFake, securityFake.SecurityContextConstraints(), test.user, io.Discard)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}

--- a/pkg/cli/admin/prune/imageprune/prune_test.go
+++ b/pkg/cli/admin/prune/imageprune/prune_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -2048,7 +2048,7 @@ func TestLayerDeleter(t *testing.T) {
 	var actions []string
 	client := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 		actions = append(actions, req.Method+":"+req.URL.String())
-		return &http.Response{StatusCode: http.StatusServiceUnavailable, Body: ioutil.NopCloser(bytes.NewReader([]byte{}))}, nil
+		return &http.Response{StatusCode: http.StatusServiceUnavailable, Body: io.NopCloser(bytes.NewReader([]byte{}))}, nil
 	})
 	layerLinkDeleter := NewLayerLinkDeleter(client, &url.URL{Scheme: "http", Host: "registry1"})
 	layerLinkDeleter.DeleteLayerLink("repo", "layer1")
@@ -2065,7 +2065,7 @@ func TestNotFoundLayerDeleter(t *testing.T) {
 	var actions []string
 	client := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 		actions = append(actions, req.Method+":"+req.URL.String())
-		return &http.Response{StatusCode: http.StatusNotFound, Body: ioutil.NopCloser(bytes.NewReader([]byte{}))}, nil
+		return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(bytes.NewReader([]byte{}))}, nil
 	})
 	layerLinkDeleter := NewLayerLinkDeleter(client, &url.URL{Scheme: "https", Host: "registry1"})
 	layerLinkDeleter.DeleteLayerLink("repo", "layer1")

--- a/pkg/cli/admin/prune/images/images.go
+++ b/pkg/cli/admin/prune/images/images.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -721,7 +720,7 @@ func getRegistryClient(clientConfig *restclient.Config, registryCABundle string,
 	}
 
 	if len(registryCABundle) > 0 {
-		cadata, err = ioutil.ReadFile(registryCABundle)
+		cadata, err = os.ReadFile(registryCABundle)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read registry ca bundle: %v", err)
 		}

--- a/pkg/cli/admin/prune/images/images_test.go
+++ b/pkg/cli/admin/prune/images/images_test.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -47,7 +46,7 @@ func TestPruneWithoutImagesWithRegistryAccess(t *testing.T) {
 		BuildClient:   &fakebuildv1client.FakeBuildV1{Fake: &(fakebuildclient.NewSimpleClientset().Fake)},
 		ImageClient:   &fakeimagev1client.FakeImageV1{Fake: &(fakeimageclient.NewSimpleClientset().Fake)},
 		KubeClient:    fakekubernetes.NewSimpleClientset(),
-		Out:           ioutil.Discard,
+		Out:           io.Discard,
 		ErrOut:        os.Stderr,
 		Confirm:       true,
 		PruneRegistry: &pruneRegistry,
@@ -65,7 +64,7 @@ func TestPruneWithoutImagesNoRegistryAccess(t *testing.T) {
 		BuildClient: &fakebuildv1client.FakeBuildV1{Fake: &(fakebuildclient.NewSimpleClientset().Fake)},
 		ImageClient: &fakeimagev1client.FakeImageV1{Fake: &(fakeimageclient.NewSimpleClientset().Fake)},
 		KubeClient:  fakekubernetes.NewSimpleClientset(),
-		Out:         ioutil.Discard,
+		Out:         io.Discard,
 		ErrOut:      os.Stderr,
 		Confirm:     true,
 	}
@@ -88,7 +87,7 @@ func TestImagePruneNamespaced(t *testing.T) {
 		BuildClient: &fakebuildv1client.FakeBuildV1{Fake: &(fakebuildclient.NewSimpleClientset().Fake)},
 		ImageClient: imageFake,
 		KubeClient:  kFake,
-		Out:         ioutil.Discard,
+		Out:         io.Discard,
 		ErrOut:      os.Stderr,
 	}
 
@@ -148,7 +147,7 @@ func TestImagePruneErrOnBadReference(t *testing.T) {
 		KubeClient:      kFake,
 		DiscoveryClient: fakeDiscovery,
 		Timeout:         time.Second,
-		Out:             ioutil.Discard,
+		Out:             io.Discard,
 		ErrOut:          errBuf,
 	}
 
@@ -233,7 +232,7 @@ func objBody(object interface{}) io.ReadCloser {
 	if err != nil {
 		panic(err)
 	}
-	return ioutil.NopCloser(bytes.NewReader([]byte(output)))
+	return io.NopCloser(bytes.NewReader([]byte(output)))
 }
 
 func TestValidateRegistryURL(t *testing.T) {

--- a/pkg/cli/admin/release/bug.go
+++ b/pkg/cli/admin/release/bug.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -137,7 +136,7 @@ func retrieveRefsJira(refs []Ref) (*RefRemoteList, error) {
 			lastErr = fmt.Errorf("jira server responded with %d", resp.StatusCode)
 			continue
 		}
-		data, err := ioutil.ReadAll(resp.Body)
+		data, err := io.ReadAll(resp.Body)
 		if err != nil {
 			lastErr = fmt.Errorf("unable to get body contents: %v", err)
 			continue
@@ -196,7 +195,7 @@ func retrieveRefsBugzila(bugs []Ref) (*RefRemoteList, error) {
 			lastErr = fmt.Errorf("server responded with %d", resp.StatusCode)
 			continue
 		}
-		data, err := ioutil.ReadAll(resp.Body)
+		data, err := io.ReadAll(resp.Body)
 		if err != nil {
 			lastErr = fmt.Errorf("unable to get body contents: %v", err)
 			continue

--- a/pkg/cli/admin/release/extract_tools.go
+++ b/pkg/cli/admin/release/extract_tools.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -440,7 +439,7 @@ func (o *ExtractOptions) extractCommand(command string) error {
 	var hashFn = sha256.New
 	var signer *openpgp.Entity
 	if willArchive && len(o.SigningKey) > 0 {
-		key, err := ioutil.ReadFile(o.SigningKey)
+		key, err := os.ReadFile(o.SigningKey)
 		if err != nil {
 			return err
 		}
@@ -780,7 +779,7 @@ func (o *ExtractOptions) extractCommand(command string) error {
 			return err
 		}
 		filename := "release.txt"
-		if err := ioutil.WriteFile(filepath.Join(dir, filename), buf.Bytes(), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, filename), buf.Bytes(), 0644); err != nil {
 			return err
 		}
 		hash := hashFn()
@@ -807,7 +806,7 @@ func (o *ExtractOptions) extractCommand(command string) error {
 		// write the content manifest
 		data := []byte(strings.Join(lines, "\n"))
 		filename := "sha256sum.txt"
-		if err := ioutil.WriteFile(filepath.Join(dir, filename), data, 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, filename), data, 0644); err != nil {
 			return fmt.Errorf("unable to write checksum file: %v", err)
 		}
 		// sign the content manifest
@@ -816,7 +815,7 @@ func (o *ExtractOptions) extractCommand(command string) error {
 			if err := openpgp.ArmoredDetachSign(buf, signer, bytes.NewBuffer(data), nil); err != nil {
 				return fmt.Errorf("unable to sign the sha256sum.txt file: %v", err)
 			}
-			if err := ioutil.WriteFile(filepath.Join(dir, filename+".asc"), buf.Bytes(), 0644); err != nil {
+			if err := os.WriteFile(filepath.Join(dir, filename+".asc"), buf.Bytes(), 0644); err != nil {
 				return fmt.Errorf("unable to write signed manifest: %v", err)
 			}
 		}

--- a/pkg/cli/admin/release/info.go
+++ b/pkg/cli/admin/release/info.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -271,10 +270,10 @@ func replaceStableSemanticArgs(args []string, semanticArgs map[string]semver.Ver
 				switch resp.StatusCode {
 				case http.StatusOK:
 				default:
-					io.Copy(ioutil.Discard, resp.Body)
+					io.Copy(io.Discard, resp.Body)
 					return fmt.Errorf("unable to retrieve status for %q: %d", arg, resp.StatusCode)
 				}
-				data, err := ioutil.ReadAll(resp.Body)
+				data, err := io.ReadAll(resp.Body)
 				if err != nil {
 					return err
 				}
@@ -807,7 +806,7 @@ func (o *InfoOptions) LoadReleaseInfo(image string, retrieveImages bool) (*Relea
 	opts.TarEntryCallback = func(hdr *tar.Header, _ extract.LayerInfo, r io.Reader) (bool, error) {
 		switch hdr.Name {
 		case "image-references":
-			data, err := ioutil.ReadAll(r)
+			data, err := io.ReadAll(r)
 			if err != nil {
 				errs = append(errs, fmt.Errorf("unable to read release image-references: %v", err))
 				return true, nil
@@ -820,7 +819,7 @@ func (o *InfoOptions) LoadReleaseInfo(image string, retrieveImages bool) (*Relea
 			}
 			release.References = is
 		case "release-metadata":
-			data, err := ioutil.ReadAll(r)
+			data, err := io.ReadAll(r)
 			if err != nil {
 				errs = append(errs, fmt.Errorf("unable to read release metadata: %v", err))
 				return true, nil
@@ -835,7 +834,7 @@ func (o *InfoOptions) LoadReleaseInfo(image string, retrieveImages bool) (*Relea
 		default:
 			if ext := path.Ext(hdr.Name); len(ext) > 0 && (ext == ".yaml" || ext == ".yml" || ext == ".json") {
 				klog.V(4).Infof("Found manifest %s", hdr.Name)
-				data, err := ioutil.ReadAll(r)
+				data, err := io.ReadAll(r)
 				if err != nil {
 					errs = append(errs, fmt.Errorf("unable to read release manifest %q: %v", hdr.Name, err))
 					return true, nil

--- a/pkg/cli/admin/release/mirror.go
+++ b/pkg/cli/admin/release/mirror.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -400,7 +399,7 @@ func (o *MirrorOptions) handleSignatures(context context.Context, signaturesByDi
 				if err := os.MkdirAll(filepath.Dir(fullName), 0750); err != nil {
 					return err
 				}
-				if err := ioutil.WriteFile(fullName, cmDataBytes, 0640); err != nil {
+				if err := os.WriteFile(fullName, cmDataBytes, 0640); err != nil {
 					return err
 				}
 				fmt.Fprintf(o.Out, "Configmap signature file %s created\n", fullName)

--- a/pkg/cli/admin/verifyimagesignature/verify-signature.go
+++ b/pkg/cli/admin/verifyimagesignature/verify-signature.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -145,7 +144,7 @@ func (o *VerifyImageSignatureOptions) Complete(f kcmdutil.Factory, cmd *cobra.Co
 	var err error
 
 	if len(o.PublicKeyFilename) > 0 {
-		if o.PublicKey, err = ioutil.ReadFile(o.PublicKeyFilename); err != nil {
+		if o.PublicKey, err = os.ReadFile(o.PublicKeyFilename); err != nil {
 			return fmt.Errorf("unable to read --public-key: %v", err)
 		}
 	}

--- a/pkg/cli/deployer/strategy/recreate/recreate.go
+++ b/pkg/cli/deployer/strategy/recreate/recreate.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -66,10 +65,10 @@ type RecreateDeploymentStrategy struct {
 func NewRecreateDeploymentStrategy(kubeClient kubernetes.Interface, imageClient imageclienttyped.ImageStreamTagsGetter, events record.EventSink, out, errOut io.Writer,
 	until string) *RecreateDeploymentStrategy {
 	if out == nil {
-		out = ioutil.Discard
+		out = io.Discard
 	}
 	if errOut == nil {
-		errOut = ioutil.Discard
+		errOut = io.Discard
 	}
 
 	return &RecreateDeploymentStrategy{

--- a/pkg/cli/deployer/strategy/rolling/rolling.go
+++ b/pkg/cli/deployer/strategy/rolling/rolling.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -81,10 +80,10 @@ type acceptingDeploymentStrategy interface {
 func NewRollingDeploymentStrategy(namespace string, kubeClient kubernetes.Interface, imageClient imageclienttyped.ImageStreamTagsGetter,
 	initialStrategy acceptingDeploymentStrategy, out, errOut io.Writer, until string) *RollingDeploymentStrategy {
 	if out == nil {
-		out = ioutil.Discard
+		out = io.Discard
 	}
 	if errOut == nil {
-		errOut = ioutil.Discard
+		errOut = io.Discard
 	}
 
 	return &RollingDeploymentStrategy{

--- a/pkg/cli/deployer/strategy/support/lifecycle_test.go
+++ b/pkg/cli/deployer/strategy/support/lifecycle_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"io/ioutil"
 	"reflect"
 	"sort"
 	"strings"
@@ -116,7 +115,7 @@ func TestHookExecutor_executeExecNewPodSucceeded(t *testing.T) {
 		pods: client.CoreV1(),
 		out:  podLogs,
 		getPodLogs: func(*corev1.Pod) (io.ReadCloser, error) {
-			return ioutil.NopCloser(strings.NewReader("test")), nil
+			return io.NopCloser(strings.NewReader("test")), nil
 		},
 	}
 
@@ -178,9 +177,9 @@ func TestHookExecutor_executeExecNewPodFailed(t *testing.T) {
 
 	executor := &hookExecutor{
 		pods: client.CoreV1(),
-		out:  ioutil.Discard,
+		out:  io.Discard,
 		getPodLogs: func(*corev1.Pod) (io.ReadCloser, error) {
-			return ioutil.NopCloser(strings.NewReader("test")), nil
+			return io.NopCloser(strings.NewReader("test")), nil
 		},
 	}
 

--- a/pkg/cli/image/append/append.go
+++ b/pkg/cli/image/append/append.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"time"
@@ -506,7 +505,7 @@ func (o *AppendImageOptions) append(ctx context.Context, createdAt *time.Time,
 								return fmt.Errorf("unable to access the layer %s in order to calculate its content ID: %v", layer.Digest, err)
 							}
 							defer r.Close()
-							layerDigest, _, _, _, err := add.DigestCopy(ioutil.Discard.(io.ReaderFrom), r)
+							layerDigest, _, _, _, err := add.DigestCopy(io.Discard.(io.ReaderFrom), r)
 							if err != nil {
 								return fmt.Errorf("unable to calculate contentID for layer %s: %v", layer.Digest, err)
 							}
@@ -677,7 +676,7 @@ func appendFileAsLayer(ctx context.Context, name string, layers []distribution.D
 
 func appendLayer(ctx context.Context, r io.Reader, layers []distribution.Descriptor, config *dockerv1client.DockerImageConfig, dryRun bool, out io.Writer, blobs distribution.BlobService) ([]distribution.Descriptor,
 	error) {
-	var readerFrom io.ReaderFrom = ioutil.Discard.(io.ReaderFrom)
+	var readerFrom io.ReaderFrom = io.Discard.(io.ReaderFrom)
 	var done = func(distribution.Descriptor) error { return nil }
 	if !dryRun {
 		fmt.Fprint(out, "Uploading ... ")
@@ -718,7 +717,7 @@ func appendLayer(ctx context.Context, r io.Reader, layers []distribution.Descrip
 
 func calculateLayerDigest(blobs distribution.BlobService, dgst digest.Digest, readerFrom io.ReaderFrom, r io.Reader) (digest.Digest, error) {
 	if readerFrom == nil {
-		readerFrom = ioutil.Discard.(io.ReaderFrom)
+		readerFrom = io.Discard.(io.ReaderFrom)
 	}
 	layerDigest, _, _, _, err := add.DigestCopy(readerFrom, r)
 	return layerDigest, err

--- a/pkg/cli/image/archive/archive.go
+++ b/pkg/cli/image/archive/archive.go
@@ -4,7 +4,6 @@ import (
 	"archive/tar"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -187,7 +186,7 @@ func unpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 				basename := filepath.Base(hdr.Name)
 				aufsHardlinks[basename] = hdr
 				if aufsTempdir == "" {
-					if aufsTempdir, err = ioutil.TempDir("", "dockerplnk"); err != nil {
+					if aufsTempdir, err = os.MkdirTemp("", "dockerplnk"); err != nil {
 						return 0, err
 					}
 					defer os.RemoveAll(aufsTempdir)

--- a/pkg/cli/image/mirror/mirror.go
+++ b/pkg/cli/image/mirror/mirror.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
@@ -811,7 +810,7 @@ func (s *descriptorBlobSource) Get(ctx context.Context, desc distribution.Descri
 		}
 		data, err = func() ([]byte, error) {
 			defer resp.Body.Close()
-			return ioutil.ReadAll(resp.Body)
+			return io.ReadAll(resp.Body)
 		}()
 		if err != nil {
 			continue

--- a/pkg/cli/image/serve/serve.go
+++ b/pkg/cli/image/serve/serve.go
@@ -3,7 +3,7 @@ package serve
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path"
@@ -102,7 +102,7 @@ func (o *ServeOptions) Run() error {
 			case "manifests":
 				if f, err := dir.Open(req.URL.Path); err == nil {
 					defer f.Close()
-					if data, err := ioutil.ReadAll(f); err == nil {
+					if data, err := io.ReadAll(f); err == nil {
 						var versioned manifest.Versioned
 						if err = json.Unmarshal(data, &versioned); err == nil {
 							w.Header().Set("Content-Type", versioned.MediaType)

--- a/pkg/cli/newapp/newapp.go
+++ b/pkg/cli/newapp/newapp.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -188,7 +188,7 @@ func (o *ObjectGeneratorOptions) Complete(f kcmdutil.Factory, c *cobra.Command, 
 	if len(o.Action.Output) == 0 {
 		o.Config.Out = o.Out
 	} else {
-		o.Config.Out = ioutil.Discard
+		o.Config.Out = io.Discard
 	}
 	o.Config.ErrOut = o.ErrOut
 
@@ -1209,7 +1209,7 @@ func (r *configSecretRetriever) CACert() (string, error) {
 		return string(r.config.CAData), nil
 	}
 	if len(r.config.CAFile) > 0 {
-		data, err := ioutil.ReadFile(r.config.CAFile)
+		data, err := os.ReadFile(r.config.CAFile)
 		if err != nil {
 			return "", fmt.Errorf("unable to read CA cert from config %s: %v", r.config.CAFile, err)
 		}

--- a/pkg/cli/newbuild/newbuild.go
+++ b/pkg/cli/newbuild/newbuild.go
@@ -2,7 +2,7 @@ package newbuild
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
@@ -175,7 +175,7 @@ func (o *BuildOptions) Complete(f kcmdutil.Factory, cmd *cobra.Command, args []s
 	}
 
 	if o.ObjectGeneratorOptions.Config.Dockerfile == "-" {
-		data, err := ioutil.ReadAll(o.In)
+		data, err := io.ReadAll(o.In)
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/observe/observe.go
+++ b/pkg/cli/observe/observe.go
@@ -3,7 +3,6 @@ package observe
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -344,7 +343,7 @@ func (o *ObserveOptions) Complete(f kcmdutil.Factory, cmd *cobra.Command, args [
 	o.printer = printerWrapper{printer: printer}
 
 	if o.quiet {
-		o.debugOut = ioutil.Discard
+		o.debugOut = io.Discard
 	} else {
 		o.debugOut = o.Out
 	}

--- a/pkg/cli/recycle/recycle_test.go
+++ b/pkg/cli/recycle/recycle_test.go
@@ -2,7 +2,6 @@ package recycle
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -50,7 +49,7 @@ func prepareTestDir(root string, filenames []string) error {
 
 		for _, file := range filenames {
 			filepath := path.Join(dirpath, file)
-			if err := ioutil.WriteFile(filepath, []byte(filepath), os.FileMode(0755)); err != nil {
+			if err := os.WriteFile(filepath, []byte(filepath), os.FileMode(0755)); err != nil {
 				return fmt.Errorf("Error writing file %s\n%v", filepath, err)
 			}
 
@@ -63,7 +62,7 @@ func prepareTestDir(root string, filenames []string) error {
 }
 
 func TestRecycle(t *testing.T) {
-	root, err := ioutil.TempDir("", "recycler-test-")
+	root, err := os.MkdirTemp("", "recycler-test-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -120,7 +119,7 @@ func TestCheckEmpty(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		root, err := ioutil.TempDir("", "recycler-test-")
+		root, err := os.MkdirTemp("", "recycler-test-")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cli/recycle/walker_test.go
+++ b/pkg/cli/recycle/walker_test.go
@@ -1,7 +1,6 @@
 package recycle
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -9,7 +8,7 @@ import (
 )
 
 func TestStatUID(t *testing.T) {
-	root, err := ioutil.TempDir("", "walker-test-")
+	root, err := os.MkdirTemp("", "walker-test-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -42,7 +41,7 @@ func TestStatUID(t *testing.T) {
 				t.Fatalf("Error writing dir %s\n%v", path, err)
 				continue
 			}
-			if err := ioutil.WriteFile(path, []byte(path), os.FileMode(0755)); err != nil {
+			if err := os.WriteFile(path, []byte(path), os.FileMode(0755)); err != nil {
 				t.Fatalf("Error writing file %s\n%v", path, err)
 			}
 		}

--- a/pkg/cli/rsync/copy_rsyncd.go
+++ b/pkg/cli/rsync/copy_rsyncd.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"strconv"
@@ -178,7 +177,7 @@ func (s *rsyncDaemonStrategy) startRemoteDaemon() error {
 			return fmt.Errorf("timed out waiting for rsync daemon to start")
 		}
 		checkScript.Reset()
-		err = s.RemoteExecutor.Execute([]string{"sh"}, checkScript, ioutil.Discard, ioutil.Discard)
+		err = s.RemoteExecutor.Execute([]string{"sh"}, checkScript, io.Discard, io.Discard)
 		if err == nil {
 			break
 		}

--- a/pkg/cli/rsync/copy_tar.go
+++ b/pkg/cli/rsync/copy_tar.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -59,7 +58,7 @@ func NewTarStrategy(o *RsyncOptions) CopyStrategy {
 
 func deleteContents(dir string) error {
 	klog.V(4).Infof("Deleting local directory contents: %s", dir)
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		klog.V(4).Infof("Could not read directory %s: %v", dir, err)
 		return err
@@ -129,7 +128,7 @@ func (r *tarStrategy) Copy(source, destination *PathSpec, out, errOut io.Writer)
 			return fmt.Errorf("unable to delete files in destination: %v", err)
 		}
 	}
-	tmp, err := ioutil.TempFile("", "rsync")
+	tmp, err := os.CreateTemp("", "rsync")
 	if err != nil {
 		return fmt.Errorf("cannot create local temporary file for tar: %v", err)
 	}

--- a/pkg/cli/startbuild/startbuild.go
+++ b/pkg/cli/startbuild/startbuild.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime"
 	"net/http"
 	"net/url"
@@ -779,7 +778,7 @@ func streamPathToBuild(repo git.Repository, in io.Reader, out io.Writer, client 
 				}
 
 				// Create a temp directory to move the repo contents to
-				tempDirectory, err := ioutil.TempDir(os.TempDir(), "oc_cloning_"+options.Commit)
+				tempDirectory, err := os.MkdirTemp(os.TempDir(), "oc_cloning_"+options.Commit)
 				if err != nil {
 					return nil, err
 				}
@@ -972,11 +971,11 @@ func (o *StartBuildOptions) RunStartBuildWebHook() error {
 	case resp.StatusCode == 301 || resp.StatusCode == 302:
 		// TODO: follow redirect and display output
 	case resp.StatusCode < 200 || resp.StatusCode >= 300:
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("server rejected our request %d\nremote: %s", resp.StatusCode, string(body))
 	}
 
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 	if len(body) > 0 {
 		// In later server versions we return the created Build in the body.
 		newBuild := &buildv1.Build{}

--- a/pkg/cli/startbuild/startbuild_test.go
+++ b/pkg/cli/startbuild/startbuild_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -125,7 +124,7 @@ func TestStartBuildHookPostReceive(t *testing.T) {
 	}))
 	defer server.Close()
 
-	f, _ := ioutil.TempFile("", "test")
+	f, _ := os.CreateTemp("", "test")
 	defer os.Remove(f.Name())
 	fmt.Fprintf(f, `0000 2384 refs/heads/master
 2548 2548 refs/heads/stage`)
@@ -161,7 +160,7 @@ type FakeBuildConfigs struct {
 }
 
 func (c FakeBuildConfigs) InstantiateBinary(name string, options *buildv1.BinaryBuildRequestOptions, r io.Reader) (result *buildv1.Build, err error) {
-	if binary, err := ioutil.ReadAll(r); err != nil {
+	if binary, err := io.ReadAll(r); err != nil {
 		c.t.Errorf("Error while reading binary over HTTP: %v", err)
 	} else if string(binary) != "hi" {
 		c.t.Errorf("Wrong value while reading binary over HTTP: %q", binary)
@@ -385,7 +384,7 @@ func TestStreamBuildLogs(t *testing.T) {
 					}
 					return &http.Response{
 						StatusCode: http.StatusOK,
-						Body:       ioutil.NopCloser(body),
+						Body:       io.NopCloser(body),
 					}, nil
 				}),
 			}

--- a/pkg/helpers/describe/projectstatus_test.go
+++ b/pkg/helpers/describe/projectstatus_test.go
@@ -2,7 +2,7 @@ package describe
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 	"text/tabwriter"
@@ -668,7 +668,7 @@ func TestPrintMarkerSuggestions(t *testing.T) {
 
 // readObjectsFromPath reads objects from the specified file for testing.
 func readObjectsFromPath(path, namespace string) ([]runtime.Object, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/helpers/file/fileutil.go
+++ b/pkg/helpers/file/fileutil.go
@@ -2,7 +2,6 @@ package file
 
 import (
 	"bufio"
-	"io/ioutil"
 	"os"
 )
 
@@ -28,7 +27,7 @@ func LoadData(file string) ([]byte, error) {
 		return []byte{}, nil
 	}
 
-	bytes, err := ioutil.ReadFile(file)
+	bytes, err := os.ReadFile(file)
 	if err != nil {
 		return []byte{}, err
 	}

--- a/pkg/helpers/graph/genericgraph/test/runtimeobject_nodebuilder.go
+++ b/pkg/helpers/graph/genericgraph/test/runtimeobject_nodebuilder.go
@@ -2,7 +2,7 @@ package test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"reflect"
 
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
@@ -126,7 +126,7 @@ func BuildGraph(path string) (osgraph.Graph, []runtime.Object, error) {
 	g := osgraph.New()
 	objs := []runtime.Object{}
 
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return g, objs, err
 	}

--- a/pkg/helpers/groupsync/grouppruner_test.go
+++ b/pkg/helpers/groupsync/grouppruner_test.go
@@ -3,7 +3,7 @@ package syncgroups
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -119,8 +119,8 @@ func newTestPruner() (*LDAPGroupPruner, *fakeuserv1client.FakeUserV1) {
 		GroupNameMapper: newTestGroupNameMapper(),
 		GroupClient:     tc.Groups(),
 		Host:            newTestHost(),
-		Out:             ioutil.Discard,
-		Err:             ioutil.Discard,
+		Out:             io.Discard,
+		Err:             io.Discard,
 	}, tc
 
 }

--- a/pkg/helpers/groupsync/groupsyncer_test.go
+++ b/pkg/helpers/groupsync/groupsyncer_test.go
@@ -3,7 +3,7 @@ package syncgroups
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"reflect"
 	"strings"
 	"testing"
@@ -22,8 +22,8 @@ import (
 
 func TestMakeOpenShiftGroup(t *testing.T) {
 	syncer := &LDAPGroupSyncer{
-		Out:  ioutil.Discard,
-		Err:  ioutil.Discard,
+		Out:  io.Discard,
+		Err:  io.Discard,
 		Host: "test-host:port",
 		GroupNameMapper: &TestGroupNameMapper{
 			NameMapping: map[string]string{
@@ -338,8 +338,8 @@ func newTestSyncer() (*LDAPGroupSyncer, *fakeuserv1client.FakeUserV1) {
 		GroupNameMapper:      newTestGroupNameMapper(),
 		GroupClient:          tc.Groups(),
 		Host:                 newTestHost(),
-		Out:                  ioutil.Discard,
-		Err:                  ioutil.Discard,
+		Out:                  io.Discard,
+		Err:                  io.Discard,
 	}, tc
 
 }

--- a/pkg/helpers/groupsync/ldap/ldap.go
+++ b/pkg/helpers/groupsync/ldap/ldap.go
@@ -3,7 +3,6 @@ package ldap
 import (
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"unicode"
@@ -38,7 +37,7 @@ func ResolveStringValue(s legacyconfigv1.StringSource) (string, error) {
 	case len(s.Env) > 0:
 		value = os.Getenv(s.Env)
 	case len(s.File) > 0:
-		data, err := ioutil.ReadFile(s.File)
+		data, err := os.ReadFile(s.File)
 		if err != nil {
 			return "", err
 		}
@@ -52,7 +51,7 @@ func ResolveStringValue(s legacyconfigv1.StringSource) (string, error) {
 		return value, nil
 	}
 
-	keyData, err := ioutil.ReadFile(s.KeyFile)
+	keyData, err := os.ReadFile(s.KeyFile)
 	if err != nil {
 		return "", err
 	}
@@ -284,7 +283,7 @@ func ValidateStringSource(s legacyconfigv1.StringSource, fieldPath *field.Path) 
 
 		// If the file was otherwise ok, and its value will be used verbatim, warn about trailing whitespace
 		if len(fileErrors) == 0 && len(s.KeyFile) == 0 {
-			if data, err := ioutil.ReadFile(s.File); err != nil {
+			if data, err := os.ReadFile(s.File); err != nil {
 				validationResults.AddErrors(field.Invalid(fieldPath.Child("file"), s.File, fmt.Sprintf("could not read file: %v", err)))
 			} else if len(data) > 0 {
 				r, _ := utf8.DecodeLastRune(data)

--- a/pkg/helpers/groupsync/rfc2307/ldapinterface_test.go
+++ b/pkg/helpers/groupsync/rfc2307/ldapinterface_test.go
@@ -3,7 +3,7 @@ package rfc2307
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"reflect"
 	"testing"
 
@@ -43,8 +43,8 @@ func newTestLDAPInterfaceOrDie(client ldap.Client) *LDAPInterface {
 	userNameAttributes := []string{"cn"}
 
 	errorHandler := syncerror.NewCompoundHandler(
-		syncerror.NewMemberLookupOutOfBoundsSuppressor(ioutil.Discard),
-		syncerror.NewMemberLookupMemberNotFoundSuppressor(ioutil.Discard),
+		syncerror.NewMemberLookupOutOfBoundsSuppressor(io.Discard),
+		syncerror.NewMemberLookupMemberNotFoundSuppressor(io.Discard),
 	)
 
 	ldapClient, err := ldapclient.ConnectMaybeBind(ldaptestclient.NewConfig(client))

--- a/pkg/helpers/groupsync/syncerror/handler_test.go
+++ b/pkg/helpers/groupsync/syncerror/handler_test.go
@@ -2,7 +2,7 @@ package syncerror
 
 import (
 	"errors"
-	"io/ioutil"
+	"io"
 	"reflect"
 	"testing"
 
@@ -43,7 +43,7 @@ func TestSuppressMemberLookupErrorOutOfBounds(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		handler := NewMemberLookupOutOfBoundsSuppressor(ioutil.Discard)
+		handler := NewMemberLookupOutOfBoundsSuppressor(io.Discard)
 
 		actualHandled, actualFatalErr := handler.HandleError(testCase.err)
 		if actualHandled != testCase.expectedHandled {
@@ -96,7 +96,7 @@ func TestSuppressMemberLookupErrorMemberNotFound(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		handler := NewMemberLookupMemberNotFoundSuppressor(ioutil.Discard)
+		handler := NewMemberLookupMemberNotFoundSuppressor(io.Discard)
 
 		actualHandled, actualFatalErr := handler.HandleError(testCase.err)
 		if actualHandled != testCase.expectedHandled {

--- a/pkg/helpers/image/credentialprovider/config.go
+++ b/pkg/helpers/image/credentialprovider/config.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -92,7 +91,7 @@ func ReadDockercfgFile(searchPaths []string) (cfg DockerConfig, err error) {
 			continue
 		}
 		klog.V(4).Infof("looking for .dockercfg at %s", absDockerConfigFileLocation)
-		contents, err := ioutil.ReadFile(absDockerConfigFileLocation)
+		contents, err := os.ReadFile(absDockerConfigFileLocation)
 		if os.IsNotExist(err) {
 			continue
 		}
@@ -144,7 +143,7 @@ func ReadDockerConfigJSONFile(searchPaths []string) (cfg DockerConfig, err error
 func ReadSpecificDockerConfigJSONFile(filePath string) (cfg DockerConfig, err error) {
 	var contents []byte
 
-	if contents, err = ioutil.ReadFile(filePath); err != nil {
+	if contents, err = os.ReadFile(filePath); err != nil {
 		return nil, err
 	}
 
@@ -200,7 +199,7 @@ func ReadURL(url string, client *http.Client, header *http.Header) (body []byte,
 	}
 
 	limitedReader := &io.LimitedReader{R: resp.Body, N: maxReadLength}
-	contents, err := ioutil.ReadAll(limitedReader)
+	contents, err := io.ReadAll(limitedReader)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/helpers/image/credentialprovider/config_test.go
+++ b/pkg/helpers/image/credentialprovider/config_test.go
@@ -3,7 +3,6 @@ package credentialprovider
 import (
 	"encoding/base64"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -17,7 +16,7 @@ func TestReadDockerConfigFile(t *testing.T) {
 	//test dockerconfig json
 	inputDockerconfigJSONFile := "{ \"auths\": { \"http://foo.example.com\":{\"auth\":\"Zm9vOmJhcgo=\",\"email\":\"foo@example.com\"}}}"
 
-	preferredPath, err := ioutil.TempDir("", "test_foo_bar_dockerconfigjson_")
+	preferredPath, err := os.MkdirTemp("", "test_foo_bar_dockerconfigjson_")
 	if err != nil {
 		t.Fatalf("Creating tmp dir fail: %v", err)
 		return

--- a/pkg/helpers/image/dockerlayer/add/add.go
+++ b/pkg/helpers/image/dockerlayer/add/add.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"runtime"
 	"time"
 
@@ -62,7 +61,7 @@ func DigestCopy(dst io.ReaderFrom, src io.Reader) (layerDigest, blobDigest diges
 		}
 		_, err = io.Copy(layerhash, gr)
 		if err != nil {
-			io.Copy(ioutil.Discard, pr)
+			io.Copy(io.Discard, pr)
 		}
 		ch <- err
 	}()

--- a/pkg/helpers/newapp/app/env.go
+++ b/pkg/helpers/newapp/app/env.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"sort"
@@ -139,7 +138,7 @@ func LoadEnvironmentFile(filename string, stdin io.Reader) (Environment, error) 
 
 	if filename == "-" && stdin != nil {
 		//once https://github.com/joho/godotenv/pull/20 is merged we can get rid of using tempfile
-		temp, err := ioutil.TempFile("", "origin-env-stdin")
+		temp, err := os.CreateTemp("", "origin-env-stdin")
 		if err != nil {
 			return nil, fmt.Errorf("Cannot create temporary file: %s", err)
 		}

--- a/pkg/helpers/newapp/app/sourcelookup.go
+++ b/pkg/helpers/newapp/app/sourcelookup.go
@@ -3,7 +3,6 @@ package app
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -31,7 +30,7 @@ type Dockerfile interface {
 }
 
 func NewDockerfileFromFile(path string) (Dockerfile, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
@@ -258,7 +257,7 @@ func (r *SourceRepository) LocalPath() (string, error) {
 	} else {
 		gitRepo := git.NewRepository()
 		var err error
-		if r.localDir, err = ioutil.TempDir("", "gen"); err != nil {
+		if r.localDir, err = os.MkdirTemp("", "gen"); err != nil {
 			return "", err
 		}
 		r.localDir, err = CloneAndCheckoutSources(gitRepo, r.url.StringNoFragment(), r.url.URL.Fragment, r.localDir, r.contextDir)
@@ -289,12 +288,12 @@ func (r *SourceRepository) DetectAuth() error {
 	if !ok {
 		return nil // No auth needed, we can't find a remote URL
 	}
-	tempHome, err := ioutil.TempDir("", "githome")
+	tempHome, err := os.MkdirTemp("", "githome")
 	if err != nil {
 		return err
 	}
 	defer os.RemoveAll(tempHome)
-	tempSrc, err := ioutil.TempDir("", "gen")
+	tempSrc, err := os.MkdirTemp("", "gen")
 	if err != nil {
 		return err
 	}

--- a/pkg/helpers/newapp/newapptest/newapp_test.go
+++ b/pkg/helpers/newapp/newapptest/newapp_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -65,7 +64,7 @@ func skipExternalGit(t *testing.T) {
 }
 
 func TestNewAppAddArguments(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "test-newapp")
+	tmpDir, err := os.MkdirTemp("", "test-newapp")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -1590,7 +1589,7 @@ func TestNewAppBuildOutputCycleDetection(t *testing.T) {
 				"imageStream": {"ruby-27-centos7"},
 			},
 			checkOutput: func(stdout, stderr io.Reader) error {
-				got, err := ioutil.ReadAll(stderr)
+				got, err := io.ReadAll(stderr)
 				if err != nil {
 					return err
 				}
@@ -1614,7 +1613,7 @@ func TestNewAppBuildOutputCycleDetection(t *testing.T) {
 				"imageStream": {"centos"},
 			},
 			checkOutput: func(stdout, stderr io.Reader) error {
-				got, err := ioutil.ReadAll(stderr)
+				got, err := io.ReadAll(stderr)
 				if err != nil {
 					return err
 				}
@@ -1638,7 +1637,7 @@ func TestNewAppBuildOutputCycleDetection(t *testing.T) {
 				"imageStream": {"ruby-27-centos7"},
 			},
 			checkOutput: func(stdout, stderr io.Reader) error {
-				got, err := ioutil.ReadAll(stderr)
+				got, err := io.ReadAll(stderr)
 				if err != nil {
 					return err
 				}
@@ -1698,7 +1697,7 @@ func TestNewAppBuildOutputCycleDetection(t *testing.T) {
 				"imageStream": {"ruby-27-centos7"},
 			},
 			checkOutput: func(stdout, stderr io.Reader) error {
-				got, err := ioutil.ReadAll(stderr)
+				got, err := io.ReadAll(stderr)
 				if err != nil {
 					return err
 				}
@@ -1730,7 +1729,7 @@ func TestNewAppBuildOutputCycleDetection(t *testing.T) {
 				"imageStream": {"ruby-27-centos7"},
 			},
 			checkOutput: func(stdout, stderr io.Reader) error {
-				got, err := ioutil.ReadAll(stderr)
+				got, err := io.ReadAll(stderr)
 				if err != nil {
 					return err
 				}
@@ -2091,7 +2090,7 @@ func TestNewAppListAndSearch(t *testing.T) {
 
 func setupLocalGitRepo(t *testing.T, passwordProtected bool, requireProxy bool) (string, string) {
 	// Create test directories
-	testDir, err := ioutil.TempDir("", "gitauth")
+	testDir, err := os.MkdirTemp("", "gitauth")
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -2122,7 +2121,7 @@ func setupLocalGitRepo(t *testing.T, passwordProtected bool, requireProxy bool) 
 	if err = gitRepo.Init(initialRepoDir, false); err != nil {
 		t.Fatalf("%v", err)
 	}
-	if err = ioutil.WriteFile(filepath.Join(initialRepoDir, "Dockerfile"), []byte("FROM mysql\nLABEL mylabel=myvalue\n"), 0644); err != nil {
+	if err = os.WriteFile(filepath.Join(initialRepoDir, "Dockerfile"), []byte("FROM mysql\nLABEL mylabel=myvalue\n"), 0644); err != nil {
 		t.Fatalf("%v", err)
 	}
 	if err = gitRepo.Add(initialRepoDir, "."); err != nil {
@@ -2202,7 +2201,7 @@ insteadOf = %s
 		gitConfig += proxySection
 	}
 
-	if err = ioutil.WriteFile(filepath.Join(userHomeDir, ".gitconfig"), []byte(gitConfig), 0644); err != nil {
+	if err = os.WriteFile(filepath.Join(userHomeDir, ".gitconfig"), []byte(gitConfig), 0644); err != nil {
 		t.Fatalf("%v", err)
 	}
 	os.Setenv("HOME", userHomeDir)

--- a/pkg/helpers/source-to-image/cmd/test/cmd.go
+++ b/pkg/helpers/source-to-image/cmd/test/cmd.go
@@ -3,7 +3,6 @@ package test
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 
 	"github.com/openshift/oc/pkg/helpers/source-to-image/cmd"
 )
@@ -32,7 +31,7 @@ func (f *FakeCmdRunner) Run(name string, args ...string) error {
 // StartWithStdoutPipe executes a command returning a ReadCloser connected to
 // the command's stdout.
 func (f *FakeCmdRunner) StartWithStdoutPipe(opts cmd.CommandOpts, name string, arg ...string) (io.ReadCloser, error) {
-	return ioutil.NopCloser(&bytes.Buffer{}), f.Err
+	return io.NopCloser(&bytes.Buffer{}), f.Err
 }
 
 // Wait waits for the command to exit.

--- a/pkg/helpers/source-to-image/fs/fs.go
+++ b/pkg/helpers/source-to-image/fs/fs.go
@@ -334,7 +334,7 @@ func (h *fs) RemoveDirectory(dir string) error {
 
 // CreateWorkingDirectory creates a directory to be used for STI
 func (h *fs) CreateWorkingDirectory() (directory string, err error) {
-	directory, err = ioutil.TempDir("", "s2i")
+	directory, err = os.MkdirTemp("", "s2i")
 	if err != nil {
 		return "", s2ierr.NewWorkDirError(directory, err)
 	}
@@ -355,7 +355,7 @@ func (h *fs) Create(filename string) (io.WriteCloser, error) {
 // WriteFile opens a file and writes data to it, returning error if such
 // occurred
 func (h *fs) WriteFile(filename string, data []byte) error {
-	return ioutil.WriteFile(filename, data, 0700)
+	return os.WriteFile(filename, data, 0700)
 }
 
 // Walk walks the file tree rooted at root, calling walkFn for each file or

--- a/pkg/helpers/source-to-image/git/testhelpers.go
+++ b/pkg/helpers/source-to-image/git/testhelpers.go
@@ -1,7 +1,6 @@
 package git
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -51,7 +50,7 @@ func CreateLocalGitDirectory() (string, error) {
 func CreateEmptyLocalGitDirectory() (string, error) {
 	cr := cmd.NewCommandRunner()
 
-	dir, err := ioutil.TempDir(os.TempDir(), "gitdir-s2i-test")
+	dir, err := os.MkdirTemp(os.TempDir(), "gitdir-s2i-test")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/helpers/source-to-image/tar/tar.go
+++ b/pkg/helpers/source-to-image/tar/tar.go
@@ -4,7 +4,6 @@ import (
 	"archive/tar"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -197,7 +196,7 @@ func (t *stiTar) SetExclusionPattern(p *regexp.Regexp) {
 // while excluding files that match the given exclusion pattern
 // It returns the name of the created file
 func (t *stiTar) CreateTarFile(base, dir string) (string, error) {
-	tarFile, err := ioutil.TempFile(base, "tar")
+	tarFile, err := os.CreateTemp(base, "tar")
 	defer tarFile.Close()
 	if err != nil {
 		return "", err

--- a/pkg/helpers/source-to-image/tar/tar_test.go
+++ b/pkg/helpers/source-to-image/tar/tar_test.go
@@ -4,7 +4,6 @@ import (
 	"archive/tar"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -47,7 +46,7 @@ func createTestFiles(baseDir string, dirs []dirDesc, files []fileDesc, links []l
 	}
 	for _, fd := range files {
 		fileName := filepath.Join(baseDir, fd.name)
-		err := ioutil.WriteFile(fileName, []byte(fd.content), fd.mode)
+		err := os.WriteFile(fileName, []byte(fd.content), fd.mode)
 		if err != nil {
 			return err
 		}
@@ -140,7 +139,7 @@ func verifyTarFile(t *testing.T, filename string, dirs []dirDesc, files []fileDe
 				t.Errorf("File %q from tar %q does not match expected modified date. Expected: %v, actual: %v",
 					hdr.Name, filename, fd.modifiedDate, finfo.ModTime().UTC())
 			}
-			fileBytes, err := ioutil.ReadAll(tr)
+			fileBytes, err := io.ReadAll(tr)
 			if err != nil {
 				t.Fatalf("Error reading tar %q: %v", filename, err)
 			}
@@ -168,7 +167,7 @@ func verifyTarFile(t *testing.T, filename string, dirs []dirDesc, files []fileDe
 }
 
 func TestCreateTarStreamIncludeParentDir(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "testtar")
+	tempDir, err := os.MkdirTemp("", "testtar")
 	defer os.RemoveAll(tempDir)
 	if err != nil {
 		t.Fatalf("Cannot create temp directory for test: %v", err)
@@ -190,7 +189,7 @@ func TestCreateTarStreamIncludeParentDir(t *testing.T) {
 		t.Fatalf("Cannot create test files: %v", err)
 	}
 	th := New(fs.NewFileSystem())
-	tarFile, err := ioutil.TempFile("", "testtarout")
+	tarFile, err := os.CreateTemp("", "testtarout")
 	if err != nil {
 		t.Fatalf("Unable to create temporary file %v", err)
 	}
@@ -211,7 +210,7 @@ func TestCreateTarStreamIncludeParentDir(t *testing.T) {
 
 func TestCreateTar(t *testing.T) {
 	th := New(fs.NewFileSystem())
-	tempDir, err := ioutil.TempDir("", "testtar")
+	tempDir, err := os.MkdirTemp("", "testtar")
 	defer os.RemoveAll(tempDir)
 	if err != nil {
 		t.Fatalf("Cannot create temp directory for test: %v", err)
@@ -252,7 +251,7 @@ func TestCreateTar(t *testing.T) {
 func TestCreateTarIncludeDotGit(t *testing.T) {
 	th := New(fs.NewFileSystem())
 	th.SetExclusionPattern(regexp.MustCompile("test3.txt"))
-	tempDir, err := ioutil.TempDir("", "testtar")
+	tempDir, err := os.MkdirTemp("", "testtar")
 	defer os.RemoveAll(tempDir)
 	if err != nil {
 		t.Fatalf("Cannot create temp directory for test: %v", err)
@@ -292,7 +291,7 @@ func TestCreateTarIncludeDotGit(t *testing.T) {
 func TestCreateTarEmptyRegexp(t *testing.T) {
 	th := New(fs.NewFileSystem())
 	th.SetExclusionPattern(regexp.MustCompile(""))
-	tempDir, err := ioutil.TempDir("", "testtar")
+	tempDir, err := os.MkdirTemp("", "testtar")
 	defer os.RemoveAll(tempDir)
 	if err != nil {
 		t.Fatalf("Cannot create temp directory for test: %v", err)
@@ -501,7 +500,7 @@ func verifyDirectory(t *testing.T, dir string, dirs []dirDesc, files []fileDesc,
 					relpath, fd.modifiedDate, info.ModTime())
 			}
 			if !info.IsDir() {
-				contentBytes, err := ioutil.ReadFile(path)
+				contentBytes, err := os.ReadFile(path)
 				if err != nil {
 					t.Errorf("Error reading file %q: %v", path, err)
 					return err
@@ -565,7 +564,7 @@ func TestExtractTarStream(t *testing.T) {
 		{"dir01/dir03/tëst3.txt", modificationDate, 0444, "utf-8 header file content", false, ""},
 	}
 	reader, writer := io.Pipe()
-	destDir, err := ioutil.TempDir("", "testExtract")
+	destDir, err := os.MkdirTemp("", "testExtract")
 	if err != nil {
 		t.Fatalf("Cannot create temp directory: %v", err)
 	}
@@ -586,7 +585,7 @@ func TestExtractTarStream(t *testing.T) {
 
 func TestExtractTarStreamTimeout(t *testing.T) {
 	reader, writer := io.Pipe()
-	destDir, err := ioutil.TempDir("", "testExtract")
+	destDir, err := os.MkdirTemp("", "testExtract")
 	if err != nil {
 		t.Fatalf("Cannot create temp directory: %v", err)
 	}
@@ -603,12 +602,12 @@ func TestExtractTarStreamTimeout(t *testing.T) {
 func TestRoundTripTar(t *testing.T) {
 	tarWriter := New(fs.NewFileSystem())
 	tarReader := New(fs.NewFileSystem())
-	tempDir, err := ioutil.TempDir("", "testtar")
+	tempDir, err := os.MkdirTemp("", "testtar")
 	defer os.RemoveAll(tempDir)
 	if err != nil {
 		t.Fatalf("Cannot create temp input directory for test: %v", err)
 	}
-	destDir, err := ioutil.TempDir("", "testExtract")
+	destDir, err := os.MkdirTemp("", "testExtract")
 	defer os.RemoveAll(destDir)
 	if err != nil {
 		t.Fatalf("Cannot create temp extract directory for test: %v", err)

--- a/tools/gendocs/gendocs/gendocs.go
+++ b/tools/gendocs/gendocs/gendocs.go
@@ -2,7 +2,6 @@ package gendocs
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -35,7 +34,7 @@ func GenDocs(cmd *cobra.Command, filename string, admin, microshift bool) error 
 	if err != nil {
 		return err
 	}
-	template, err := ioutil.ReadFile(templateFile)
+	template, err := os.ReadFile(templateFile)
 	if err != nil {
 		return err
 	}

--- a/tools/genman/gen_man.go
+++ b/tools/genman/gen_man.go
@@ -63,7 +63,7 @@ func genCmdMan(cmdName string, cmd *cobra.Command) {
 	// Set environment variables used by openshift so the output is consistent,
 	// regardless of where we run.
 	os.Setenv("HOME", "/home/username")
-	// TODO os.Stdin should really be something like ioutil.Discard, but a Reader
+	// TODO os.Stdin should really be something like io.Discard, but a Reader
 	genMarkdown(cmd, "", outDir)
 	for _, c := range cmd.Commands() {
 		genMarkdown(c, cmdName, outDir)


### PR DESCRIPTION
This PR migrates from deprecated `ioutil` to all relevant suggested libraries.

There are a few ioutil usages left. Because `ioutil.ReadDir` and `os.ReadDir` return different objects and 
to keep the simplicity of this PR, these will be handled in a followup PR.