### PR TITLE
NO-JIRA: Simplified kubectl component version check

### DIFF
--- a/pkg/cli/admin/release/info.go
+++ b/pkg/cli/admin/release/info.go
@@ -936,6 +936,7 @@ func readComponentVersions(is *imageapi.ImageStream) (ComponentVersions, []error
 	var errs []error
 	combined := make(map[string]sets.String)
 	combinedDisplayNames := make(map[string]sets.String)
+	kubectlVersions := sets.New[string]()
 	for _, tag := range is.Spec.Tags {
 		versions, ok := tag.Annotations[annotationBuildVersions]
 		if !ok {
@@ -946,6 +947,12 @@ func readComponentVersions(is *imageapi.ImageStream) (ComponentVersions, []error
 			errs = append(errs, fmt.Errorf("the referenced image %s had an invalid version annotation: %v", tag.Name, err))
 		}
 		for k, v := range all {
+			if k == "kubectl" {
+				kubectlVersions.Insert(v.Version)
+				if tag.Name != "cli" && tag.Name != "cli-artifacts" {
+					continue
+				}
+			}
 			existing, ok := combined[k]
 			if !ok {
 				existing = sets.NewString()
@@ -963,6 +970,9 @@ func readComponentVersions(is *imageapi.ImageStream) (ComponentVersions, []error
 	}
 
 	multiples := sets.NewString()
+	if kubectlVersions.Len() > 2 {
+		multiples.Insert("kubectl")
+	}
 	var out ComponentVersions
 	var keys []string
 	for k := range combined {

--- a/pkg/cli/admin/release/info_test.go
+++ b/pkg/cli/admin/release/info_test.go
@@ -316,6 +316,172 @@ func Test_readComponentVersions(t *testing.T) {
 			},
 			wantErr: []error{fmt.Errorf("multiple versions or display names reported for the following component(s): a1")},
 		},
+		{
+			is: &imageapi.ImageStream{
+				Spec: imageapi.ImageStreamSpec{
+					Tags: []imageapi.TagReference{
+						{
+							Name: "cli",
+							Annotations: map[string]string{
+								annotationBuildVersions: "kubectl=1.1.0",
+							},
+						},
+						{
+							Name: "test2",
+							Annotations: map[string]string{
+								annotationBuildVersions: "kubectl=1.0.0",
+							},
+						},
+						{
+							Name: "test3",
+							Annotations: map[string]string{
+								annotationBuildVersions: "kubectl=1.0.0",
+							},
+						},
+					},
+				},
+			},
+			want: ComponentVersions{
+				"kubectl": {Version: "1.1.0"},
+			},
+		},
+		{
+			is: &imageapi.ImageStream{
+				Spec: imageapi.ImageStreamSpec{
+					Tags: []imageapi.TagReference{
+						{
+							Name: "cli",
+							Annotations: map[string]string{
+								annotationBuildVersions: "kubectl=1.1.0",
+							},
+						},
+						{
+							Name: "cli-artifacts",
+							Annotations: map[string]string{
+								annotationBuildVersions: "kubectl=1.0.0",
+							},
+						},
+						{
+							Name: "test3",
+							Annotations: map[string]string{
+								annotationBuildVersions: "kubectl=1.0.0",
+							},
+						},
+					},
+				},
+			},
+			want: ComponentVersions{
+				"kubectl": {Version: "1.0.0"},
+			},
+			wantErr: []error{fmt.Errorf("multiple versions or display names reported for the following component(s): kubectl")},
+		},
+		{
+			is: &imageapi.ImageStream{
+				Spec: imageapi.ImageStreamSpec{
+					Tags: []imageapi.TagReference{
+						{
+							Name: "cli",
+							Annotations: map[string]string{
+								annotationBuildVersions: "kubectl=1.1.0",
+							},
+						},
+						{
+							Name: "cli-artifacts",
+							Annotations: map[string]string{
+								annotationBuildVersions: "kubectl=1.1.0",
+							},
+						},
+						{
+							Name: "test3",
+							Annotations: map[string]string{
+								annotationBuildVersions: "kubectl=1.0.0",
+							},
+						},
+						{
+							Name: "test3",
+							Annotations: map[string]string{
+								annotationBuildVersions: "kubectl=1.0.1",
+							},
+						},
+					},
+				},
+			},
+			want: ComponentVersions{
+				"kubectl": {Version: "1.1.0"},
+			},
+			wantErr: []error{fmt.Errorf("multiple versions or display names reported for the following component(s): kubectl")},
+		},
+		{
+			is: &imageapi.ImageStream{
+				Spec: imageapi.ImageStreamSpec{
+					Tags: []imageapi.TagReference{
+						{
+							Name: "cli",
+							Annotations: map[string]string{
+								annotationBuildVersions: "kubectl=1.1.0",
+							},
+						},
+						{
+							Name: "cli-artifacts",
+							Annotations: map[string]string{
+								annotationBuildVersions: "kubectl=1.1.0",
+							},
+						},
+						{
+							Name: "test3",
+							Annotations: map[string]string{
+								annotationBuildVersions: "kubectl=1.0.0",
+							},
+						},
+						{
+							Name: "test3",
+							Annotations: map[string]string{
+								annotationBuildVersions: "kubectl=1.0.1",
+							},
+						},
+					},
+				},
+			},
+			want: ComponentVersions{
+				"kubectl": {Version: "1.1.0"},
+			},
+			wantErr: []error{fmt.Errorf("multiple versions or display names reported for the following component(s): kubectl")},
+		},
+		{
+			is: &imageapi.ImageStream{
+				Spec: imageapi.ImageStreamSpec{
+					Tags: []imageapi.TagReference{
+						{
+							Name: "cli",
+							Annotations: map[string]string{
+								annotationBuildVersions: "kubectl=1.1.0",
+							},
+						},
+						{
+							Name: "cli-artifacts",
+							Annotations: map[string]string{
+								annotationBuildVersions: "kubectl=1.1.0",
+							},
+						},
+						{
+							Name: "test3",
+							Annotations: map[string]string{
+								annotationBuildVersions: "kubectl=1.0.0",
+							},
+						},
+						{
+							Name: "test4",
+							Annotations: map[string]string{
+								annotationBuildVersions: "kubectl=1.1.0",
+							},
+						},
+					},
+				},
+			},
+			want: ComponentVersions{
+				"kubectl": {Version: "1.1.0"},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
With this PR https://github.com/openshift/oc/pull/1656, we relaxed the kubectl component version
check by only allowing kubectl version in cli and cli-artifacts images and kubectl version between 
other images. However, as seen in this revert https://github.com/openshift/oc/pull/1660, there are other oc commands
having this strict component version check which caused failures in HCP.

This PR adopts simpler approach for kubectl specific component version checking. It simply
populates all the kubectl versions in a set and if the length is greater than 2(actual kubectl version 1.29.0 and the current ones 1.28.2) which means that this is indeed kubectl version mismatch. 