### PR TITLE
TRT-1503: Tools image no longer has python;adding

### DIFF
--- a/images/tools/Dockerfile
+++ b/images/tools/Dockerfile
@@ -36,6 +36,7 @@ RUN INSTALL_PKGS="\
   xfsprogs \
   fio \
   stress-ng \
+  python36 \
   " && \
   yum -y install $INSTALL_PKGS && rpm -V --nosize --nofiledigest --nomtime --nomode $INSTALL_PKGS && yum clean all && rm -rf /var/cache/*
   # Disabled until they are buildable on s390x


### PR DESCRIPTION
Something has recently changed with the parent images of the tools image where it no longer has python causing CI failures. Adding `python3` to the tools image.



