### PR TITLE
OTA-1036: `adm upgrade status`: Add control plane nodes status

### DIFF
--- a/pkg/cli/admin/upgrade/status/examples/4.14.1-degraded.output
+++ b/pkg/cli/admin/upgrade/status/examples/4.14.1-degraded.output
@@ -12,6 +12,12 @@ Completion:      97%
 Duration:        1h58m50s
 Operator Status: 33 Total, 32 Available, 1 Progressing, 4 Degraded
 
+Control Plane Node(s)
+NAME                                        ASSESSMENT   PHASE     VERSION       EST   MESSAGE
+ip-10-0-30-217.us-east-2.compute.internal   Outdated     Pending   4.14.0-rc.3   ?     
+ip-10-0-53-40.us-east-2.compute.internal    Outdated     Pending   4.14.0-rc.3   ?     
+ip-10-0-92-180.us-east-2.compute.internal   Outdated     Pending   4.14.0-rc.3   ?     
+
 = Worker Upgrade =
 
 = Worker Pool =

--- a/pkg/cli/admin/upgrade/status/examples/4.14.1-paused-worker-pool.output
+++ b/pkg/cli/admin/upgrade/status/examples/4.14.1-paused-worker-pool.output
@@ -6,6 +6,12 @@ Completion:      12%
 Duration:        6s
 Operator Status: 33 Total, 33 Available, 0 Progressing, 0 Degraded
 
+Control Plane Node(s)
+NAME                                        ASSESSMENT   PHASE     VERSION   EST   MESSAGE
+ip-10-0-30-217.us-east-2.compute.internal   Outdated     Pending   4.14.0    ?     
+ip-10-0-53-40.us-east-2.compute.internal    Outdated     Pending   4.14.0    ?     
+ip-10-0-92-180.us-east-2.compute.internal   Outdated     Pending   4.14.0    ?     
+
 = Worker Upgrade =
 
 = Worker Pool =

--- a/pkg/cli/admin/upgrade/status/examples/4.14.1-workers-started-updating-multiple-pools.output
+++ b/pkg/cli/admin/upgrade/status/examples/4.14.1-workers-started-updating-multiple-pools.output
@@ -6,6 +6,12 @@ Completion:      97%
 Duration:        14m4s
 Operator Status: 33 Total, 32 Available, 1 Progressing, 0 Degraded
 
+Control Plane Node(s)
+NAME                                        ASSESSMENT    PHASE      VERSION   EST    MESSAGE
+ip-10-0-53-40.us-east-2.compute.internal    Progressing   Draining   4.14.0    +30m   
+ip-10-0-30-217.us-east-2.compute.internal   Outdated      Pending    4.14.0    ?      
+ip-10-0-92-180.us-east-2.compute.internal   Outdated      Pending    4.14.0    ?      
+
 = Worker Upgrade =
 
 = Worker Pool =

--- a/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-b02-cos-not-annotated.output
+++ b/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-b02-cos-not-annotated.output
@@ -6,6 +6,12 @@ Completion:      43%
 Duration:        52m56s
 Operator Status: 7 Total, 7 Available, 0 Progressing, 0 Degraded
 
+Control Plane Node(s)
+NAME                                        ASSESSMENT   PHASE     VERSION       EST   MESSAGE
+ip-10-0-30-217.us-east-2.compute.internal   Outdated     Pending   4.15.0-ec.1   ?     
+ip-10-0-53-40.us-east-2.compute.internal    Outdated     Pending   4.15.0-ec.1   ?     
+ip-10-0-92-180.us-east-2.compute.internal   Outdated     Pending   4.15.0-ec.1   ?     
+
 = Worker Upgrade =
 
 = Worker Pool =

--- a/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-early.output
+++ b/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-early.output
@@ -6,6 +6,12 @@ Completion:      3%
 Duration:        1m29s
 Operator Status: 33 Total, 33 Available, 2 Progressing, 0 Degraded
 
+Control Plane Node(s)
+NAME                                        ASSESSMENT   PHASE     VERSION   EST   MESSAGE
+ip-10-0-30-217.us-east-2.compute.internal   Outdated     Pending   4.14.1    ?     
+ip-10-0-53-40.us-east-2.compute.internal    Outdated     Pending   4.14.1    ?     
+ip-10-0-92-180.us-east-2.compute.internal   Outdated     Pending   4.14.1    ?     
+
 = Worker Upgrade =
 
 = Worker Pool =

--- a/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-unavailable-mco-20m.output
+++ b/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-unavailable-mco-20m.output
@@ -6,6 +6,12 @@ Completion:      97%
 Duration:        58m53s
 Operator Status: 33 Total, 31 Available, 1 Progressing, 1 Degraded
 
+Control Plane Node(s)
+NAME                                        ASSESSMENT   PHASE     VERSION       EST   MESSAGE
+ip-10-0-30-217.us-east-2.compute.internal   Outdated     Pending   4.14.0-rc.3   ?     
+ip-10-0-53-40.us-east-2.compute.internal    Outdated     Pending   4.14.0-rc.3   ?     
+ip-10-0-92-180.us-east-2.compute.internal   Outdated     Pending   4.14.0-rc.3   ?     
+
 = Worker Upgrade =
 
 = Worker Pool =

--- a/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.output
+++ b/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.output
@@ -12,6 +12,12 @@ Completion:      100%
 Duration:        3h30m31s
 Operator Status: 36 Total, 36 Available, 0 Progressing, 1 Degraded
 
+Control Plane Node(s)
+NAME                                                  ASSESSMENT   PHASE     VERSION       EST   MESSAGE
+build0-gstfj-m-0.c.openshift-ci-build-farm.internal   Completed    Updated   4.16.0-ec.3   -     
+build0-gstfj-m-1.c.openshift-ci-build-farm.internal   Completed    Updated   4.16.0-ec.3   -     
+build0-gstfj-m-2.c.openshift-ci-build-farm.internal   Completed    Updated   4.16.0-ec.3   -     
+
 = Worker Upgrade =
 
 = Worker Pool =


### PR DESCRIPTION
The goal of this pull request is to display additional information upon executing `oc adm upgrade status`.

The additional information consists of the status of control plane nodes.

This pull request references https://issues.redhat.com/browse/OTA-1036