### PR TITLE
Set the correct version release in the OC binary

### DIFF
--- a/vendor/github.com/openshift/build-machinery-go/make/lib/golang.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/lib/golang.mk
@@ -50,7 +50,7 @@ GO_TEST_FLAGS ?=-race
 
 GO_LD_EXTRAFLAGS ?=
 
-SOURCE_GIT_TAG ?=$(shell git describe --long --tags --abbrev=7 --match 'v[0-9]*' || echo 'v0.0.0-unknown-$(SOURCE_GIT_COMMIT)')
+SOURCE_GIT_TAG ?=$(shell git describe --long --tags --abbrev=7 --match 'openshift-clients-*' | sed 's/openshift-clients-/v/g' || echo 'v0.0.0-unknown-$(SOURCE_GIT_COMMIT)')
 SOURCE_GIT_COMMIT ?=$(shell git rev-parse --short "HEAD^{commit}" 2>/dev/null)
 SOURCE_GIT_TREE_STATE ?=$(shell ( ( [ ! -d ".git/" ] || git diff --quiet ) && echo 'clean' ) || echo 'dirty')
 


### PR DESCRIPTION
Set the correct version release in the OC binary.

Update `SOURCE_GIT_TAG` parsing logic to correctly identify the new tag format: `openshift-clients-<version>`. Previously, it incorrectly returned `v4.2.0-alpha.0` for all releases.

Fixes #1688 
Fixes #744
Fixes #740