### PR TITLE
OCPBUGS-30212: oc adm catalog mirror: use ToSlash and FromSlash to unify the path separators

### DIFF
--- a/pkg/cli/image/extract/extract.go
+++ b/pkg/cli/image/extract/extract.go
@@ -696,7 +696,7 @@ func (n *copyFromPattern) Alter(hdr *tar.Header) (bool, error) {
 			return false, nil
 		}
 		matchName = hdr.Name
-		if i := strings.Index(matchName, "/"); i != -1 {
+		if i := strings.Index(matchName, string(filepath.Separator)); i != -1 {
 			matchName = matchName[:i]
 		}
 	}
@@ -721,19 +721,19 @@ func changeTarEntryName(hdr *tar.Header, name string) bool {
 }
 
 func changeTarEntryParent(hdr *tar.Header, from string) bool {
-	if !strings.HasPrefix(hdr.Name, from) {
-		klog.V(5).Infof("Exclude %s due to missing prefix %s", hdr.Name, from)
+	if !strings.HasPrefix(filepath.ToSlash(hdr.Name), from) {
+		klog.V(5).Infof("Exclude %s due to missing prefix %s", filepath.ToSlash(hdr.Name), from)
 		return false
 	}
 	if len(hdr.Linkname) > 0 {
-		if strings.HasPrefix(hdr.Linkname, from) {
-			hdr.Linkname = strings.TrimPrefix(hdr.Linkname, from)
+		if strings.HasPrefix(filepath.ToSlash(hdr.Linkname), from) {
+			hdr.Linkname = filepath.FromSlash(strings.TrimPrefix(filepath.ToSlash(hdr.Linkname), from))
 			klog.V(5).Infof("Updated link to %s", hdr.Linkname)
 		} else {
 			klog.V(4).Infof("Name %s won't correctly point to %s outside of %s", hdr.Name, hdr.Linkname, from)
 		}
 	}
-	hdr.Name = strings.TrimPrefix(hdr.Name, from)
+	hdr.Name = filepath.FromSlash(strings.TrimPrefix(filepath.ToSlash(hdr.Name), from))
 	klog.V(5).Infof("Updated name %s", hdr.Name)
 	return true
 }

--- a/pkg/cli/image/imagesource/file.go
+++ b/pkg/cli/image/imagesource/file.go
@@ -101,7 +101,7 @@ func (s *fileTagStore) Get(ctx context.Context, tag string) (distribution.Descri
 		return distribution.Descriptor{}, err
 	}
 	return distribution.Descriptor{
-		Digest: godigest.Digest(filepath.Base(target)),
+		Digest: godigest.Digest(reconstructDigest(filepath.Base(target))),
 		Size:   fi.Size(),
 	}, nil
 }

--- a/pkg/cli/image/imagesource/file_unix.go
+++ b/pkg/cli/image/imagesource/file_unix.go
@@ -13,3 +13,8 @@ import "path/filepath"
 func generateDigestPath(digest string, elem ...string) string {
 	return filepath.Join(append(elem, digest)...)
 }
+
+// reconstructDigest is a no-op on Unix. See file_windows.go for more details.
+func reconstructDigest(digest string) string {
+	return digest
+}

--- a/pkg/cli/image/imagesource/file_windows.go
+++ b/pkg/cli/image/imagesource/file_windows.go
@@ -1,6 +1,7 @@
 package imagesource
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 )
@@ -13,4 +14,32 @@ import (
 func generateDigestPath(digest string, elem ...string) string {
 	dgst := strings.ReplaceAll(digest, ":", "-")
 	return filepath.Join(append(elem, dgst)...)
+}
+
+// reconstructDigest replaces ":" with "-" which makes the digest parsing nondeterministic.
+// A digest regex corresponds to `[a-z0-9](?:[.+_-][a-z0-9])*:[a-zA-Z0-9=_-]+`.
+// Making "sha256-sha256:659d863050ebd58ebd2ea4b4e89226b494ba39457932ebf11669763eea3b2ed0" a valid digest.
+// After the ":" replacement the filename gets translated into
+// "sha256-sha256-659d863050ebd58ebd2ea4b4e89226b494ba39457932ebf11669763eea3b2ed0" which has
+// two matching digests:
+// - sha256-sha256:659d863050ebd58ebd2ea4b4e89226b494ba39457932ebf11669763eea3b2ed0
+// - sha256:sha256-659d863050ebd58ebd2ea4b4e89226b494ba39457932ebf11669763eea3b2ed0
+//
+// From https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests:
+// digest                ::= algorithm ":" encoded
+// algorithm             ::= algorithm-component (algorithm-separator algorithm-component)*
+// algorithm-component   ::= [a-z0-9]+
+// algorithm-separator   ::= [+._-]
+// encoded               ::= [a-zA-Z0-9=_-]+
+//
+// Given only sha256 and sha512 are currently supported (based on the linked descriptor.md#digests)
+// we can parse these two cases and panic for the rest.
+func reconstructDigest(digest string) string {
+	if strings.HasPrefix(digest, "sha256-") {
+		return "sha256:" + strings.TrimPrefix(digest, "sha256-")
+	}
+	if strings.HasPrefix(digest, "sha512-") {
+		return "sha512:" + strings.TrimPrefix(digest, "sha512-")
+	}
+	panic(fmt.Sprintf("Only 'sha256-' and 'sha512-' digest prefixes are supported on Windows. Got %q", digest))
 }


### PR DESCRIPTION
Image label (`operators.operatorframework.io.index.configs.v1`), mappings and other code parts uses Unix path separators (`/`). `github.com/docker/docker/pkg/archive` implementation produces windows path separators when running on Windows platform. ToSlash and FromSlash allows to treat all path seperators as Unix path seperators.