### PR TITLE
WRKLDS-1171: Add openshift-install-fips target to oc release extract

### DIFF
--- a/pkg/cli/admin/release/extract_tools.go
+++ b/pkg/cli/admin/release/extract_tools.go
@@ -449,6 +449,18 @@ func (o *ExtractOptions) extractCommand(command string) error {
 			ArchiveFormat:        "openshift-baremetal-install-linux-%s.tar.gz",
 		},
 		{
+			OS:       "linux",
+			Arch:     targetReleaseArch,
+			Command:  "openshift-install-fips",
+			Optional: true,
+			Mapping:  extract.Mapping{Image: "baremetal-installer", From: "usr/bin/openshift-install"},
+
+			Readme:               readmeInstallUnix,
+			InjectReleaseImage:   true,
+			InjectReleaseVersion: true,
+			ArchiveFormat:        "openshift-install-rhel-%s.tar.gz",
+		},
+		{
 			OS:      "linux",
 			Arch:    targetReleaseArch,
 			Command: "ccoctl",


### PR DESCRIPTION
Allow the openshift-baremetal-install binary to also be extracted using the openshift-install-fips command. This is clearer for users who need this binary only for FIPS compliance reasons.