### PR TITLE
ART-8372: el7 version of oc in 4.11

### DIFF
--- a/images/cli-artifacts/Dockerfile.rhel
+++ b/images/cli-artifacts/Dockerfile.rhel
@@ -5,11 +5,18 @@ WORKDIR /go/src/github.com/openshift/oc
 COPY . .
 RUN make cross-build --warn-undefined-variables
 
+FROM registry.ci.openshift.org/ocp/builder:rhel-7-golang-1.18-openshift-4.11 AS builder-rhel-7
+WORKDIR /go/src/github.com/openshift/oc
+COPY . .
+RUN make cross-build --warn-undefined-variables
+
 FROM registry.ci.openshift.org/ocp/4.11:cli
 COPY --from=builder /go/src/github.com/openshift/oc/_output/bin/darwin_amd64/oc /usr/share/openshift/mac/oc
 COPY --from=builder /go/src/github.com/openshift/oc/_output/bin/darwin_arm64/oc /usr/share/openshift/mac_arm64/oc
 COPY --from=builder /go/src/github.com/openshift/oc/_output/bin/windows_amd64/oc.exe /usr/share/openshift/windows/oc.exe
 COPY --from=builder /go/src/github.com/openshift/oc/_output/bin/linux_amd64/oc /usr/share/openshift/linux_amd64/oc
+COPY --from=builder /go/src/github.com/openshift/oc/_output/bin/linux_amd64/oc /usr/share/openshift/linux_amd64/oc.rhel8
+COPY --from=builder-rhel-7 /go/src/github.com/openshift/oc/_output/bin/linux_amd64/oc /usr/share/openshift/linux_amd64/oc.rhel7
 COPY --from=builder /go/src/github.com/openshift/oc/_output/bin/linux_amd64/oc /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/oc/_output/bin/linux_arm64/oc /usr/share/openshift/linux_arm64/oc
 COPY --from=builder /go/src/github.com/openshift/oc/_output/bin/linux_ppc64le/oc /usr/share/openshift/linux_ppc64le/oc


### PR DESCRIPTION
Fixes rolled out for FIPS make it impossible for a binary compiled on RHELX to run on RHELY (in a FIPS compliant way) if the RHELY host is running with FIPS enabled.

This is because the binary will not find a compatible OpenSSL library and fall back to using internal Go crypto. Only OpenSSL is FIPS certified.

With the introduction of "FIPS or Die", binaries run in FIPS mode but which cannot use OpenSSL will exit with an error. Customers using RHEL7 with FIPS enabled, therefore, need a RHEL7 based oc.