### PR TITLE
SDN-4114: Add cri-tools to tools image

### DIFF
--- a/images/tools/Dockerfile
+++ b/images/tools/Dockerfile
@@ -5,6 +5,7 @@ RUN INSTALL_PKGS="\
   bind-utils \
   blktrace \
   crash \
+  cri-tools \
   e2fsprogs \
   ethtool \
   file \


### PR DESCRIPTION
I'm not sure if there's a definition of what does and doesn't belong in `tools` but would it be OK to add `cri-tools` (ie, in particular, `crictl`)? (This is for a daemonset that needs to check all local pods to see if they have created any iptables rules, so we can warn customers that iptables is deprecated and will go away in RHEL 10. https://github.com/openshift/cluster-network-operator/pull/2329)

One possible issue is that it requires the host `/run` to be mounted in order to be useful, so it wouldn't be usable in "ordinary" uses of the image... Though some of the other things in `tools` also seem like they're only useful for containers that have certain other things mounted (eg, `pciutils` presumably requires `/dev`) so maybe that's ok?
