### PR TITLE
OCPBUGS-29039: fix copy-to-node 

### DIFF
--- a/pkg/cli/admin/copytonode/command.go
+++ b/pkg/cli/admin/copytonode/command.go
@@ -36,7 +36,7 @@ type CopyToNodeOptions struct {
 	genericiooptions.IOStreams
 }
 
-func NewCopyToNode(restClientGetter genericclioptions.RESTClientGetter, streams genericiooptions.IOStreams) *CopyToNodeOptions {
+func NewRestartKubelet(restClientGetter genericclioptions.RESTClientGetter, streams genericiooptions.IOStreams) *CopyToNodeOptions {
 	return &CopyToNodeOptions{
 		PerNodePodOptions: pernodepod.NewPerNodePodOptions(
 			"openshift-copy-to-node-",
@@ -50,7 +50,7 @@ func NewCopyToNode(restClientGetter genericclioptions.RESTClientGetter, streams 
 }
 
 func NewCmdCopyToNode(restClientGetter genericclioptions.RESTClientGetter, streams genericiooptions.IOStreams) *cobra.Command {
-	o := NewCopyToNode(restClientGetter, streams)
+	o := NewRestartKubelet(restClientGetter, streams)
 
 	cmd := &cobra.Command{
 		Use:                   "copy-to-node",

--- a/pkg/cli/admin/pernodepod/command.go
+++ b/pkg/cli/admin/pernodepod/command.go
@@ -72,12 +72,7 @@ func (o *PerNodePodOptions) AddFlags(cmd *cobra.Command) {
 	o.ResourceBuilderFlags.AddFlags(cmd.Flags())
 
 	cmd.Flags().BoolVar(&o.DryRun, "dry-run", o.DryRun, "Set to true to use server-side dry run.")
-	// this "hack" ensures we don't put single % sign, which breaks formatting in flag printing
-	parallelism := o.Parallelism
-	if strings.Count(parallelism, "%") == 1 {
-		parallelism = parallelism + "%"
-	}
-	cmd.Flags().StringVar(&o.Parallelism, "parallelism", parallelism, "parallelism is a raw number or a percentage of the nodes to work with concurrently.")
+	cmd.Flags().StringVar(&o.Parallelism, "parallelism", o.Parallelism, "parallelism is a raw number or a percentage of the nodes to work with concurrently.")
 }
 
 func (o *PerNodePodOptions) ToRuntime(args []string) (*PerNodePodRuntime, error) {


### PR DESCRIPTION
This reverts commit d6762a7cc46eadcb29a420316373b11fae90b6d5.

/assign @ardaguclu 