### PR TITLE
[release-4.15] OCPBUGS-28204: Add RHEL9 and RHEL8 based oc as new targets in command extraction

### DIFF
--- a/images/cli-artifacts/Dockerfile.rhel
+++ b/images/cli-artifacts/Dockerfile.rhel
@@ -5,6 +5,11 @@ WORKDIR /go/src/github.com/openshift/oc
 COPY . .
 RUN make cross-build --warn-undefined-variables
 
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.15 AS builder-rhel-9
+WORKDIR /go/src/github.com/openshift/oc
+COPY . .
+RUN make cross-build --warn-undefined-variables
+
 FROM registry.ci.openshift.org/ocp/4.15:cli
 
 COPY --from=builder /go/src/github.com/openshift/oc/_output/bin/ /usr/share/openshift/
@@ -12,6 +17,14 @@ COPY --from=builder /go/src/github.com/openshift/oc/_output/bin/ /usr/share/open
 RUN cd /usr/share/openshift && \
     ln -sf /usr/share/openshift/linux_$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/')/oc /usr/bin/oc && \
     mv windows_amd64 windows && mv darwin_amd64 mac && mv darwin_arm64 mac_arm64
+
+COPY --from=builder /go/src/github.com/openshift/oc/_output/bin/linux_amd64/oc /usr/share/openshift/linux_amd64/oc.rhel8
+COPY --from=builder /go/src/github.com/openshift/oc/_output/bin/linux_arm64/oc /usr/share/openshift/linux_arm64/oc.rhel8
+COPY --from=builder /go/src/github.com/openshift/oc/_output/bin/linux_ppc64le/oc /usr/share/openshift/linux_ppc64le/oc.rhel8
+
+COPY --from=builder-rhel-9 /go/src/github.com/openshift/oc/_output/bin/linux_amd64/oc /usr/share/openshift/linux_amd64/oc.rhel9
+COPY --from=builder-rhel-9 /go/src/github.com/openshift/oc/_output/bin/linux_arm64/oc /usr/share/openshift/linux_arm64/oc.rhel9
+COPY --from=builder-rhel-9 /go/src/github.com/openshift/oc/_output/bin/linux_ppc64le/oc /usr/share/openshift/linux_ppc64le/oc.rhel9
 
 COPY --from=builder /go/src/github.com/openshift/oc/LICENSE /usr/share/openshift/LICENSE
 


### PR DESCRIPTION
This PR is manual backport of a group of PRs to enable the extraction of rhel9 and rhel8 based oc binaries.

* https://github.com/openshift/oc/pull/1632
* https://github.com/openshift/oc/pull/1647
* https://github.com/openshift/oc/pull/1669

This PR also covers https://github.com/openshift/oc/pull/1665

These PRs are prerequisite of this PR;
* https://github.com/openshift-eng/ocp-build-data/pull/4303
* https://github.com/openshift/oc/pull/1669