### PR TITLE
OCPBUGS-31615: Add help text the behavior of filter-by-os against single image

### DIFF
--- a/pkg/cli/image/info/info.go
+++ b/pkg/cli/image/info/info.go
@@ -53,6 +53,8 @@ func NewInfo(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Comm
 
 			Images in manifest list format will be shown for your current operating system.
 			To see the image for a particular OS use the --filter-by-os=OS/ARCH flag.
+			When --filter-by-os is used against an image which is not in manifest list format,
+			--filter-by-os flag will be ignored.
 		`),
 		Example: templates.Examples(`
 			# Show information about an image


### PR DESCRIPTION
`--filter-by-os` flag is ignored (even with invalid value `--filter-by-os=invalid`), when it is used against an single image. This PR adds this into the long text. 