### PR TITLE
OCPBUGS-23386: Generate FIPS compatible RHEL9 oc binary

### DIFF
--- a/images/cli-artifacts/Dockerfile.rhel
+++ b/images/cli-artifacts/Dockerfile.rhel
@@ -5,6 +5,11 @@ WORKDIR /go/src/github.com/openshift/oc
 COPY . .
 RUN make cross-build --warn-undefined-variables
 
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder-rhel-9
+WORKDIR /go/src/github.com/openshift/oc
+COPY . .
+RUN make cross-build --warn-undefined-variables
+
 FROM registry.ci.openshift.org/ocp/4.16:cli
 
 COPY --from=builder /go/src/github.com/openshift/oc/_output/bin/ /usr/share/openshift/
@@ -12,6 +17,10 @@ COPY --from=builder /go/src/github.com/openshift/oc/_output/bin/ /usr/share/open
 RUN cd /usr/share/openshift && \
     ln -sf /usr/share/openshift/linux_$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/')/oc /usr/bin/oc && \
     mv windows_amd64 windows && mv darwin_amd64 mac && mv darwin_arm64 mac_arm64
+
+COPY --from=builder-rhel-9 /go/src/github.com/openshift/oc/_output/bin/linux_amd64/oc /usr/share/openshift/linux_amd64/oc.rhel9
+COPY --from=builder-rhel-9 /go/src/github.com/openshift/oc/_output/bin/linux_arm64/oc /usr/share/openshift/linux_arm64/oc.rhel9
+COPY --from=builder-rhel-9 /go/src/github.com/openshift/oc/_output/bin/linux_ppc64le/oc /usr/share/openshift/linux_ppc64le/oc.rhel9
 
 COPY --from=builder /go/src/github.com/openshift/oc/LICENSE /usr/share/openshift/LICENSE
 


### PR DESCRIPTION
This PR generates RHEL9 FIPS enabled compatible oc binaries in linux_amd64,
linux_arm64, linux_ppc64le architectures and saves them as oc.rhel9(this will be backported to 4.15 and 4.14).