### PR TITLE
OCPBUGS-25461: Add RHEL9 and RHEL8 based oc as new targets in command extraction

### DIFF
--- a/images/cli-artifacts/Dockerfile.rhel
+++ b/images/cli-artifacts/Dockerfile.rhel
@@ -18,6 +18,10 @@ RUN cd /usr/share/openshift && \
     ln -sf /usr/share/openshift/linux_$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/')/oc /usr/bin/oc && \
     mv windows_amd64 windows && mv darwin_amd64 mac && mv darwin_arm64 mac_arm64
 
+RUN ln -sf /usr/share/openshift/linux_amd64/oc /usr/share/openshift/linux_amd64/oc.rhel8
+RUN ln -sf /usr/share/openshift/linux_arm64/oc /usr/share/openshift/linux_arm64/oc.rhel8
+RUN ln -sf /usr/share/openshift/linux_ppc64le/oc /usr/share/openshift/linux_ppc64le/oc.rhel8
+
 COPY --from=builder-rhel-9 /go/src/github.com/openshift/oc/_output/bin/linux_amd64/oc /usr/share/openshift/linux_amd64/oc.rhel9
 COPY --from=builder-rhel-9 /go/src/github.com/openshift/oc/_output/bin/linux_arm64/oc /usr/share/openshift/linux_arm64/oc.rhel9
 COPY --from=builder-rhel-9 /go/src/github.com/openshift/oc/_output/bin/linux_ppc64le/oc /usr/share/openshift/linux_ppc64le/oc.rhel9

--- a/pkg/cli/admin/release/extract_tools.go
+++ b/pkg/cli/admin/release/extract_tools.go
@@ -58,11 +58,12 @@ type extractTarget struct {
 	InjectReleaseVersion bool
 	SignMachOBinary      bool
 
-	ArchiveFormat string
-	AsArchive     bool
-	AsZip         bool
-	Readme        string
-	LinkTo        []string
+	ArchiveFormat     string
+	AsArchive         bool
+	AsZip             bool
+	Readme            string
+	LinkTo            []string
+	TargetCommandName string
 
 	Mapping extract.Mapping
 }
@@ -275,6 +276,7 @@ func (o *ExtractOptions) extractCommand(command string) error {
 			Readme:               readmeCLIUnix,
 			InjectReleaseVersion: true,
 			ArchiveFormat:        "openshift-client-linux-amd64-rhel9-%s.tar.gz",
+			TargetCommandName:    "oc",
 		},
 		{
 			OS:      "linux",
@@ -286,6 +288,7 @@ func (o *ExtractOptions) extractCommand(command string) error {
 			Readme:               readmeCLIUnix,
 			InjectReleaseVersion: true,
 			ArchiveFormat:        "openshift-client-linux-amd64-rhel8-%s.tar.gz",
+			TargetCommandName:    "oc",
 		},
 		{
 			OS:      "linux",
@@ -310,6 +313,7 @@ func (o *ExtractOptions) extractCommand(command string) error {
 			Readme:               readmeCLIUnix,
 			InjectReleaseVersion: true,
 			ArchiveFormat:        "openshift-client-linux-arm64-rhel9-%s.tar.gz",
+			TargetCommandName:    "oc",
 		},
 		{
 			OS:      "linux",
@@ -322,6 +326,7 @@ func (o *ExtractOptions) extractCommand(command string) error {
 			Readme:               readmeCLIUnix,
 			InjectReleaseVersion: true,
 			ArchiveFormat:        "openshift-client-linux-arm64-rhel8-%s.tar.gz",
+			TargetCommandName:    "oc",
 		},
 		{
 			OS:      "windows",
@@ -590,6 +595,11 @@ func (o *ExtractOptions) extractCommand(command string) error {
 		}
 		target.Mapping.Image = spec
 		target.Mapping.ImageRef = imagesource.TypedImageReference{Ref: ref, Type: imagesource.DestinationRegistry}
+		// if the name of the extracted binary is set to different from the
+		// actual command name, we set it to new target command name.
+		if target.TargetCommandName != "" {
+			target.Command = target.TargetCommandName
+		}
 		if target.AsArchive {
 			willArchive = true
 			target.Mapping.Name = fmt.Sprintf(target.ArchiveFormat, releaseName)

--- a/pkg/cli/admin/release/extract_tools.go
+++ b/pkg/cli/admin/release/extract_tools.go
@@ -278,6 +278,17 @@ func (o *ExtractOptions) extractCommand(command string) error {
 		},
 		{
 			OS:      "linux",
+			Arch:    "amd64",
+			Command: "oc.rhel8",
+			Mapping: extract.Mapping{Image: "cli-artifacts", From: "usr/share/openshift/linux_amd64/oc.rhel8"},
+
+			LinkTo:               []string{"kubectl"},
+			Readme:               readmeCLIUnix,
+			InjectReleaseVersion: true,
+			ArchiveFormat:        "openshift-client-linux-amd64-rhel8-%s.tar.gz",
+		},
+		{
+			OS:      "linux",
 			Arch:    "arm64",
 			Command: "oc",
 			NewArch: true,
@@ -299,6 +310,18 @@ func (o *ExtractOptions) extractCommand(command string) error {
 			Readme:               readmeCLIUnix,
 			InjectReleaseVersion: true,
 			ArchiveFormat:        "openshift-client-linux-arm64-rhel9-%s.tar.gz",
+		},
+		{
+			OS:      "linux",
+			Arch:    "arm64",
+			Command: "oc.rhel8",
+			NewArch: true,
+			Mapping: extract.Mapping{Image: "cli-artifacts", From: "usr/share/openshift/linux_arm64/oc.rhel8"},
+
+			LinkTo:               []string{"kubectl"},
+			Readme:               readmeCLIUnix,
+			InjectReleaseVersion: true,
+			ArchiveFormat:        "openshift-client-linux-arm64-rhel8-%s.tar.gz",
 		},
 		{
 			OS:      "windows",

--- a/pkg/cli/admin/release/extract_tools.go
+++ b/pkg/cli/admin/release/extract_tools.go
@@ -267,6 +267,17 @@ func (o *ExtractOptions) extractCommand(command string) error {
 		},
 		{
 			OS:      "linux",
+			Arch:    "amd64",
+			Command: "oc.rhel9",
+			Mapping: extract.Mapping{Image: "cli-artifacts", From: "usr/share/openshift/linux_amd64/oc.rhel9"},
+
+			LinkTo:               []string{"kubectl"},
+			Readme:               readmeCLIUnix,
+			InjectReleaseVersion: true,
+			ArchiveFormat:        "openshift-client-linux-amd64-rhel9-%s.tar.gz",
+		},
+		{
+			OS:      "linux",
 			Arch:    "arm64",
 			Command: "oc",
 			NewArch: true,
@@ -276,6 +287,18 @@ func (o *ExtractOptions) extractCommand(command string) error {
 			Readme:               readmeCLIUnix,
 			InjectReleaseVersion: true,
 			ArchiveFormat:        "openshift-client-linux-arm64-%s.tar.gz",
+		},
+		{
+			OS:      "linux",
+			Arch:    "arm64",
+			Command: "oc.rhel9",
+			NewArch: true,
+			Mapping: extract.Mapping{Image: "cli-artifacts", From: "usr/share/openshift/linux_arm64/oc.rhel9"},
+
+			LinkTo:               []string{"kubectl"},
+			Readme:               readmeCLIUnix,
+			InjectReleaseVersion: true,
+			ArchiveFormat:        "openshift-client-linux-arm64-rhel9-%s.tar.gz",
 		},
 		{
 			OS:      "windows",

--- a/pkg/cli/admin/release/extract_tools.go
+++ b/pkg/cli/admin/release/extract_tools.go
@@ -901,6 +901,13 @@ func (o *ExtractOptions) extractCommand(command string) error {
 			if target.NewArch {
 				continue
 			}
+			if command == "" && (strings.Contains(target.Mapping.From, "rhel9") || strings.Contains(target.Mapping.From, "rhel8")) {
+				// if user explicitly wants to extract oc.rhel9(or installer.rhel9) via --command=oc.rhel9 and
+				// if release does not have this binary, we can safely return error.
+				// On the other hand, if user wants to extract all the tooling in older versions via --tools flag,
+				// we shouldn't print any error indicating that oc.rhel9 does not exist in this release payload.
+				continue
+			}
 			missing = append(missing, target.Mapping.From)
 		}
 		sort.Strings(missing)


### PR DESCRIPTION
As explained in the referenced bug, oc compiled in RHEL8 does not work
on FIPS enabled RHEL9 environment. However, we need to provide a way to
users to enable extraction of oc compiled in RHEL9 to work on FIPS enabled clusters.

This PR adds new command targets in `oc adm release extract` command that
users can extract oc specific to their RHEL versions as a continuation of 
https://github.com/openshift/oc/pull/1632

<details>
<summary>Single command extraction</summary>

```sh
$ ./oc adm release extract registry.ci.openshift.org/ocp/release:4.16.0-0.nightly-2024-01-03-193825 --to=/tmp/test_extract --command=oc.rhel9
# Downloads oc.rhel9
$ ./oc adm release extract registry.ci.openshift.org/ocp/release:4.16.0-0.nightly-2024-01-03-193825 --to=/tmp/test_extract --command=oc.rhel8
# Downloads oc.rhel8
$ ./oc adm release extract registry.ci.openshift.org/ocp/release:4.16.0-0.nightly-2024-01-03-193825 --to=/tmp/test_extract --command=oc --command-os=linux/arm64
# Downloads oc compiled in linux/arm64 with whichever RHEL based image is set(currently RHEL8)
$ ./oc adm release extract registry.ci.openshift.org/ocp/release:4.16.0-0.nightly-2024-01-03-193825 --to=/tmp/test_extract --command=oc.rhel9 --command-os=linux/arm64
# Downloads oc.rhel9 compiled in RHEL9 arm64 architecture
```
</details>

<details>
<summary>All tools extraction</summary>

```sh
$ ./oc adm release extract registry.ci.openshift.org/ocp/release:4.16.0-0.nightly-2024-01-03-193825 --to=/tmp/test_extract --tools
ccoctl-linux-4.16.0-0.nightly-2024-01-03-193825.tar.gz
openshift-client-linux-4.16.0-0.nightly-2024-01-03-193825.tar.gz
openshift-client-linux-amd64-rhel9-4.16.0-0.nightly-2024-01-03-193825.tar.gz
# There should also be openshift-client-linux-amd64-rhel8-4.16.0-0.nightly-2024-01-03-193825.tar.gz but we haven't added that yet
openshift-install-linux-4.16.0-0.nightly-2024-01-03-193825.tar.gz
```
</details>

<details>
<summary>All tools extraction in specific os/arch</summary>

```sh
$ ./oc adm release extract registry.ci.openshift.org/ocp/release:4.16.0-0.nightly-2024-01-03-193825 --to=/tmp/test_extract_arm64 --tools --command-os=linux/arm64
openshift-client-linux-arm64-4.16.0-0.nightly-2024-01-03-193825.tar.gz
openshift-client-linux-arm64-rhel9-4.16.0-0.nightly-2024-01-03-193825.tar.gz
# There should also be openshift-client-linux-arm64-rhel8-4.16.0-0.nightly-2024-01-03-193825.tar.gz but we haven't added that yet
openshift-install-linux-arm64-4.16.0-0.nightly-2024-01-03-193825.tar.gz
```
</details>

**These new targets will stay until the fully migration to RHEL9 is completed and we'll return back to defaults.**