### PR TITLE
OCPBUGS-26599: release-4.11: use correct namespace with sample templates

### DIFF
--- a/pkg/helpers/newapp/cmd/newapp.go
+++ b/pkg/helpers/newapp/cmd/newapp.go
@@ -567,7 +567,10 @@ func (c *AppConfig) buildTemplates(components app.ComponentReferences, parameter
 	name := ""
 	for _, ref := range components {
 		tpl := ref.Input().ResolvedMatch.Template
-
+		if len(tpl.Namespace) > 0 && tpl.Namespace != c.OriginNamespace {
+			// if set, template namespace must match the namespace it will be processed in.
+			tpl.Namespace = c.OriginNamespace
+		}
 		klog.V(4).Infof("processing template %s/%s", c.OriginNamespace, tpl.Name)
 		if len(c.ContextDir) > 0 {
 			return "", nil, fmt.Errorf("--context-dir is not supported when using a template")


### PR DESCRIPTION
This is required to make the build test pass in https://github.com/openshift/openshift-apiserver/pull/400.

This was fixed a while ago as part of https://github.com/openshift/oc/pull/1272 in 4.12 onward.