### PR TITLE
NO-JIRA: Set up foundations and add unit tests for get-token command

### DIFF
--- a/pkg/cli/gettoken/credwriter/credwriter.go
+++ b/pkg/cli/gettoken/credwriter/credwriter.go
@@ -11,6 +11,10 @@ import (
 	v1 "k8s.io/client-go/pkg/apis/clientauthentication/v1"
 )
 
+type CredWriter interface {
+	Write(token string, expiry time.Time) error
+}
+
 // Writer writes ExecCredentials and basically
 // populates the status with the retrieved
 // token and expiration time.

--- a/pkg/cli/gettoken/credwriter/credwriter_test.go
+++ b/pkg/cli/gettoken/credwriter/credwriter_test.go
@@ -1,0 +1,27 @@
+package credwriter
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+)
+
+func TestCredWriter(t *testing.T) {
+	streams, _, out, _ := genericiooptions.NewTestIOStreams()
+	writer := NewWriter(streams)
+	tm, err := time.Parse(time.DateTime, "2006-01-02 15:04:05")
+	if err != nil {
+		t.Errorf("unexpected time parsing error %v", err)
+	}
+	err = writer.Write("test", tm)
+	if err != nil {
+		t.Errorf("unexpected credentials exec plugin write error %v", err)
+	}
+	expected := `{"kind":"ExecCredential","apiVersion":"client.authentication.k8s.io/v1","spec":{"interactive":false},"status":{"expirationTimestamp":"2006-01-02T15:04:05Z","token":"test"}}`
+	expected = fmt.Sprintf("%s\n", expected)
+	if out.String() != expected {
+		t.Errorf("unexpected credentials exec writer output %s expected %s", out.String(), expected)
+	}
+}

--- a/pkg/cli/gettoken/gettoken.go
+++ b/pkg/cli/gettoken/gettoken.go
@@ -58,8 +58,8 @@ type GetTokenOptions struct {
 	AutoOpenBrowser bool
 
 	authenticator         oidc.Authenticator
-	tokenCache            *tokencache.Repository
-	credWriter            *credwriter.Writer
+	tokenCache            tokencache.TokenCacher
+	credWriter            credwriter.CredWriter
 	tokenCacheDir         string
 	authenticationTimeout time.Duration
 

--- a/pkg/cli/gettoken/gettoken_test.go
+++ b/pkg/cli/gettoken/gettoken_test.go
@@ -1,0 +1,160 @@
+package gettoken
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+
+	"github.com/openshift/oc/pkg/cli/gettoken/credwriter"
+
+	"golang.org/x/oauth2"
+
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/openshift/oc/pkg/cli/gettoken/tokencache"
+)
+
+type FakeClient struct {
+	authCodeExpire bool
+	refreshExpire  bool
+	verifyExpire   bool
+}
+
+func (c *FakeClient) GetTokenByAuthCode(ctx context.Context, callbackAddress string, localServerReadyChan chan<- string) (string, string, time.Time, error) {
+	if c.authCodeExpire {
+		return "", "", time.Now(), &oidc.TokenExpiredError{}
+	}
+	tm, err := time.Parse(time.DateTime, "2006-01-02 15:04:05")
+	if err != nil {
+		return "", "", time.Now(), err
+	}
+	return "test", "test", tm, nil
+}
+
+func (c *FakeClient) Refresh(ctx context.Context, refreshToken string) (string, string, time.Time, error) {
+	if c.refreshExpire {
+		return "", "", time.Now(), &oidc.TokenExpiredError{}
+	}
+	tm, err := time.Parse(time.DateTime, "2006-01-02 15:04:05")
+	if err != nil {
+		return "", "", time.Now(), err
+	}
+	return "test", refreshToken, tm, nil
+}
+
+func (c *FakeClient) VerifyToken(ctx context.Context, token *oauth2.Token, nonce string) (string, time.Time, error) {
+	if c.verifyExpire {
+		return "", time.Now(), &oidc.TokenExpiredError{}
+	}
+	tm, err := time.Parse(time.DateTime, "2006-01-02 15:04:05")
+	if err != nil {
+		return "", time.Now(), err
+	}
+	return "test", tm, nil
+}
+
+type FakeTokenCacher struct {
+	cache map[tokencache.Key]tokencache.Set
+}
+
+func NewFakeTokenCacher() *FakeTokenCacher {
+	cache := make(map[tokencache.Key]tokencache.Set)
+	return &FakeTokenCacher{cache: cache}
+}
+
+func (f *FakeTokenCacher) FindByKey(dir string, key tokencache.Key) (*tokencache.Set, error) {
+	if k, ok := f.cache[key]; ok {
+		return &k, nil
+	} else {
+		return nil, nil
+	}
+}
+
+func (f *FakeTokenCacher) Save(dir string, key tokencache.Key, tokenSet tokencache.Set) error {
+	f.cache[key] = tokenSet
+	return nil
+}
+
+func TestGetToken(t *testing.T) {
+	streams, _, out, _ := genericiooptions.NewTestIOStreams()
+
+	options := NewGetTokenOptions(streams)
+	err := options.Validate()
+	if err == nil || err.Error() != "--issuer-url is required" {
+		t.Errorf("expected --issuer-url is required err %v", err)
+	}
+	options.IssuerURL = "test-issuer-url"
+	err = options.Validate()
+	if err == nil || err.Error() != "--client-id is required" {
+		t.Errorf("expected --client-id is required error %v", err)
+	}
+	options.ClientID = "test-client-id"
+	options.authenticator = &FakeClient{}
+	options.tokenCache = NewFakeTokenCacher()
+	options.credWriter = credwriter.NewWriter(streams)
+	err = options.Run()
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	expected := `{"kind":"ExecCredential","apiVersion":"client.authentication.k8s.io/v1","spec":{"interactive":false},"status":{"expirationTimestamp":"2006-01-02T15:04:05Z","token":"test"}}`
+	expected = fmt.Sprintf("%s\n", expected)
+	if out.String() != expected {
+		t.Errorf("unexpected output %s expected %s", out.String(), expected)
+	}
+	value, err := options.tokenCache.FindByKey("", tokencache.Key{
+		IssuerURL: "test-issuer-url",
+		ClientID:  "test-client-id",
+	})
+	if err != nil {
+		t.Errorf("unexpected error during cache retrieval %v", err)
+	}
+	if value == nil || value.IDToken != "test" || value.RefreshToken != "test" {
+		t.Errorf("unexpected value returned from cache %v", value)
+	}
+	out.Reset()
+	err = options.Run()
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	expected = `{"kind":"ExecCredential","apiVersion":"client.authentication.k8s.io/v1","spec":{"interactive":false},"status":{"expirationTimestamp":"2006-01-02T15:04:05Z","token":"test"}}`
+	expected = fmt.Sprintf("%s\n", expected)
+	if out.String() != expected {
+		t.Errorf("unexpected output %s expected %s", out.String(), expected)
+	}
+
+	options.authenticator = &FakeClient{verifyExpire: true}
+	out.Reset()
+	err = options.Run()
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	expected = `{"kind":"ExecCredential","apiVersion":"client.authentication.k8s.io/v1","spec":{"interactive":false},"status":{"expirationTimestamp":"2006-01-02T15:04:05Z","token":"test"}}`
+	expected = fmt.Sprintf("%s\n", expected)
+	if out.String() != expected {
+		t.Errorf("unexpected output %s expected %s", out.String(), expected)
+	}
+
+	options.authenticator = &FakeClient{verifyExpire: true, refreshExpire: true}
+	out.Reset()
+	err = options.Run()
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	expected = `{"kind":"ExecCredential","apiVersion":"client.authentication.k8s.io/v1","spec":{"interactive":false},"status":{"expirationTimestamp":"2006-01-02T15:04:05Z","token":"test"}}`
+	expected = fmt.Sprintf("%s\n", expected)
+	if out.String() != expected {
+		t.Errorf("unexpected output %s expected %s", out.String(), expected)
+	}
+
+	options.authenticator = &FakeClient{verifyExpire: true, refreshExpire: true, authCodeExpire: true}
+	out.Reset()
+	err = options.Run()
+	tokenExpiredError := &oidc.TokenExpiredError{}
+	if !errors.As(err, &tokenExpiredError) {
+		t.Errorf("unexpected error %v", err)
+	}
+}

--- a/pkg/cli/gettoken/oidc/client_test.go
+++ b/pkg/cli/gettoken/oidc/client_test.go
@@ -1,0 +1,20 @@
+package oidc
+
+import (
+	"testing"
+
+	gooidc "github.com/coreos/go-oidc/v3/oidc"
+	"golang.org/x/oauth2"
+)
+
+func TestAuthorizationRequestOptions(t *testing.T) {
+	oauthCodeOptions := authorizationRequestOptions("test-nonce", "test-pkce")
+	expectedOptions := []oauth2.AuthCodeOption{
+		oauth2.AccessTypeOffline,
+		gooidc.Nonce("test-nonce"),
+		oauth2.S256ChallengeOption("test-pkce"),
+	}
+	if len(oauthCodeOptions) != len(expectedOptions) {
+		t.Errorf("unexpected oauth code options length %d expected %d", len(oauthCodeOptions), len(expectedOptions))
+	}
+}

--- a/pkg/cli/gettoken/tokencache/tokencache.go
+++ b/pkg/cli/gettoken/tokencache/tokencache.go
@@ -33,6 +33,11 @@ type tokenCacheEntity struct {
 	RefreshToken string `json:"refresh_token,omitempty"`
 }
 
+type TokenCacher interface {
+	FindByKey(dir string, key Key) (*Set, error)
+	Save(dir string, key Key, tokenSet Set) error
+}
+
 type Repository struct{}
 
 // FindByKey finds the key from the given cache directory and


### PR DESCRIPTION
This PR is the continuation of https://github.com/openshift/oc/pull/1640 by adding
unit tests for reliability and stability of the new `get-token` command.