### PR TITLE
OCPBUGS-30162: Introduce --issuer-url flag in oc login

### DIFF
--- a/pkg/cli/login/login.go
+++ b/pkg/cli/login/login.go
@@ -97,7 +97,7 @@ func NewCmdLogin(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.
 	cmds.Flags().StringVar(&o.OIDCClientID, "client-id", o.OIDCClientID, "Experimental: Client ID for external OIDC issuer. Only supports Auth Code + PKCE. Required.")
 	cmds.Flags().StringVar(&o.OIDCClientSecret, "client-secret", o.OIDCClientSecret, "Experimental: Client secret for external OIDC issuer. Optional.")
 	cmds.Flags().StringSliceVar(&o.OIDCExtraScopes, "extra-scopes", o.OIDCExtraScopes, "Experimental: Extra scopes for external OIDC issuer. Optional.")
-	cmds.Flags().StringVar(&o.OIDCIssuerURL, "issuer-url", o.OIDCIssuerURL, "Experimental: Issuer url for external issuer. Optional.")
+	cmds.Flags().StringVar(&o.OIDCIssuerURL, "issuer-url", o.OIDCIssuerURL, "Experimental: Issuer url for external issuer. Required.")
 	return cmds
 }
 
@@ -198,6 +198,10 @@ func (o LoginOptions) Validate(cmd *cobra.Command, serverFlag string, args []str
 
 	if o.OIDCExecPluginType != "" && (o.WebLogin || o.Username != "" || o.Password != "" || o.Token != "") {
 		return errors.New("--exec-plugin cannot be used along with --web, --username, --password or --token")
+	}
+
+	if o.OIDCExecPluginType == string(OCOIDC) && (o.OIDCIssuerURL == "" || o.OIDCClientID == "") {
+		return fmt.Errorf("--issuer-url and --client-id are required fields for oc-oidc type")
 	}
 
 	if o.OIDCIssuerURL != "" {

--- a/pkg/cli/login/loginoptions.go
+++ b/pkg/cli/login/loginoptions.go
@@ -5,12 +5,10 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net"
-	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -32,7 +30,6 @@ import (
 	kterm "k8s.io/kubectl/pkg/util/term"
 
 	projectv1typedclient "github.com/openshift/client-go/project/clientset/versioned/typed/project/v1"
-	"github.com/openshift/library-go/pkg/oauth/oauthdiscovery"
 	"github.com/openshift/library-go/pkg/oauth/tokenrequest"
 	"github.com/openshift/library-go/pkg/oauth/tokenrequest/challengehandlers"
 
@@ -337,14 +334,6 @@ func (o *LoginOptions) gatherAuthInfo() error {
 // prepareBuiltinExecPlugin sets up the ExecConfig correctly
 // with the given values
 func (o *LoginOptions) prepareBuiltinExecPlugin() (*kclientcmdapi.ExecConfig, error) {
-	var err error
-	if o.OIDCIssuerURL == "" {
-		o.OIDCIssuerURL, err = o.extractIssuerURLForOIDC()
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	execProvider := &kclientcmdapi.ExecConfig{
 		APIVersion: clientauthentication.GroupName + "/v1",
 		Command:    "oc",
@@ -575,38 +564,6 @@ func (o *LoginOptions) SaveConfig() (bool, error) {
 	}
 
 	return created, nil
-}
-
-func (o *LoginOptions) extractIssuerURLForOIDC() (string, error) {
-	rt, err := restclient.TransportFor(o.Config)
-	if err != nil {
-		return "", err
-	}
-
-	requestURL := strings.TrimRight(o.Config.Host, "/") + "/.well-known/oauth-authorization-server"
-
-	req, err := http.NewRequest(http.MethodGet, requestURL, nil)
-	if err != nil {
-		return "", err
-	}
-	req.Header.Set("X-CSRF-Token", "1")
-
-	resp, err := rt.RoundTrip(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("couldn't get %v: unexpected response status %v", requestURL, resp.StatusCode)
-	}
-
-	metadata := &oauthdiscovery.OauthAuthorizationServerMetadata{}
-	if err := json.NewDecoder(resp.Body).Decode(metadata); err != nil {
-		return "", err
-	}
-
-	return metadata.Issuer, nil
 }
 
 func (o *LoginOptions) usernameProvided() bool {

--- a/pkg/cli/login/loginoptions.go
+++ b/pkg/cli/login/loginoptions.go
@@ -87,6 +87,7 @@ type LoginOptions struct {
 	OIDCClientID       string
 	OIDCClientSecret   string
 	OIDCExtraScopes    []string
+	OIDCIssuerURL      string
 
 	Token string
 
@@ -336,9 +337,12 @@ func (o *LoginOptions) gatherAuthInfo() error {
 // prepareBuiltinExecPlugin sets up the ExecConfig correctly
 // with the given values
 func (o *LoginOptions) prepareBuiltinExecPlugin() (*kclientcmdapi.ExecConfig, error) {
-	issuerUrl, err := o.extractIssuerURLForOIDC()
-	if err != nil {
-		return nil, err
+	var err error
+	if o.OIDCIssuerURL == "" {
+		o.OIDCIssuerURL, err = o.extractIssuerURLForOIDC()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	execProvider := &kclientcmdapi.ExecConfig{
@@ -346,7 +350,7 @@ func (o *LoginOptions) prepareBuiltinExecPlugin() (*kclientcmdapi.ExecConfig, er
 		Command:    "oc",
 		Args: []string{
 			"get-token",
-			fmt.Sprintf("--issuer-url=%s", issuerUrl),
+			fmt.Sprintf("--issuer-url=%s", o.OIDCIssuerURL),
 			fmt.Sprintf("--client-id=%s", o.OIDCClientID),
 			fmt.Sprintf("--callback-address=127.0.0.1:%d", o.CallbackPort),
 		},


### PR DESCRIPTION
Normally, oc login extracts the issuer url from API server but in cases where multiple oidc providers exist, user may want to explicitly specify issuer url to authenticate. That's why, this PR introduces `--issuer-url` flag in oc login to be passed to `oc get-token` oidc cred exec plugin of oc.