### PR TITLE
OCPBUGS-31498: Add OIDC specific certificate authority bundle flag

### DIFF
--- a/pkg/cli/login/login.go
+++ b/pkg/cli/login/login.go
@@ -98,6 +98,7 @@ func NewCmdLogin(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.
 	cmds.Flags().StringVar(&o.OIDCClientSecret, "client-secret", o.OIDCClientSecret, "Experimental: Client secret for external OIDC issuer. Optional.")
 	cmds.Flags().StringSliceVar(&o.OIDCExtraScopes, "extra-scopes", o.OIDCExtraScopes, "Experimental: Extra scopes for external OIDC issuer. Optional.")
 	cmds.Flags().StringVar(&o.OIDCIssuerURL, "issuer-url", o.OIDCIssuerURL, "Experimental: Issuer url for external issuer. Required.")
+	cmds.Flags().StringVar(&o.OIDCCAFile, "oidc-certificate-authority", o.OIDCCAFile, "Experimental: The path to a certificate authority bundle to use when communicating with external OIDC issuer.")
 	return cmds
 }
 

--- a/pkg/cli/login/loginoptions.go
+++ b/pkg/cli/login/loginoptions.go
@@ -85,6 +85,7 @@ type LoginOptions struct {
 	OIDCClientSecret   string
 	OIDCExtraScopes    []string
 	OIDCIssuerURL      string
+	OIDCCAFile         string
 
 	Token string
 
@@ -359,8 +360,8 @@ func (o *LoginOptions) prepareBuiltinExecPlugin() (*kclientcmdapi.ExecConfig, er
 		execProvider.Args = append(execProvider.Args, "--insecure-skip-tls-verify")
 	}
 
-	if len(o.Config.CAFile) > 0 {
-		execProvider.Args = append(execProvider.Args, fmt.Sprintf("--certificate-authority=%s", o.Config.CAFile))
+	if len(o.OIDCCAFile) > 0 {
+		execProvider.Args = append(execProvider.Args, fmt.Sprintf("--certificate-authority=%s", o.OIDCCAFile))
 	}
 
 	return execProvider, nil


### PR DESCRIPTION
In oc login, `certificate-authority` global flag provided by oc is used to authenticate to API server, when API Server's
CA bundle is self-signed. We tried to use it against external OIDC issuers as well but it is not correct behavior because external OIDC issuer's CA bundle may differ from API server.

This PR introduces a new `oidc-certificate-authority` flag which will be used to pass to external OIDC issuer during authentication. This separation enables two different CA bundles can be used at the same invocation and global `certificate-authority` flag is still used against API server. 