### PR TITLE
OTA-492: pkg/cli/admin/upgrade/rollback: New rollback command

### DIFF
--- a/pkg/cli/admin/upgrade/rollback/rollback.go
+++ b/pkg/cli/admin/upgrade/rollback/rollback.go
@@ -1,0 +1,165 @@
+// Package rollback initiates a rollback to a previous release.
+package rollback
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/blang/semver"
+	configv1 "github.com/openshift/api/config/v1"
+	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	"github.com/spf13/cobra"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+func newOptions(streams genericiooptions.IOStreams) *options {
+	return &options{
+		IOStreams: streams,
+	}
+}
+
+func New(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
+	o := newOptions(streams)
+	cmd := &cobra.Command{
+		Use:    "rollback",
+		Hidden: true,
+		Short:  "Rollback the cluster to the previous release.",
+		Long: templates.LongDesc(`
+			Rollback the cluster to the previous release.
+
+			Only patch version rollbacks within the same z stream, e.g. 4.y.newer to 4.y.older, are supported.
+			Minor version rollbacks from 4.newer to 4.older are not supported.  Updates to releases other than
+			the most-recent previous release that the cluster was attempting are not supported.  Rolling back
+			re-exposes the cluster to all the bugs which had been fixed from 4.y.older to 4.y.newer.  In most
+			cases, you probably want to understand what's having trouble and roll forward with fixes.
+		`),
+
+		Run: func(cmd *cobra.Command, args []string) {
+			kcmdutil.CheckErr(o.Complete(f, cmd, args))
+			kcmdutil.CheckErr(o.Run(cmd.Context()))
+		},
+	}
+
+	return cmd
+}
+
+// clusterVersionInterface is the subset of configv1client.ClusterVersionInterface
+// that we need, for easier mocking in unit tests.
+type clusterVersionInterface interface {
+	Get(ctx context.Context, name string, opts metav1.GetOptions) (*configv1.ClusterVersion, error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *configv1.ClusterVersion, err error)
+}
+
+type options struct {
+	genericiooptions.IOStreams
+
+	Client clusterVersionInterface
+}
+
+func (o *options) Complete(f kcmdutil.Factory, cmd *cobra.Command, args []string) error {
+	kcmdutil.RequireNoArguments(cmd, args)
+
+	cfg, err := f.ToRESTConfig()
+	if err != nil {
+		return err
+	}
+	client, err := configv1client.NewForConfig(cfg)
+	if err != nil {
+		return err
+	}
+	o.Client = client.ClusterVersions()
+
+	return nil
+}
+
+func (o *options) Run(ctx context.Context) error {
+	cv, err := o.Client.Get(ctx, "version", metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("no cluster version information available - you must be connected to an OpenShift version 4 server to fetch the current version")
+		}
+		return err
+	}
+
+	targetVersion, err := semver.Parse(cv.Status.Desired.Version)
+	if err != nil {
+		return fmt.Errorf("invalid ClusterVersion status.desired.version: %w", err)
+	}
+
+	var previousVersion *semver.Version
+	var previousImage string
+	for _, entry := range cv.Status.History {
+		if entry.Version != targetVersion.String() || entry.Image != cv.Status.Desired.Image {
+			version, err := semver.Parse(entry.Version)
+			if err != nil {
+				return fmt.Errorf("previous version %q invalid SemVer: %w", entry.Version, err)
+			} else {
+				previousVersion = &version
+				previousImage = entry.Image
+			}
+			break
+		}
+	}
+
+	if previousVersion == nil {
+		return fmt.Errorf("no previous version found in ClusterVersion's status.history besides the current %s (%s).", targetVersion, cv.Status.Desired.Image)
+	}
+
+	if previousVersion.GE(targetVersion) {
+		return fmt.Errorf("previous version %s (%s) is greater than or equal to current version %s (%s).  Use 'oc adm upgrade ...' to update, and not this rollback command.", previousVersion, previousImage, targetVersion, cv.Status.Desired.Image)
+	}
+
+	if previousVersion.Major != targetVersion.Major || previousVersion.Minor != targetVersion.Minor {
+		return fmt.Errorf("%s is less than the current target %s and matches the cluster's previous version, but rollbacks that change major or minor versions are not recommended.", previousVersion, targetVersion)
+	}
+
+	update := &configv1.Update{
+		Version: previousVersion.String(),
+		Image:   previousImage,
+	}
+
+	if c := findClusterOperatorStatusCondition(cv.Status.Conditions, configv1.OperatorProgressing); c == nil {
+		return fmt.Errorf("no current %s info, see `oc describe clusterversion` for more details.\n", configv1.OperatorProgressing)
+	} else if c.Status != configv1.ConditionFalse {
+		return fmt.Errorf("unable to rollback while an update is %s=%s: %s: %s.", c.Type, c.Status, c.Reason, c.Message)
+	}
+
+	if err := patchDesiredUpdate(ctx, update, o.Client, cv.Name); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(o.Out, "Requested rollback from %s to %s\n", targetVersion, previousVersion)
+
+	return nil
+}
+
+func findClusterOperatorStatusCondition(conditions []configv1.ClusterOperatorStatusCondition, name configv1.ClusterStatusConditionType) *configv1.ClusterOperatorStatusCondition {
+	for i := range conditions {
+		if conditions[i].Type == name {
+			return &conditions[i]
+		}
+	}
+	return nil
+}
+
+func patchDesiredUpdate(ctx context.Context, update *configv1.Update, client clusterVersionInterface,
+	clusterVersionName string) error {
+
+	updateJSON, err := json.Marshal(update)
+	if err != nil {
+		return fmt.Errorf("marshal ClusterVersion patch: %v", err)
+	}
+	patch := []byte(fmt.Sprintf(`{"spec":{"desiredUpdate": %s}}`, updateJSON))
+	if _, err := client.Patch(ctx, clusterVersionName, types.MergePatchType, patch,
+		metav1.PatchOptions{}); err != nil {
+
+		return fmt.Errorf("Unable to rollback: %v", err)
+	}
+	return nil
+}

--- a/pkg/cli/admin/upgrade/rollback/rollback_test.go
+++ b/pkg/cli/admin/upgrade/rollback/rollback_test.go
@@ -1,0 +1,230 @@
+package rollback
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+)
+
+type mockClusterVersionInterface struct {
+	clusterVersion *configv1.ClusterVersion
+	patch          string
+}
+
+func (i *mockClusterVersionInterface) Get(_ context.Context, name string, _ metav1.GetOptions) (*configv1.ClusterVersion, error) {
+	expectedName := "version"
+	if name != expectedName {
+		return nil, fmt.Errorf("unrecognized Get name: %q != %q", name, expectedName)
+	}
+
+	return i.clusterVersion, nil
+}
+
+func (i *mockClusterVersionInterface) Patch(_ context.Context, name string, pt types.PatchType, data []byte, _ metav1.PatchOptions, subresources ...string) (result *configv1.ClusterVersion, err error) {
+	expectedName := "version"
+	if name != expectedName {
+		return nil, fmt.Errorf("unrecognized Patch name: %q != %q", name, expectedName)
+	}
+
+	expectedPatchType := types.MergePatchType
+	if pt != expectedPatchType {
+		return nil, fmt.Errorf("unrecognized Patch type: %v != %v", pt, expectedPatchType)
+	}
+
+	if len(subresources) > 0 {
+		return nil, fmt.Errorf("unrecognized Patch subresources: %v", subresources)
+	}
+
+	i.patch = string(data)
+	var clusterVersion *configv1.ClusterVersion // nil, because we know options.Run does not consume this return value
+	return clusterVersion, nil
+}
+
+func TestRollback(t *testing.T) {
+	ctx := context.Background()
+
+	for _, testCase := range []struct {
+		name           string
+		clusterVersion *configv1.ClusterVersion
+		expectedPatch  string
+		expectedError  string
+		expectedOut    string
+	}{
+		{
+			name: "installing",
+			clusterVersion: &configv1.ClusterVersion{
+				Status: configv1.ClusterVersionStatus{
+					Desired: configv1.Release{Version: "1.2.3", Image: "example.com/a"},
+					Conditions: []configv1.ClusterOperatorStatusCondition{
+						{
+							Type:    configv1.OperatorProgressing,
+							Status:  configv1.ConditionTrue,
+							Reason:  "ClusterOperatorNotAvailable",
+							Message: "Still installing",
+						},
+					},
+					History: []configv1.UpdateHistory{
+						{State: configv1.PartialUpdate, Version: "1.2.3", Image: "example.com/a"},
+					},
+				},
+			},
+			expectedError: "no previous version found in ClusterVersion's status.history besides the current 1.2.3 (example.com/a).",
+		}, {
+			name: "installed",
+			clusterVersion: &configv1.ClusterVersion{
+				Status: configv1.ClusterVersionStatus{
+					Desired: configv1.Release{Version: "1.2.3", Image: "example.com/a"},
+					Conditions: []configv1.ClusterOperatorStatusCondition{
+						{
+							Type:    configv1.OperatorProgressing,
+							Status:  configv1.ConditionFalse,
+							Reason:  "AsExpected",
+							Message: "Happy on 1.2.3",
+						},
+					},
+					History: []configv1.UpdateHistory{
+						{State: configv1.CompletedUpdate, Version: "1.2.3", Image: "example.com/a"},
+					},
+				},
+			},
+			expectedError: "no previous version found in ClusterVersion's status.history besides the current 1.2.3 (example.com/a).",
+		}, {
+			name: "update in progress",
+			clusterVersion: &configv1.ClusterVersion{
+				Status: configv1.ClusterVersionStatus{
+					Desired: configv1.Release{Version: "1.2.4", Image: "example.com/b"},
+					Conditions: []configv1.ClusterOperatorStatusCondition{
+						{
+							Type:    configv1.OperatorProgressing,
+							Status:  configv1.ConditionTrue,
+							Reason:  "Updating",
+							Message: "Off to 1.2.4",
+						},
+					},
+					History: []configv1.UpdateHistory{
+						{State: configv1.PartialUpdate, Version: "1.2.4", Image: "example.com/b"},
+						{State: configv1.CompletedUpdate, Version: "1.2.3", Image: "example.com/a"},
+					},
+				},
+			},
+			expectedError: "unable to rollback while an update is Progressing=True: Updating: Off to 1.2.4.",
+		}, {
+			name: "after architecture pivot",
+			clusterVersion: &configv1.ClusterVersion{
+				Status: configv1.ClusterVersionStatus{
+					Desired: configv1.Release{Version: "1.2.3", Image: "example.com/b"},
+					Conditions: []configv1.ClusterOperatorStatusCondition{
+						{
+							Type:    configv1.OperatorProgressing,
+							Status:  configv1.ConditionFalse,
+							Reason:  "AsExpected",
+							Message: "Happy on a new multi-arch image for 1.2.3",
+						},
+					},
+					History: []configv1.UpdateHistory{
+						{State: configv1.CompletedUpdate, Version: "1.2.3", Image: "example.com/b"},
+						{State: configv1.CompletedUpdate, Version: "1.2.3", Image: "example.com/a"},
+					},
+				},
+			},
+			expectedError: "previous version 1.2.3 (example.com/a) is greater than or equal to current version 1.2.3 (example.com/b).  Use 'oc adm upgrade ...' to update, and not this rollback command.",
+		}, {
+			name: "after minor update",
+			clusterVersion: &configv1.ClusterVersion{
+				Status: configv1.ClusterVersionStatus{
+					Desired: configv1.Release{Version: "1.3.0", Image: "example.com/b"},
+					Conditions: []configv1.ClusterOperatorStatusCondition{
+						{
+							Type:    configv1.OperatorProgressing,
+							Status:  configv1.ConditionFalse,
+							Reason:  "AsExpected",
+							Message: "Happy on 1.3.0",
+						},
+					},
+					History: []configv1.UpdateHistory{
+						{State: configv1.CompletedUpdate, Version: "1.3.0", Image: "example.com/b"},
+						{State: configv1.CompletedUpdate, Version: "1.2.3", Image: "example.com/a"},
+					},
+				},
+			},
+			expectedError: "1.2.3 is less than the current target 1.3.0 and matches the cluster's previous version, but rollbacks that change major or minor versions are not recommended.",
+		}, {
+			name: "after patch update",
+			clusterVersion: &configv1.ClusterVersion{
+				Status: configv1.ClusterVersionStatus{
+					Desired: configv1.Release{Version: "1.2.4", Image: "example.com/b"},
+					Conditions: []configv1.ClusterOperatorStatusCondition{
+						{
+							Type:    configv1.OperatorProgressing,
+							Status:  configv1.ConditionFalse,
+							Reason:  "AsExpected",
+							Message: "Happy on 1.2.4",
+						},
+					},
+					History: []configv1.UpdateHistory{
+						{State: configv1.CompletedUpdate, Version: "1.2.4", Image: "example.com/b"},
+						{State: configv1.CompletedUpdate, Version: "1.2.3", Image: "example.com/a"},
+					},
+				},
+			},
+			expectedPatch: `{"spec":{"desiredUpdate": {"architecture":"","version":"1.2.3","image":"example.com/a","force":false}}}`,
+			expectedOut:   "Requested rollback from 1.2.4 to 1.2.3\n",
+		}, {
+			name: "after re-targeted partial update",
+			clusterVersion: &configv1.ClusterVersion{
+				Status: configv1.ClusterVersionStatus{
+					Desired: configv1.Release{Version: "1.2.5", Image: "example.com/c"},
+					Conditions: []configv1.ClusterOperatorStatusCondition{
+						{
+							Type:    configv1.OperatorProgressing,
+							Status:  configv1.ConditionFalse,
+							Reason:  "AsExpected",
+							Message: "Happy on 1.2.5",
+						},
+					},
+					History: []configv1.UpdateHistory{
+						{State: configv1.CompletedUpdate, Version: "1.2.5", Image: "example.com/c"},
+						{State: configv1.PartialUpdate, Version: "1.2.4", Image: "example.com/b"},
+						{State: configv1.CompletedUpdate, Version: "1.2.3", Image: "example.com/a"},
+					},
+				},
+			},
+			expectedPatch: `{"spec":{"desiredUpdate": {"architecture":"","version":"1.2.4","image":"example.com/b","force":false}}}`,
+			expectedOut:   "Requested rollback from 1.2.5 to 1.2.4\n",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			streams, _, out, errOut := genericiooptions.NewTestIOStreams()
+			clusterVersion := testCase.clusterVersion
+			if clusterVersion != nil {
+				clusterVersion.ObjectMeta.Name = "version"
+			}
+			client := &mockClusterVersionInterface{clusterVersion: clusterVersion}
+			o := &options{
+				IOStreams: streams,
+				Client:    client,
+			}
+			err := o.Run(ctx)
+			if (err == nil && testCase.expectedError != "") || (err != nil && err.Error() != testCase.expectedError) {
+				t.Errorf("Run() error: %v (expected %q)", err, testCase.expectedError)
+			}
+
+			if client.patch != testCase.expectedPatch {
+				t.Errorf("Run() patch %q, expected %q", client.patch, testCase.expectedPatch)
+			}
+
+			if out.String() != testCase.expectedOut {
+				t.Errorf("Run() output %q, expected %q", out.String(), testCase.expectedOut)
+			}
+
+			if errOut.String() != "" {
+				t.Errorf("Run() error output %q, expected none", errOut.String())
+			}
+		})
+	}
+}

--- a/pkg/cli/admin/upgrade/upgrade.go
+++ b/pkg/cli/admin/upgrade/upgrade.go
@@ -26,6 +26,7 @@ import (
 	imagereference "github.com/openshift/library-go/pkg/image/reference"
 
 	"github.com/openshift/oc/pkg/cli/admin/upgrade/channel"
+	"github.com/openshift/oc/pkg/cli/admin/upgrade/rollback"
 	"github.com/openshift/oc/pkg/cli/admin/upgrade/status"
 )
 
@@ -117,6 +118,7 @@ func New(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command 
 	}
 
 	cmd.AddCommand(channel.New(f, streams))
+	cmd.AddCommand(rollback.New(f, streams))
 
 	return cmd
 }


### PR DESCRIPTION
The "which release to roll back to?" criteria are matched to openshift/cluster-version-operator@12fdd0456b
(openshift/cluster-version-operator#996), where, based on [OTA-553](https://issues.redhat.com/browse/OTA-553), Lala, Scott, and Subin all agreed that rollbacks to the cluster's previous release should not be blocked, as long as the previous and current version had the same `major.minor` version (i.e. "within a z-stream", using `x.y.z` naming for `major.minor.patch`).  We agreed to ignore whether the previous history entry is `Completed` or `Partial`, expecting that most users who are interested in rolling back will make that decision at the first sign of trouble, and not after attempting a few roll-forward retargets.

I'm currently blocking `Progressing!=False` from rolling back, to align with our CI coverage in openshift/release@f4d37e7f87 (openshift/release#45115).  We could lift this restriction if we wanted to allow rollbacks to be requested from the middle of an in-progress update, but if we do, we'd probably want to add matching CI to cover that use-case.

The new subcommand is hidden, as Lala requested in [OTA-492](https://issues.redhat.com/browse/OTA-492)'s `Description` on 2021-09-22.  I have not put it behind a feature-gate environment variable in this commit, but that's also an option if we wanted to make it even less reachable.