### PR TITLE
NO-JIRA: oc release extract: Introduce --idms-file and deprecate icsp-file

### DIFF
--- a/pkg/cli/admin/release/extract.go
+++ b/pkg/cli/admin/release/extract.go
@@ -129,6 +129,8 @@ func NewExtract(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.C
 	o.ParallelOptions.Bind(flags)
 
 	flags.StringVar(&o.ICSPFile, "icsp-file", o.ICSPFile, "Path to an ImageContentSourcePolicy file. If set, data from this file will be used to find alternative locations for images.")
+	flags.MarkDeprecated("icsp-file", "support for it will be removed in a future release. Use --idms-file instead.")
+	flags.StringVar(&o.IDMSFile, "idms-file", o.IDMSFile, "Path to an ImageDigestMirrorSet file. If set, data from this file will be used to find alternative locations for images.")
 
 	flags.StringVar(&o.From, "from", o.From, "Image containing the release payload.")
 	flags.StringVar(&o.File, "file", o.File, "Extract a single file from the payload to standard output.")
@@ -163,6 +165,7 @@ type ExtractOptions struct {
 	RESTConfig *rest.Config
 
 	ICSPFile string
+	IDMSFile string
 
 	Output string
 
@@ -259,6 +262,10 @@ func (o *ExtractOptions) Run(ctx context.Context) error {
 		return fmt.Errorf("--install-config is only supported with --included")
 	}
 
+	if len(o.ICSPFile) > 0 && len(o.IDMSFile) > 0 {
+		return fmt.Errorf("icsp-file and idms-file are mutually exclusive")
+	}
+
 	if len(o.Cloud) > 0 && !o.CredentialsRequests && !o.Included {
 		return fmt.Errorf("--cloud is only supported with --credentials-requests or --included")
 	}
@@ -306,6 +313,7 @@ func (o *ExtractOptions) Run(ctx context.Context) error {
 	opts.FileDir = o.FileDir
 	opts.OnlyFiles = true
 	opts.ICSPFile = o.ICSPFile
+	opts.IDMSFile = o.IDMSFile
 	opts.Mappings = []extract.Mapping{
 		{
 			ImageRef: ref,

--- a/pkg/cli/admin/release/extract_tools.go
+++ b/pkg/cli/admin/release/extract_tools.go
@@ -481,6 +481,7 @@ func (o *ExtractOptions) extractCommand(command string) error {
 	infoOptions.FilterOptions = o.FilterOptions
 	infoOptions.FileDir = o.FileDir
 	infoOptions.ICSPFile = o.ICSPFile
+	infoOptions.IDMSFile = o.IDMSFile
 	release, err := infoOptions.LoadReleaseInfo(o.From, false)
 	if err != nil {
 		return err
@@ -559,6 +560,7 @@ func (o *ExtractOptions) extractCommand(command string) error {
 	opts.SecurityOptions = o.SecurityOptions
 	opts.FilterOptions = o.FilterOptions
 	opts.ICSPFile = o.ICSPFile
+	opts.IDMSFile = o.IDMSFile
 	opts.OnlyFiles = true
 
 	// create the mapping lookup of the valid targets


### PR DESCRIPTION
This PR adds new --idms-file flag to support IDMS as alternative registry source and deprecates --icsp-file flag.
This PR uses foundational work introduced in https://github.com/openshift/oc/pull/1426