### PR TITLE
NO-JIRA: Print log rather than returning an error when kubectl version mistmaches

### DIFF
--- a/pkg/cli/admin/release/image_mapper_test.go
+++ b/pkg/cli/admin/release/image_mapper_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	imageapi "github.com/openshift/api/image/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/diff"
@@ -697,7 +699,8 @@ func Test_loadImageStreamTransforms(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, got1, got2, err := loadImageStreamTransforms(tt.input, tt.local, tt.allowMissingImages, tt.src)
+			ioStream := genericiooptions.NewTestIOStreamsDiscard()
+			got, got1, got2, err := loadImageStreamTransforms(tt.input, tt.local, tt.allowMissingImages, tt.src, ioStream.ErrOut)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("loadImageStreamTransforms() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/pkg/cli/admin/release/info.go
+++ b/pkg/cli/admin/release/info.go
@@ -860,7 +860,7 @@ func (o *InfoOptions) LoadReleaseInfo(image string, retrieveImages bool) (*Relea
 		return nil, fmt.Errorf("release image did not contain an image-references file")
 	}
 
-	release.ComponentVersions, errs = readComponentVersions(release.References)
+	release.ComponentVersions, errs = readComponentVersions(release.References, o.ErrOut)
 	for _, err := range errs {
 		release.Warnings = append(release.Warnings, err.Error())
 	}
@@ -932,7 +932,7 @@ func (o *InfoOptions) LoadReleaseInfo(image string, retrieveImages bool) (*Relea
 	return release, nil
 }
 
-func readComponentVersions(is *imageapi.ImageStream) (ComponentVersions, []error) {
+func readComponentVersions(is *imageapi.ImageStream, errOut io.Writer) (ComponentVersions, []error) {
 	var errs []error
 	combined := make(map[string]sets.String)
 	combinedDisplayNames := make(map[string]sets.String)
@@ -971,7 +971,7 @@ func readComponentVersions(is *imageapi.ImageStream) (ComponentVersions, []error
 
 	multiples := sets.NewString()
 	if kubectlVersions.Len() > 2 {
-		multiples.Insert("kubectl")
+		fmt.Fprintf(errOut, "warning: multiple versions reported for the kubectl: %v\n", strings.Join(kubectlVersions.UnsortedList(), ","))
 	}
 	var out ComponentVersions
 	var keys []string

--- a/pkg/cli/admin/release/info_test.go
+++ b/pkg/cli/admin/release/info_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	digest "github.com/opencontainers/go-digest"
 	"github.com/openshift/library-go/pkg/image/dockerv1client"
 	"k8s.io/apimachinery/pkg/util/diff"
@@ -409,7 +411,6 @@ func Test_readComponentVersions(t *testing.T) {
 			want: ComponentVersions{
 				"kubectl": {Version: "1.1.0"},
 			},
-			wantErr: []error{fmt.Errorf("multiple versions or display names reported for the following component(s): kubectl")},
 		},
 		{
 			is: &imageapi.ImageStream{
@@ -445,7 +446,6 @@ func Test_readComponentVersions(t *testing.T) {
 			want: ComponentVersions{
 				"kubectl": {Version: "1.1.0"},
 			},
-			wantErr: []error{fmt.Errorf("multiple versions or display names reported for the following component(s): kubectl")},
 		},
 		{
 			is: &imageapi.ImageStream{
@@ -485,7 +485,8 @@ func Test_readComponentVersions(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, got1 := readComponentVersions(tt.is)
+			ioStreams := genericiooptions.NewTestIOStreamsDiscard()
+			got, got1 := readComponentVersions(tt.is, ioStreams.ErrOut)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("%s", diff.ObjectReflectDiff(got, tt.want))
 			}


### PR DESCRIPTION
There are images that are based on `cli` image in the release payload and those images also manifest their kubectl versions (i.e. [cluster-samples-operator](https://github.com/openshift/cluster-samples-operator/blob/master/manifests/image-references) [1]). It is reasonable to assume that all the kubectl versions should match, because base image is the same for all of them. However, rebuilt strategy of some images simply rely on a new commit in their repository. That means if there is no new commit merged for a repository that the image is residing in, this image will not be rebuilt and still manifests an old kubectl version. That causes a new release payload generation mechanism a failure (even a minor kubectl version bump in oc would cause a org-wide failures).

Due to this uncontrolled environment for kubectl versions, this PR switches the kubectl version check from error to information log. Users will still see mismatches but this just won't cause any failure. This shouldn't create a problem because our source of truths are still `cli` and `cli-artifacts` images.

[1] _For example must-gather image manifests kubectl 1.28.2 https://quay.io/repository/openshift/origin-must-gather/manifest/sha256:b36b9314580632d7eb4f4d5d71b1297eb637b91f84f0ab7df51137524f704228 and refers to an old commit because there is no changes in https://github.com/openshift/must-gather within this time period._