### PR TITLE
OCPBUGS-27957: pkg/cli/admin/inspect: use since/since-time for previous container logs

### DIFF
--- a/pkg/cli/admin/inspect/pod.go
+++ b/pkg/cli/admin/inspect/pod.go
@@ -249,6 +249,12 @@ func (o *InspectOptions) gatherContainerLogs(destDir string, pod *corev1.Pod, co
 			Previous:   true,
 			Timestamps: true,
 		}
+		if len(o.sinceTime) > 0 {
+			logOptions.SinceTime = &o.sinceTimestamp
+		}
+		if o.since != 0 {
+			logOptions.SinceSeconds = &o.sinceInt
+		}
 		logsReq := o.kubeClient.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, logOptions)
 		filename := "previous.log"
 		if err := o.fileWriter.WriteFromSource(path.Join(destDir, "/"+filename), logsReq); err != nil {


### PR DESCRIPTION
Looks like previous logs were missed when the `--since` and `--since-time` flags were first introduced on `oc adm inspect`.