### PR TITLE
WRKLDS-1103: tools: extend the image with sosreport

### DIFF
--- a/images/tools/Dockerfile
+++ b/images/tools/Dockerfile
@@ -26,6 +26,7 @@ RUN INSTALL_PKGS="\
   procps-ng \
   psmisc \
   perf \
+  sos \
   strace \
   sysstat \
   tcpdump \


### PR DESCRIPTION
In the disconnected env it's really hard to add a new image or rpms. Thus, making the sosreport part of the tools image removes the need for pulling another image/installing an rpm.