### PR TITLE
OCPBUGS-27859: oc login: Use merged config's CA file for better usability

### DIFF
--- a/pkg/cli/login/loginoptions.go
+++ b/pkg/cli/login/loginoptions.go
@@ -279,7 +279,7 @@ func (o *LoginOptions) gatherAuthInfo() error {
 	}
 
 	if o.OIDCExecPluginType == string(OCOIDC) {
-		execProvider, err := o.prepareBuiltinExecPlugin()
+		execProvider, err := o.prepareBuiltinExecPlugin(clientConfig.CAFile)
 		if err != nil {
 			return err
 		}
@@ -333,7 +333,7 @@ func (o *LoginOptions) gatherAuthInfo() error {
 
 // prepareBuiltinExecPlugin sets up the ExecConfig correctly
 // with the given values
-func (o *LoginOptions) prepareBuiltinExecPlugin() (*kclientcmdapi.ExecConfig, error) {
+func (o *LoginOptions) prepareBuiltinExecPlugin(caFile string) (*kclientcmdapi.ExecConfig, error) {
 	execProvider := &kclientcmdapi.ExecConfig{
 		APIVersion: clientauthentication.GroupName + "/v1",
 		Command:    "oc",
@@ -359,8 +359,8 @@ func (o *LoginOptions) prepareBuiltinExecPlugin() (*kclientcmdapi.ExecConfig, er
 		execProvider.Args = append(execProvider.Args, "--insecure-skip-tls-verify")
 	}
 
-	if len(o.Config.CAFile) > 0 {
-		execProvider.Args = append(execProvider.Args, fmt.Sprintf("--certificate-authority=%s", o.Config.CAFile))
+	if len(caFile) > 0 {
+		execProvider.Args = append(execProvider.Args, fmt.Sprintf("--certificate-authority=%s", caFile))
 	}
 
 	return execProvider, nil


### PR DESCRIPTION
Currently, when oc login works against external OIDC issuers, it only accepts CA file explicitly specified by user. However, kubeconfig's cluster stanza can also be used just like other authentication methods in oc login. Because, direct merged config's CA file is not only populated by the flag, but also can be populated by certificate-authority field kubeconfig's cluster stanza.

This PR changes that way to increase usability. Thanks to this change, user doesn't have to specify `--certificate-authority` field, if kubeconfig has this already.