### PR TITLE
OCPBUGS-28204: Add RHEL8 based oc as new targets in command extraction

### DIFF
--- a/images/cli-artifacts/Dockerfile.rhel
+++ b/images/cli-artifacts/Dockerfile.rhel
@@ -13,6 +13,10 @@ RUN cd /usr/share/openshift && \
     ln -sf /usr/share/openshift/linux_$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/')/oc /usr/bin/oc && \
     mv windows_amd64 windows && mv darwin_amd64 mac && mv darwin_arm64 mac_arm64
 
+RUN ln -sf /usr/share/openshift/linux_amd64/oc /usr/share/openshift/linux_amd64/oc.rhel8
+RUN ln -sf /usr/share/openshift/linux_arm64/oc /usr/share/openshift/linux_arm64/oc.rhel8
+RUN ln -sf /usr/share/openshift/linux_ppc64le/oc /usr/share/openshift/linux_ppc64le/oc.rhel8
+
 COPY --from=builder /go/src/github.com/openshift/oc/LICENSE /usr/share/openshift/LICENSE
 
 LABEL io.k8s.display-name="OpenShift Clients" \

--- a/pkg/cli/admin/release/extract_tools.go
+++ b/pkg/cli/admin/release/extract_tools.go
@@ -875,6 +875,13 @@ func (o *ExtractOptions) extractCommand(command string) error {
 			if target.NewArch {
 				continue
 			}
+			if command == "" && (strings.Contains(target.Mapping.From, "rhel9") || strings.Contains(target.Mapping.From, "rhel8")) {
+				// if user explicitly wants to extract oc.rhel9(or installer.rhel9) via --command=oc.rhel9 and
+				// if release does not have this binary, we can safely return error.
+				// On the other hand, if user wants to extract all the tooling in older versions via --tools flag,
+				// we shouldn't print any error indicating that oc.rhel9 does not exist in this release payload.
+				continue
+			}
 			missing = append(missing, target.Mapping.From)
 		}
 		sort.Strings(missing)

--- a/pkg/cli/admin/release/extract_tools.go
+++ b/pkg/cli/admin/release/extract_tools.go
@@ -59,11 +59,12 @@ type extractTarget struct {
 	InjectReleaseVersion bool
 	SignMachOBinary      bool
 
-	ArchiveFormat string
-	AsArchive     bool
-	AsZip         bool
-	Readme        string
-	LinkTo        []string
+	ArchiveFormat     string
+	AsArchive         bool
+	AsZip             bool
+	Readme            string
+	LinkTo            []string
+	TargetCommandName string
 
 	Mapping extract.Mapping
 }
@@ -276,6 +277,7 @@ func (o *ExtractOptions) extractCommand(command string) error {
 			Readme:               readmeCLIUnix,
 			InjectReleaseVersion: true,
 			ArchiveFormat:        "openshift-client-linux-amd64-rhel8-%s.tar.gz",
+			TargetCommandName:    "oc",
 		},
 		{
 			OS:      "linux",
@@ -300,6 +302,7 @@ func (o *ExtractOptions) extractCommand(command string) error {
 			Readme:               readmeCLIUnix,
 			InjectReleaseVersion: true,
 			ArchiveFormat:        "openshift-client-linux-arm64-rhel8-%s.tar.gz",
+			TargetCommandName:    "oc",
 		},
 		{
 			OS:      "windows",
@@ -567,6 +570,11 @@ func (o *ExtractOptions) extractCommand(command string) error {
 		}
 		target.Mapping.Image = spec
 		target.Mapping.ImageRef = imagesource.TypedImageReference{Ref: ref, Type: imagesource.DestinationRegistry}
+		// if the name of the extracted binary is set to different from the
+		// actual command name, we set it to new target command name.
+		if target.TargetCommandName != "" {
+			target.Command = target.TargetCommandName
+		}
 		if target.AsArchive {
 			willArchive = true
 			target.Mapping.Name = fmt.Sprintf(target.ArchiveFormat, releaseName)

--- a/pkg/cli/admin/release/extract_tools.go
+++ b/pkg/cli/admin/release/extract_tools.go
@@ -268,6 +268,17 @@ func (o *ExtractOptions) extractCommand(command string) error {
 		},
 		{
 			OS:      "linux",
+			Arch:    "amd64",
+			Command: "oc.rhel8",
+			Mapping: extract.Mapping{Image: "cli-artifacts", From: "usr/share/openshift/linux_amd64/oc.rhel8"},
+
+			LinkTo:               []string{"kubectl"},
+			Readme:               readmeCLIUnix,
+			InjectReleaseVersion: true,
+			ArchiveFormat:        "openshift-client-linux-amd64-rhel8-%s.tar.gz",
+		},
+		{
+			OS:      "linux",
 			Arch:    "arm64",
 			Command: "oc",
 			NewArch: true,
@@ -277,6 +288,18 @@ func (o *ExtractOptions) extractCommand(command string) error {
 			Readme:               readmeCLIUnix,
 			InjectReleaseVersion: true,
 			ArchiveFormat:        "openshift-client-linux-arm64-%s.tar.gz",
+		},
+		{
+			OS:      "linux",
+			Arch:    "arm64",
+			Command: "oc.rhel8",
+			NewArch: true,
+			Mapping: extract.Mapping{Image: "cli-artifacts", From: "usr/share/openshift/linux_arm64/oc.rhel8"},
+
+			LinkTo:               []string{"kubectl"},
+			Readme:               readmeCLIUnix,
+			InjectReleaseVersion: true,
+			ArchiveFormat:        "openshift-client-linux-arm64-rhel8-%s.tar.gz",
 		},
 		{
 			OS:      "windows",


### PR DESCRIPTION
Manual backport of #1647 
/assign @ardaguclu 