### PR TITLE
WRKLDS-1012: oc adm must-gather: pull gather container logs

### DIFF
--- a/pkg/cli/admin/mustgather/mustgather_test.go
+++ b/pkg/cli/admin/mustgather/mustgather_test.go
@@ -114,18 +114,18 @@ func TestGetNamespace(t *testing.T) {
 	t.Parallel()
 
 	for name, tc := range map[string]struct {
-		Options          MustGatherOptions
+		Options          *MustGatherOptions
 		ShouldBeRetained bool
 		ShouldFail       bool
 	}{
 		"no namespace given": {
-			Options: MustGatherOptions{
+			Options: &MustGatherOptions{
 				Client: fake.NewSimpleClientset(),
 			},
 			ShouldBeRetained: false,
 		},
 		"namespace given": {
-			Options: MustGatherOptions{
+			Options: &MustGatherOptions{
 				Client: fake.NewSimpleClientset(
 					&corev1.Namespace{
 						ObjectMeta: metav1.ObjectMeta{
@@ -138,7 +138,7 @@ func TestGetNamespace(t *testing.T) {
 			ShouldBeRetained: true,
 		},
 		"namespace given, but does not exist": {
-			Options: MustGatherOptions{
+			Options: &MustGatherOptions{
 				Client:       fake.NewSimpleClientset(),
 				RunNamespace: "test-namespace",
 			},


### PR DESCRIPTION
- creates a gather.log file under each image directory to capture the gather container logs in case the collection fails with an error.

Tested by running:
```
$ oc adm must-gather -- ls
```