### PR TITLE
OTA-1080: pkg/cli/admin/inspectalerts: New tech-preview inspect-alerts subcommand

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -7,6 +7,14 @@ aliases:
     - mfojtik
     - smarterclayton
     - soltysh
+  monitoring-approvers:
+    - danielmellado
+    - jan--f
+    - machine424
+    - marioferh
+    - rexagod
+    - simonpasquier
+    - slashpai
   update-approvers:
     - Davoska
     - LalatenduMohanty

--- a/pkg/cli/admin/inspectalerts/OWNERS
+++ b/pkg/cli/admin/inspectalerts/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+reviewers:
+  - monitoring-approvers
+approvers:
+  - monitoring-approvers

--- a/pkg/cli/admin/inspectalerts/inspectalerts.go
+++ b/pkg/cli/admin/inspectalerts/inspectalerts.go
@@ -1,0 +1,129 @@
+// Package inspectalerts provides access to in-cluster alerts.
+package inspectalerts
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/client-go/rest"
+	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
+
+	routev1 "github.com/openshift/api/route/v1"
+	routev1client "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
+)
+
+// RouteGetter is a function that gets a Route.
+type RouteGetter func(ctx context.Context, namespace string, name string, opts metav1.GetOptions) (*routev1.Route, error)
+
+type Alert struct {
+}
+
+type options struct {
+	genericiooptions.IOStreams
+	RESTConfig *rest.Config
+	getRoute   RouteGetter
+}
+
+func newOptions(streams genericiooptions.IOStreams) *options {
+	return &options{
+		IOStreams: streams,
+	}
+}
+
+func New(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
+	o := newOptions(streams)
+	cmd := &cobra.Command{
+		Use:   "inspect-alerts",
+		Short: "Collect information about running alerts.",
+		Run: func(cmd *cobra.Command, args []string) {
+			kcmdutil.CheckErr(o.Complete(f, cmd, args))
+			kcmdutil.CheckErr(o.Run(cmd.Context()))
+		},
+	}
+
+	return cmd
+}
+
+func (o *options) Complete(f kcmdutil.Factory, cmd *cobra.Command, args []string) error {
+	kcmdutil.RequireNoArguments(cmd, args)
+
+	cfg, err := f.ToRESTConfig()
+	if err != nil {
+		return err
+	}
+
+	o.RESTConfig = cfg
+
+	routeClient, err := routev1client.NewForConfig(cfg)
+	if err != nil {
+		return err
+	}
+	o.getRoute = func(ctx context.Context, namespace string, name string, opts metav1.GetOptions) (*routev1.Route, error) {
+		return routeClient.Routes(namespace).Get(ctx, name, opts)
+	}
+
+	return nil
+}
+
+func (o *options) Run(ctx context.Context) error {
+	alertBytes, err := GetWithBearer(ctx, o.getRoute, "openshift-monitoring", "alertmanager-main", "/api/v2/alerts", o.RESTConfig.BearerToken)
+	if err != nil {
+		return err
+	}
+
+	_, err = o.Out.Write(alertBytes)
+	return nil
+}
+
+// GetWithBearer gets a Route by namespace/name, contructs a URI using
+// status.ingress[].host and the path argument, and performs GETs on that
+// URI using Bearer authentication with the token argument.
+func GetWithBearer(ctx context.Context, getRoute RouteGetter, namespace, name, path, bearerToken string) ([]byte, error) {
+	if len(bearerToken) == 0 {
+		return nil, fmt.Errorf("no token is currently in use for this session")
+	}
+
+	route, err := getRoute(ctx, namespace, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	client := &http.Client{}
+	uris := make([]string, 0, len(route.Status.Ingress))
+	for _, ingress := range route.Status.Ingress {
+		uri := &url.URL{
+			Scheme: "https",
+			Host:   ingress.Host,
+			Path:   path,
+		}
+		uris = append(uris, uri.String())
+		req, err := http.NewRequest("GET", uri.String(), nil)
+		if err != nil {
+			return nil, err
+		}
+
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", bearerToken))
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+
+		return body, err
+	}
+
+	return nil, fmt.Errorf("unable to get %s from any of %d URIs in the %s Route in the %s namespace: %s", path, len(uris), name, namespace, strings.Join(uris, ", "))
+}


### PR DESCRIPTION
The new subcommand is gated by `OC_ENABLE_CMD_INSPECT_ALERTS` to avoid customers accidentally using it while it's tech-preview:

```console
$ OC_ENABLE_CMD_INSPECT_ALERTS=true oc adm inspect-alerts | jq -r '[.[] | .startsAt + " " + .endsAt + " " + .status.state + " " + (.labels | .severity + " " + .alertname) + " " + .annotations.summary] | sort[]'
2024-01-19T20:13:28.083Z 2024-01-31T05:23:28.083Z suppressed none Watchdog An alert that should always be firing to certify that Alertmanager is working properly.
2024-01-19T20:14:13.174Z 2024-01-31T05:24:13.174Z suppressed info ClusterNotUpgradeable One or more cluster operators have been blocking minor version cluster upgrades for at least an hour.
2024-01-19T20:14:20.600Z 2024-01-31T05:24:20.600Z suppressed warning TechPreviewNoUpgrade Cluster has enabled tech preview features that will prevent upgrades.
2024-01-22T15:56:45.824Z 2024-01-31T05:23:15.824Z suppressed info PodStartupStorageOperationsFailing Pods can't start because volume_mount of volume plugin kubernetes.io/configmap is permanently failing on node build0-gstfj-w-b-d6xzf.c.openshift-ci-build-farm.internal.
2024-01-22T15:56:45.824Z 2024-01-31T05:23:15.824Z suppressed info PodStartupStorageOperationsFailing Pods can't start because volume_mount of volume plugin kubernetes.io/configmap is permanently failing on node build0-gstfj-w-c-q85c8.c.openshift-ci-build-farm.internal.
2024-01-30T06:02:23.913Z 2024-01-31T05:24:23.913Z active warning KubeJobFailed Job failed to complete.
```

This provides a more convenient syntax based on [the existing docs'][1]:

```console
$ oc login -u <username> -p <password>
$ host=$(oc -n openshift-monitoring get route alertmanager-main -ojsonpath={.spec.host})
$ token=$(oc whoami -t)
$ curl -H "Authorization: Bearer $token" -k "https://$host/api/v2/receivers"
```

But I'm using [the `/alerts` path][2] instead of the `/receivers` path given in the docs example.  This provides convenient access when the console isn't available (e.g. because the `Console` ClusterVersion capability is not enabled) or for use in other tooling like the tech-preview `oc adm upgrade status`, and has [a long-standing (but currently deferred) RFE][3].

I'm also dropping the `-k`/`--insecure` from the doc'ed curl in my Go translation, because:

* I don't want to leak a sensitive token to an untrusted server.
* Clusters are supposed to have [set up a well-known cert/CA for their ingress][4]:

    > The Ingress Operator generates a default certificate for an Ingress Controller to serve as a placeholder until you configure a custom default certificate. Do not use Operator-generated default certificates in production clusters.

    so our client will likely trust the cluster.

and failing on "I don't trust that server" seems fine for this tech-preview proof-of-concept, vs. trying to use the kubeconfig-protected connections to automatically figure out which CA I need to trust.

I'm iterating over `status.ingress[].host` entries instead of using the doc'ed `spec.host`, because [the `spec` property is `optional`][5], while [the `status` property is `required`][6].  It also seems safer to consume the Route controller's output `status` instead of wiring up directly to Route-admin written `spec` input.

I'm not currently filtering on `RouteIngress.Conditions` including an `Admitted=True` entry, although something like that might be reasonable to avoid wasting time poking known-to-be-broken hosts.

I haven't dug into `Bearer` token RFCs or the REST config structure to know if I need to worry about any encoding issues (base64?) in this handoff, but in testing it works for me.  Please feel free to stiffen, or at least research, that handoff before making this generally available :).

If I get a failure from one `status.ingress[].host`, I don't bother attempting the others.  Wiring up that kind of fallback with error aggregation when all hosts fail would be a useful future refinement.

We seem to have types in the vendored `github.com/prometheus/common/model` that could be used to deserialize this output (e.g. for table printing), but for now I'll just dump the JSON to output.

[1]: https://docs.openshift.com/container-platform/4.14/monitoring/accessing-third-party-monitoring-apis.html
[2]: https://github.com/prometheus/alertmanager/blob/v0.26.0/api/v2/openapi.yaml#L134
[3]: https://issues.redhat.com/browse/RFE-928
[4]: https://docs.openshift.com/container-platform/4.14/security/certificate_types_descriptions/ingress-certificates.html#location
[5]: https://github.com/openshift/api/blob/4f00b4f16b634830bb16b432eec91f6e514f2981/route/v1/types.go#L95
[6]: https://github.com/openshift/api/blob/4f00b4f16b634830bb16b432eec91f6e514f2981/route/v1/types.go#L352-L353