### PR TITLE
NO-JIRA: Sanitize path using filepath Clean

### DIFF
--- a/pkg/cli/admin/release/new.go
+++ b/pkg/cli/admin/release/new.go
@@ -1595,7 +1595,7 @@ type PayloadVerifier func(filename string, data []byte) error
 func pruneUnreferencedImageStreams(out io.Writer, is *imageapi.ImageStream, metadata map[string]imageData, include []string) error {
 	referenced := make(map[string]struct{})
 	for _, v := range metadata {
-		is, err := parseImageStream(filepath.Join(v.Directory, "image-references"))
+		is, err := parseImageStream(filepath.Clean(filepath.Join(v.Directory, "image-references")))
 		if os.IsNotExist(err) {
 			continue
 		}

--- a/pkg/cli/rsync/copy_tar.go
+++ b/pkg/cli/rsync/copy_tar.go
@@ -66,10 +66,10 @@ func deleteContents(dir string) error {
 	for _, f := range files {
 		if f.IsDir() {
 			klog.V(5).Infof("Deleting directory: %s", f.Name())
-			err = os.RemoveAll(filepath.Join(dir, f.Name()))
+			err = os.RemoveAll(filepath.Clean(filepath.Join(dir, f.Name())))
 		} else {
 			klog.V(5).Infof("Deleting file: %s", f.Name())
-			err = os.Remove(filepath.Join(dir, f.Name()))
+			err = os.Remove(filepath.Clean(filepath.Join(dir, f.Name())))
 		}
 		if err != nil {
 			klog.V(4).Infof("Error deleting file or directory: %s: %v", f.Name(), err)


### PR DESCRIPTION
As getting warnings from snyk checks about some unsanitized input[1], to have a
green CI check, this PR sanitizes the path inputs.

[1] https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_oc/1644/pull-ci-openshift-oc-master-security/1737775363041267712