### PR TITLE
WRKLDS-1010: pkg/cli/admin/inspect: use since/since-time for rotated logs

### DIFF
--- a/pkg/cli/admin/inspect/inspect.go
+++ b/pkg/cli/admin/inspect/inspect.go
@@ -117,7 +117,7 @@ func NewCmdInspect(streams genericiooptions.IOStreams) *cobra.Command {
 	cmd.Flags().BoolVarP(&o.allNamespaces, "all-namespaces", "A", o.allNamespaces, "If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
 	cmd.Flags().StringVar(&o.sinceTime, "since-time", o.sinceTime, "Only return logs after a specific date (RFC3339). Defaults to all logs. Only one of since-time / since may be used.")
 	cmd.Flags().DurationVar(&o.since, "since", o.since, "Only return logs newer than a relative duration like 5s, 2m, or 3h. Defaults to all logs. Only one of since-time / since may be used.")
-	cmd.Flags().BoolVar(&o.rotatedPodLogs, "rotated-pod-logs", o.rotatedPodLogs, "Experimental: If present, retrieve rotated log files that are available for selected pods. This can significantly increase the collected logs size. since/since-time is ignored for rotated logs.")
+	cmd.Flags().BoolVar(&o.rotatedPodLogs, "rotated-pod-logs", o.rotatedPodLogs, "Experimental: If present, retrieve rotated log files that are available for selected pods. This can significantly increase the collected logs size. since/since-time will be matched against the date in the log file name.")
 
 	// The rotated-pod-logs option should be removed once support for retrieving rotated logs is added to kubelet
 	// https://github.com/kubernetes/kubernetes/issues/59902


### PR DESCRIPTION
this solution is not very robust, but rotated logs can considerably increase the size of the gathered logs, so we do our best to support filtering them as well.

---

I only managed to test this outside the context of a must-gather, since the must-gather will use the `oc` binary present in its image. Follow these steps to test it:

```
go run ./cmd/oc adm inspect --rotated-pod-logs --since-time=2024-01-10T10:00:00Z ns/openshift-cluster-version
ll inspect.local.4575015416930189447/namespaces/openshift-cluster-version/pods/cluster-version-operator-6d799d6cc6-zwbcb/cluster-version-operator/cluster-version-operator/logs/rotated
# inspect files and make sure they do not include dates before the provided --since-time.
# repeat for --since
```

Here's an example from one of my runs on openshift local running with `--since-time=2024-01-10T10:00:00Z`
```
inspect.local.2059246489365228252/namespaces/openshift-cluster-version/pods/cluster-version-operator-6d799d6cc6-zwbcb/cluster-version-operator/cluster-version-operator/logs/
├── current.log
├── previous.insecure.log
├── previous.log
└── rotated
    ├── 4.log.20240112-031433.gz
    ├── 4.log.20240112-065352.gz
    ├── 4.log.20240112-103153.gz
    ├── 4.log.20240112-141052
    ├── 5.log.20240115-235129.gz
    ├── 5.log.20240116-021747.gz
    ├── 5.log.20240116-044405.gz
    └── 5.log.20240116-071013

2 directories, 11 files
```
And without `--since-time`:
```
tree inspect.local.2335573221674443086/namespaces/openshift-cluster-version/pods/cluster-version-operator-6d799d6cc6-zwbcb/cluster-version-operator/cluster-version-operator/logs
inspect.local.2335573221674443086/namespaces/openshift-cluster-version/pods/cluster-version-operator-6d799d6cc6-zwbcb/cluster-version-operator/cluster-version-operator/logs
├── current.log
├── previous.insecure.log
├── previous.log
└── rotated
    ├── 3.log.20240109-035321.gz     <-- skipped when filtered by the 10th!
    ├── 3.log.20240109-073120.gz     <-- skipped when filtered by the 10th!
    ├── 3.log.20240109-110927.gz     <-- skipped when filtered by the 10th!
    ├── 3.log.20240109-144731        <-- skipped when filtered by the 10th!
    ├── 4.log.20240112-031433.gz
    ├── 4.log.20240112-065352.gz
    ├── 4.log.20240112-103153.gz
    ├── 4.log.20240112-141052
    ├── 5.log.20240115-235129.gz
    ├── 5.log.20240116-021747.gz
    ├── 5.log.20240116-044405.gz
    └── 5.log.20240116-071013

2 directories, 15 files
```