### PR TITLE
WRKLDS-1128: revert cli/admin/release/git: use optimized git flags

### DIFF
--- a/pkg/cli/admin/release/extract.go
+++ b/pkg/cli/admin/release/extract.go
@@ -636,7 +636,7 @@ func (o *ExtractOptions) extractGit(dir string) error {
 				case "":
 					klog.V(2).Infof("Checkout %s from %s ...", commit, repo)
 					buf.Reset()
-					if err := extractedRepo.CheckoutCommit(repo, commit, buf, buf); err != nil {
+					if err := extractedRepo.CheckoutCommit(repo, commit); err != nil {
 						once.Do(func() { hadErrors = true })
 						fmt.Fprintf(o.ErrOut, "error: checking out commit for %s: %v\n%s\n", repo, err, buf.String())
 						return

--- a/pkg/cli/admin/release/info.go
+++ b/pkg/cli/admin/release/info.go
@@ -91,7 +91,7 @@ func NewInfo(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Comm
 			a tag when verifying an image is recommended since it ensures an attacker cannot trick you
 			into installing an older, potentially vulnerable version.
 
-			The --bugs and --changelog flags will use git to clone the git history of the release and display
+			The --bugs and --changelog flags will use git to clone the source of the release and display
 			the code changes that occurred between the two release arguments. This operation is slow
 			and requires sufficient disk space on the selected drive to clone all repositories.
 


### PR DESCRIPTION
As we discussed in https://github.com/openshift/oc/pull/1715#issuecomment-2025145649, we will reintroduce this feature when oc's base image is set to RHEL9.

Reverts openshift/oc#1708