### PR TITLE
OCPBUGS-24225: Remove deprecated password defaulting in default config flag

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -98,7 +98,7 @@ var (
 )
 
 func defaultConfigFlags() *genericclioptions.ConfigFlags {
-	return genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag().WithDiscoveryBurst(350).WithDiscoveryQPS(50.0)
+	return genericclioptions.NewConfigFlags(true).WithDiscoveryBurst(350).WithDiscoveryQPS(50.0)
 }
 
 func NewDefaultOcCommand(o kubecmd.KubectlOptions) *cobra.Command {


### PR DESCRIPTION
It seemed reasonable to add `WithDeprecatedPasswordFlag` to sync with kubectl in https://github.com/openshift/oc/pull/1424#discussion_r1269268904. However, 
unexpectedly this caused a slight behavioral change in oc command as filed in
https://github.com/openshift/oc/issues/1615 and the referenced issue to this PR.

The reason of the failure is when password is not nil(instead it is empty string ""), 
config flags prompts user to enter username and password to move forward https://github.com/kubernetes/kubernetes/blob/a504aed54d028dbc8ea2508142c94d309f5f1ec6/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go#L235. However, prior oc behavior is
password should be nil and it returns non interactive config https://github.com/kubernetes/kubernetes/blob/a504aed54d028dbc8ea2508142c94d309f5f1ec6/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go#L233 which will end up returning to user
about not found error of the resource.

This PR removes `WithDeprecatedPasswordFlag` from the default to preserve
old behavior. This change is safe because we don't use it anyway.