### PR TITLE
OCPBUGS-28540: Copy oc.rhel8 instead of symlink

### DIFF
--- a/images/cli-artifacts/Dockerfile.rhel
+++ b/images/cli-artifacts/Dockerfile.rhel
@@ -18,9 +18,9 @@ RUN cd /usr/share/openshift && \
     ln -sf /usr/share/openshift/linux_$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/')/oc /usr/bin/oc && \
     mv windows_amd64 windows && mv darwin_amd64 mac && mv darwin_arm64 mac_arm64
 
-RUN ln -sf /usr/share/openshift/linux_amd64/oc /usr/share/openshift/linux_amd64/oc.rhel8
-RUN ln -sf /usr/share/openshift/linux_arm64/oc /usr/share/openshift/linux_arm64/oc.rhel8
-RUN ln -sf /usr/share/openshift/linux_ppc64le/oc /usr/share/openshift/linux_ppc64le/oc.rhel8
+COPY --from=builder /go/src/github.com/openshift/oc/_output/bin/linux_amd64/oc /usr/share/openshift/linux_amd64/oc.rhel8
+COPY --from=builder /go/src/github.com/openshift/oc/_output/bin/linux_arm64/oc /usr/share/openshift/linux_arm64/oc.rhel8
+COPY --from=builder /go/src/github.com/openshift/oc/_output/bin/linux_ppc64le/oc /usr/share/openshift/linux_ppc64le/oc.rhel8
 
 COPY --from=builder-rhel-9 /go/src/github.com/openshift/oc/_output/bin/linux_amd64/oc /usr/share/openshift/linux_amd64/oc.rhel9
 COPY --from=builder-rhel-9 /go/src/github.com/openshift/oc/_output/bin/linux_arm64/oc /usr/share/openshift/linux_arm64/oc.rhel9


### PR DESCRIPTION
With this https://github.com/openshift/oc/pull/1647, we started allowing extraction of `oc.rhel8`.
However, it seems that symlinked binaries(i.e. `oc.rhel8`) are simply ignored during file path
traversal in tarballs. That results in the error message `oc.rhel8` is not found being raised. 

To solve the problem, in this PR we are now copying oc.rhel8 binaries from already compiled oc instead of
symlinking.