### PR TITLE
OCPBUGS-24375: Overwrite template's namespace with the explicit one

### DIFF
--- a/pkg/cli/process/process.go
+++ b/pkg/cli/process/process.go
@@ -351,10 +351,6 @@ func (o *ProcessOptions) RunProcess() error {
 			return err
 		}
 		templateObj.CreationTimestamp = metav1.Now()
-		if len(templateObj.Namespace) > 0 && templateObj.Namespace != o.namespace {
-			// if set, template namespace must match the namespace it will be processed in.
-			templateObj.Namespace = o.namespace
-		}
 		infos = append(infos, &resource.Info{Object: templateObj})
 	} else {
 		var err error

--- a/pkg/cli/process/process.go
+++ b/pkg/cli/process/process.go
@@ -387,6 +387,11 @@ func (o *ProcessOptions) RunProcess() error {
 		return fmt.Errorf("unable to parse %q, not a valid Template but %s\n", sourceName, reflect.TypeOf(infos[0].Object))
 	}
 
+	if len(obj.Namespace) > 0 && obj.Namespace != o.namespace {
+		// if set, template namespace must match the namespace it will be processed in.
+		obj.Namespace = o.namespace
+	}
+
 	// If 'parameters' flag is set it does not do processing but only print
 	// the template parameters to console for inspection.
 	if o.parameters {


### PR DESCRIPTION
https://github.com/openshift/oc/pull/1318 fixes only when the template is passed
directly. But the problem still exists, when the template is passed in a file.

This PR overwrites the namespace in template with the one passed explicitly
in command, when template's namespace and explicit namespace is mismatched.