### PR TITLE
NO-JIRA: report kubectl version to the release controller

### DIFF
--- a/hack/verify-kube-version.sh
+++ b/hack/verify-kube-version.sh
@@ -9,3 +9,9 @@ if [[ "${KUBECTL_GO_MOD_VERSION}" != "${KUBECTL_GIT_VERSION}" ]]; then
   os::log::warning "kubernetes version and kubectl version in go.mod must be equal, please update KUBE_GIT_VERSION"
   exit 1
 fi
+
+KUBECTL_DOCKER_VERSION=$(grep "kubectl=" images/cli/Dockerfile.rhel | sed 's/      io.openshift.build.versions="kubectl=1.//' | sed 's/" \\//')
+if [[ "${KUBECTL_GO_MOD_VERSION}" != "${KUBECTL_DOCKER_VERSION}" ]]; then
+  os::log::warning "kubernetes version and kubectl version in images/cli/Dockerfile.rhel must be equal, please update Dockerfile"
+  exit 1
+fi

--- a/images/cli/Dockerfile.rhel
+++ b/images/cli/Dockerfile.rhel
@@ -8,4 +8,5 @@ COPY --from=builder /go/src/github.com/openshift/oc/oc /usr/bin/
 RUN for i in kubectl openshift-deploy openshift-docker-build openshift-sti-build openshift-git-clone openshift-manage-dockerfile openshift-extract-image-content openshift-recycle; do ln -sf /usr/bin/oc /usr/bin/$i; done
 LABEL io.k8s.display-name="OpenShift Client" \
       io.k8s.description="OpenShift is a platform for developing, building, and deploying containerized applications." \
+      io.openshift.build.versions="kubectl=1.28.2" \
       io.openshift.tags="openshift,cli"

--- a/pkg/cli/admin/release/new.go
+++ b/pkg/cli/admin/release/new.go
@@ -55,7 +55,7 @@ func NewNewOptions(streams genericiooptions.IOStreams) *NewOptions {
 		// We strongly control the set of allowed component versions to prevent confusion
 		// about what component versions may be used for. Changing this list requires
 		// approval from the release architects.
-		AllowedComponents: []string{"kubernetes", "machine-os", "kernel", "crio"},
+		AllowedComponents: []string{"kubernetes", "machine-os", "kernel", "crio", "kubectl", "kubernetes-tests"},
 	}
 }
 


### PR DESCRIPTION
This adds a kubectl version to the Dockerfile so that the release controller can better represent what level of kube is present in our payloads. As our mismatch times extend, this makes certain classes of failures obvious and ensure we don't have an accident shipping.

/assign @soltysh @ardaguclu  @wking