### PR TITLE
NO-JIRA: Fix --parallelism flag formatting in help

### DIFF
--- a/pkg/cli/admin/copytonode/command.go
+++ b/pkg/cli/admin/copytonode/command.go
@@ -36,7 +36,7 @@ type CopyToNodeOptions struct {
 	genericiooptions.IOStreams
 }
 
-func NewRestartKubelet(restClientGetter genericclioptions.RESTClientGetter, streams genericiooptions.IOStreams) *CopyToNodeOptions {
+func NewCopyToNode(restClientGetter genericclioptions.RESTClientGetter, streams genericiooptions.IOStreams) *CopyToNodeOptions {
 	return &CopyToNodeOptions{
 		PerNodePodOptions: pernodepod.NewPerNodePodOptions(
 			"openshift-copy-to-node-",
@@ -50,7 +50,7 @@ func NewRestartKubelet(restClientGetter genericclioptions.RESTClientGetter, stre
 }
 
 func NewCmdCopyToNode(restClientGetter genericclioptions.RESTClientGetter, streams genericiooptions.IOStreams) *cobra.Command {
-	o := NewRestartKubelet(restClientGetter, streams)
+	o := NewCopyToNode(restClientGetter, streams)
 
 	cmd := &cobra.Command{
 		Use:                   "copy-to-node",

--- a/pkg/cli/admin/pernodepod/command.go
+++ b/pkg/cli/admin/pernodepod/command.go
@@ -72,7 +72,12 @@ func (o *PerNodePodOptions) AddFlags(cmd *cobra.Command) {
 	o.ResourceBuilderFlags.AddFlags(cmd.Flags())
 
 	cmd.Flags().BoolVar(&o.DryRun, "dry-run", o.DryRun, "Set to true to use server-side dry run.")
-	cmd.Flags().StringVar(&o.Parallelism, "parallelism", o.Parallelism, "parallelism is a raw number or a percentage of the nodes to work with concurrently.")
+	// this "hack" ensures we don't put single % sign, which breaks formatting in flag printing
+	parallelism := o.Parallelism
+	if strings.Count(parallelism, "%") == 1 {
+		parallelism = parallelism + "%"
+	}
+	cmd.Flags().StringVar(&o.Parallelism, "parallelism", parallelism, "parallelism is a raw number or a percentage of the nodes to work with concurrently.")
 }
 
 func (o *PerNodePodOptions) ToRuntime(args []string) (*PerNodePodRuntime, error) {


### PR DESCRIPTION
Before:
```
    --parallelism='10%!'(MISSING):
	parallelism is a raw number or a percentage of the nodes to work with concurrently.
```
After with a percent:
```
    --parallelism='10%':
	parallelism is a raw number or a percentage of the nodes to work with concurrently.
```
or with a default digit:
```
    --parallelism='1':
	parallelism is a raw number or a percentage of the nodes to work with concurrently.
```

/assign @ardaguclu 