### PR TITLE
NO-ISSUE: add information about featuregate diff in a particular release

### DIFF
--- a/pkg/cli/admin/release/config.go
+++ b/pkg/cli/admin/release/config.go
@@ -1,0 +1,58 @@
+package release
+
+import (
+	"encoding/json"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+var (
+	configScheme = runtime.NewScheme()
+	configCodecs = serializer.NewCodecFactory(configScheme)
+)
+
+func init() {
+	utilruntime.Must(configv1.AddToScheme(configScheme))
+}
+
+func ReadFeatureGateV1(objBytes []byte) (*configv1.FeatureGate, error) {
+	requiredObj, err := runtime.Decode(configCodecs.UniversalDecoder(configv1.SchemeGroupVersion), objBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return requiredObj.(*configv1.FeatureGate), nil
+}
+
+func ReadFeatureGateV1OrDie(objBytes []byte) *configv1.FeatureGate {
+	requiredObj, err := ReadFeatureGateV1(objBytes)
+	if err != nil {
+		panic(err)
+	}
+
+	return requiredObj
+}
+func WriteFeatureGateV1(obj *configv1.FeatureGate) (string, error) {
+	// done for pretty printing of JSON (technically also yaml)
+	asMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return "", err
+	}
+	ret, err := json.MarshalIndent(asMap, "", "    ")
+	if err != nil {
+		return "", err
+	}
+	return string(ret) + "\n", nil
+}
+
+func WriteFeatureGateV1OrDie(obj *configv1.FeatureGate) string {
+	ret, err := WriteFeatureGateV1(obj)
+	if err != nil {
+		panic(err)
+	}
+	return ret
+}

--- a/pkg/cli/admin/release/info.go
+++ b/pkg/cli/admin/release/info.go
@@ -666,7 +666,7 @@ func calculateDiff(from, to *ReleaseInfo) (*ReleaseDiff, error) {
 		}
 		diff.ChangedManifests[name] = &ReleaseManifestDiff{
 			Filename: name,
-			From:     manifest,
+			To:       manifest,
 		}
 	}
 	for k, v := range diff.ChangedManifests {
@@ -1165,8 +1165,96 @@ func describeReleaseDiff(out io.Writer, diff *ReleaseDiff, showCommit bool, outp
 			}
 		})
 	}
+
+	printFeatureSetSection(diff, "Default", w)
+	printFeatureSetSection(diff, string(configv1.TechPreviewNoUpgrade), w)
+
 	fmt.Fprintln(w)
 	return nil
+}
+
+func printFeatureSetSection(diff *ReleaseDiff, featureSetName string, w io.Writer) {
+	newFeatures, newlyEnabledFeatures, newlyDisabledFeatures, newlyRemovedFeatures, changed := FeatureGatesForFeatureSetChanged(diff, featureSetName)
+	if newFeatures == nil || !changed {
+		return
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "FeatureGate changes for %q (%d enabled, %d disabled, %d removed)\n",
+		featureSetName, len(newlyEnabledFeatures), len(newlyDisabledFeatures), len(newlyRemovedFeatures))
+	if len(newlyEnabledFeatures) > 0 {
+		fmt.Fprintf(w, "Enabled:\n")
+		for _, featureGate := range newFeatures.Status.FeatureGates[0].Enabled {
+			if newlyEnabledFeatures.Has(featureGate.Name) {
+				fmt.Fprintf(w, "  %v\n", featureGate.Name)
+			}
+		}
+	}
+	if len(newlyDisabledFeatures) > 0 {
+		fmt.Fprintf(w, "Disabled:\n")
+		for _, featureGate := range newFeatures.Status.FeatureGates[0].Disabled {
+			if newlyDisabledFeatures.Has(featureGate.Name) {
+				fmt.Fprintf(w, "  %v\n", featureGate.Name)
+			}
+		}
+	}
+	if len(newlyRemovedFeatures) > 0 {
+		fmt.Fprintf(w, "Removed:\n")
+		for _, featureGate := range sets.List[string](newlyRemovedFeatures) {
+			fmt.Fprintf(w, "  %v\n", featureGate)
+		}
+	}
+}
+
+// FeatureGatesForFeatureSetChanged returns newly enabled featureGates, newly disabled featureGates, and newly removed featureGates
+func FeatureGatesForFeatureSetChanged(diff *ReleaseDiff, featureSetName string) (*configv1.FeatureGate, sets.Set[configv1.FeatureGateName], sets.Set[configv1.FeatureGateName], sets.Set[string], bool) {
+	manifestName := fmt.Sprintf("0000_50_cluster-config-api_featureGate-%v.yaml", featureSetName)
+	changed := diff.ChangedManifests[manifestName]
+	if changed == nil || len(changed.To) == 0 {
+		klog.V(2).Infof("featuregate manifest is missing in To")
+		return nil, nil, nil, nil, false
+	}
+	toFeatureGates, err := ReadFeatureGateV1(changed.To)
+	if err != nil {
+		klog.V(2).Infof("failed to decode To %v: %v", manifestName, err)
+		return nil, nil, nil, nil, false
+	}
+
+	toEntireSet := sets.Set[string]{}
+	toEnabledSet := sets.Set[configv1.FeatureGateName]{}
+	toDisabledSet := sets.Set[configv1.FeatureGateName]{}
+	for _, curr := range toFeatureGates.Status.FeatureGates[0].Enabled {
+		toEntireSet.Insert(string(curr.Name))
+		toEnabledSet.Insert(curr.Name)
+	}
+	for _, curr := range toFeatureGates.Status.FeatureGates[0].Disabled {
+		toEntireSet.Insert(string(curr.Name))
+		toDisabledSet.Insert(curr.Name)
+	}
+
+	fromEntireSet := sets.Set[string]{}
+	fromEnabledSet := sets.Set[configv1.FeatureGateName]{}
+	fromDisabledSet := sets.Set[configv1.FeatureGateName]{}
+	if len(changed.From) > 0 {
+		fromFeatureGates, err := ReadFeatureGateV1(changed.From)
+		if err != nil {
+			klog.V(2).Infof("failed to decode From %v: %v", manifestName, err)
+			return nil, nil, nil, nil, false
+		}
+		for _, curr := range fromFeatureGates.Status.FeatureGates[0].Enabled {
+			fromEntireSet.Insert(string(curr.Name))
+			fromEnabledSet.Insert(curr.Name)
+		}
+		for _, curr := range fromFeatureGates.Status.FeatureGates[0].Disabled {
+			fromEntireSet.Insert(string(curr.Name))
+			fromDisabledSet.Insert(curr.Name)
+		}
+	}
+
+	newlyEnabledFeatureGates := toEnabledSet.Difference(fromEnabledSet)
+	newlyDisabledFeatureGates := toDisabledSet.Difference(fromDisabledSet)
+	removedFeatureGates := fromEntireSet.Difference(toEntireSet)
+	haveFeaturesChange := len(newlyEnabledFeatureGates) > 0 || len(newlyDisabledFeatureGates) > 0 || len(removedFeatureGates) > 0
+	return toFeatureGates, newlyEnabledFeatureGates, newlyDisabledFeatureGates, removedFeatureGates, haveFeaturesChange
 }
 
 func repoAndCommit(ref *imageapi.TagReference) string {


### PR DESCRIPTION
4.14 to 4.16 show this

`oc adm release info registry.build05.ci.openshift.org/ci-op-sv0zdi1v/release:latest registry.ci.openshift.org/ocp/release:4.16.0-0.ci-2024-01-11-182726` produces

```
FeatureGate changes for "Default" (4 enabled, 14 disabled, 2 removed)
Enabled:
  ExternalCloudProvider
  ExternalCloudProviderGCP
  KMSv1
  OpenShiftPodSecurityAdmission
Disabled:
  ClusterAPIInstall
  DNSNameResolver
  DisableKubeletCloudCredentialProviders
  GCPClusterHostedDNS
  InstallAlternateInfrastructureAWS
  MachineConfigNodes
  ManagedBootImages
  MetricsServer
  MixedCPUsAllocation
  NetworkLiveMigration
  OnClusterBuild
  PinnedImages
  SignatureStores
  VSphereControlPlaneMachineSet
Removed:
  AdmissionWebhookMatchConditions
  RetroactiveDefaultStorageClass

FeatureGate changes for "TechPreviewNoUpgrade" (14 enabled, 2 disabled, 2 removed)
Enabled:
  DNSNameResolver
  GCPClusterHostedDNS
  InstallAlternateInfrastructureAWS
  KMSv1
  MachineConfigNodes
  ManagedBootImages
  MetricsServer
  MixedCPUsAllocation
  NetworkLiveMigration
  OnClusterBuild
  PinnedImages
  SignatureStores
  VSphereControlPlaneMachineSet
  ValidatingAdmissionPolicy
Disabled:
  ClusterAPIInstall
  DisableKubeletCloudCredentialProviders
Removed:
  AdmissionWebhookMatchConditions
  RetroactiveDefaultStorageClass
```