### PR TITLE
NO-JIRA: Print an error msg instead of panicking when all image manifests are filtered out

### DIFF
--- a/pkg/cli/image/extract/extract.go
+++ b/pkg/cli/image/extract/extract.go
@@ -407,6 +407,8 @@ func (o *ExtractOptions) Run() error {
 						if err != nil {
 							return err
 						}
+					} else {
+						return fmt.Errorf("failed to retrieve manifests from image %s: %v", from, err)
 					}
 				}
 


### PR DESCRIPTION
`$ oc image extract 'quay.io/multi-arch/yq:3.3.0' --file '/yq' --filter-by-os 'darwin/amd64'` panics: 
```bash
panic: no ':' separator in digest ""

goroutine 14 [running]:
github.com/opencontainers/go-digest.Digest.sepIndex({0x0, 0x0})
        /Users/fxie/Projects/oc/vendor/github.com/opencontainers/go-digest/digest.go:153 +0x90
github.com/opencontainers/go-digest.Digest.Algorithm(...)
        /Users/fxie/Projects/oc/vendor/github.com/opencontainers/go-digest/digest.go:122
github.com/openshift/oc/pkg/cli/image/extract.(*ExtractOptions).Run.func1.1()
        /Users/fxie/Projects/oc/pkg/cli/image/extract/extract.go:413 +0x4e0
github.com/openshift/oc/pkg/cli/image/workqueue.(*worker).Try.func1()
        /Users/fxie/Projects/oc/pkg/cli/image/workqueue/workqueue.go:137 +0x30
github.com/openshift/oc/pkg/cli/image/workqueue.(*workQueue).run.func1(0x0)
        /Users/fxie/Projects/oc/pkg/cli/image/workqueue/workqueue.go:51 +0xb4
created by github.com/openshift/oc/pkg/cli/image/workqueue.(*workQueue).run in goroutine 11
        /Users/fxie/Projects/oc/pkg/cli/image/workqueue/workqueue.go:43 +0x48
```

With this PR the same command gives:
```bash
error: failed to retrieve manifests from image quay.io/multi-arch/yq:3.3.0: filtered all images from manifest list
```