### PR TITLE
WRKLDS-1128: cli/admin/release/git: use optimized git flags

### DIFF
--- a/pkg/cli/admin/release/extract.go
+++ b/pkg/cli/admin/release/extract.go
@@ -636,7 +636,7 @@ func (o *ExtractOptions) extractGit(dir string) error {
 				case "":
 					klog.V(2).Infof("Checkout %s from %s ...", commit, repo)
 					buf.Reset()
-					if err := extractedRepo.CheckoutCommit(repo, commit); err != nil {
+					if err := extractedRepo.CheckoutCommit(repo, commit, buf, buf); err != nil {
 						once.Do(func() { hadErrors = true })
 						fmt.Fprintf(o.ErrOut, "error: checking out commit for %s: %v\n%s\n", repo, err, buf.String())
 						return

--- a/pkg/cli/admin/release/git.go
+++ b/pkg/cli/admin/release/git.go
@@ -68,7 +68,7 @@ func (g *git) ChangeContext(path string) (*git, error) {
 }
 
 func (g *git) Clone(repository string, out, errOut io.Writer) error {
-	cmd := exec.Command("git", "clone", repository, g.path)
+	cmd := exec.Command("git", "clone", "--filter=blob:none", "--bare", repository, g.path)
 	cmd.Stdout = out
 	cmd.Stderr = errOut
 	return cmd.Run()

--- a/pkg/cli/admin/release/info.go
+++ b/pkg/cli/admin/release/info.go
@@ -91,9 +91,8 @@ func NewInfo(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Comm
 			a tag when verifying an image is recommended since it ensures an attacker cannot trick you
 			into installing an older, potentially vulnerable version.
 
-			The --bugs and --changelog flags will use git to clone the source of the release and display
-			the code changes that occurred between the two release arguments. This operation is slow
-			and requires sufficient disk space on the selected drive to clone all repositories.
+			The --bugs and --changelog flags will use git to clone the git history of the release and display
+			the code changes that occurred between the two release arguments.
 
 			If the specified image supports multiple operating systems, the image that matches the
 			current operating system will be chosen. Otherwise you must pass --filter-by-os to

--- a/pkg/cli/admin/release/info.go
+++ b/pkg/cli/admin/release/info.go
@@ -92,7 +92,8 @@ func NewInfo(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Comm
 			into installing an older, potentially vulnerable version.
 
 			The --bugs and --changelog flags will use git to clone the git history of the release and display
-			the code changes that occurred between the two release arguments.
+			the code changes that occurred between the two release arguments. This operation is slow
+			and requires sufficient disk space on the selected drive to clone all repositories.
 
 			If the specified image supports multiple operating systems, the image that matches the
 			current operating system will be chosen. Otherwise you must pass --filter-by-os to


### PR DESCRIPTION
This PR adds the `--filter=blob:none --bare` flags to the `git clone` commands, which significantly reduces disk space usage (for example, for 4.14.0->4.15.0, reduction from 31GB to 900MB).