### PR TITLE
OTA-1279: pkg/cli/admin/upgrade/status: Move Failing from free-form to updateInsight

### DIFF
--- a/pkg/cli/admin/upgrade/status/controlplane_test.go
+++ b/pkg/cli/admin/upgrade/status/controlplane_test.go
@@ -126,6 +126,11 @@ func (c *coBuilder) annotated(annotations map[string]string) *coBuilder {
 var cvFixture = configv1.ClusterVersion{
 	Status: configv1.ClusterVersionStatus{
 		Desired: configv1.Release{Version: "new"},
+		Conditions: []configv1.ClusterOperatorStatusCondition{{
+			Type:   clusterStatusFailing,
+			Status: configv1.ConditionFalse,
+			Reason: "AsExpected",
+		}},
 	},
 }
 

--- a/pkg/cli/admin/upgrade/status/examples/4.14.1-degraded.detailed-output
+++ b/pkg/cli/admin/upgrade/status/examples/4.14.1-degraded.detailed-output
@@ -1,11 +1,5 @@
 An update is in progress for 1h58m50s: Unable to apply 4.14.1: wait has exceeded 40 minutes for these operators: etcd, kube-apiserver
 
-Failing=True:
-
-  Reason: ClusterOperatorsDegraded
-  Message: Cluster operators etcd, kube-apiserver are degraded
-
-
 = Control Plane =
 Assessment:      Progressing
 Completion:      97%
@@ -79,3 +73,12 @@ Message: Cluster Operator control-plane-machine-set is unavailable (UnavailableR
   Resources:
     clusteroperators.config.openshift.io: control-plane-machine-set
   Description: Missing 1 available replica(s)
+
+Message: Cluster Version version is failing to proceed with the update (ClusterOperatorsDegraded)
+  Since:       0s
+  Level:       Warning
+  Impact:      Update Stalled
+  Reference:   https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/ClusterOperatorDegraded.md
+  Resources:
+    clusterversions.config.openshift.io: version
+  Description: Cluster operators etcd, kube-apiserver are degraded

--- a/pkg/cli/admin/upgrade/status/examples/4.14.1-degraded.output
+++ b/pkg/cli/admin/upgrade/status/examples/4.14.1-degraded.output
@@ -1,11 +1,5 @@
 An update is in progress for 1h58m50s: Unable to apply 4.14.1: wait has exceeded 40 minutes for these operators: etcd, kube-apiserver
 
-Failing=True:
-
-  Reason: ClusterOperatorsDegraded
-  Message: Cluster operators etcd, kube-apiserver are degraded
-
-
 = Control Plane =
 Assessment:      Progressing
 Completion:      97%
@@ -33,11 +27,12 @@ ip-10-0-4-159.us-east-2.compute.internal    Outdated     Pending   4.14.0-rc.3  
 ip-10-0-99-40.us-east-2.compute.internal    Outdated     Pending   4.14.0-rc.3   ?     
 
 = Update Health =
-SINCE     LEVEL   IMPACT             MESSAGE
-58m18s    Error   API Availability   Cluster Operator kube-apiserver is degraded (NodeController_MasterNodesReady)
-58m18s    Error   API Availability   Cluster Operator kube-controller-manager is degraded (NodeController_MasterNodesReady)
-58m18s    Error   API Availability   Cluster Operator kube-scheduler is degraded (NodeController_MasterNodesReady)
-58m38s    Error   API Availability   Cluster Operator etcd is degraded (EtcdEndpoints_ErrorUpdatingEtcdEndpoints::EtcdMembers_UnhealthyMembers::NodeController_MasterNodesReady)
-1h0m17s   Error   API Availability   Cluster Operator control-plane-machine-set is unavailable (UnavailableReplicas)
+SINCE     LEVEL     IMPACT             MESSAGE
+58m18s    Error     API Availability   Cluster Operator kube-apiserver is degraded (NodeController_MasterNodesReady)
+58m18s    Error     API Availability   Cluster Operator kube-controller-manager is degraded (NodeController_MasterNodesReady)
+58m18s    Error     API Availability   Cluster Operator kube-scheduler is degraded (NodeController_MasterNodesReady)
+58m38s    Error     API Availability   Cluster Operator etcd is degraded (EtcdEndpoints_ErrorUpdatingEtcdEndpoints::EtcdMembers_UnhealthyMembers::NodeController_MasterNodesReady)
+1h0m17s   Error     API Availability   Cluster Operator control-plane-machine-set is unavailable (UnavailableReplicas)
+0s        Warning   Update Stalled     Cluster Version version is failing to proceed with the update (ClusterOperatorsDegraded)
 
 Run with --details=health for additional description and links to related online documentation

--- a/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.detailed-output
+++ b/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.detailed-output
@@ -1,11 +1,5 @@
 An update is in progress for 4h3m46s: Error while reconciling 4.16.0-ec.3: the cluster operator machine-config is degraded
 
-Failing=True:
-
-  Reason: ClusterOperatorDegraded
-  Message: Cluster operator machine-config is degraded
-
-
 = Control Plane =
 Assessment:      Completed
 Completion:      100%
@@ -151,6 +145,15 @@ Message: Node build0-gstfj-ci-tests-worker-c-dcz9p is degraded
   Resources:
     nodes: build0-gstfj-ci-tests-worker-c-dcz9p
   Description: failed to drain node: build0-gstfj-ci-tests-worker-c-dcz9p after 1 hour. Please see machine-config-controller logs for more information
+
+Message: Cluster Version version is failing to proceed with the update (ClusterOperatorDegraded)
+  Since:       0s
+  Level:       Warning
+  Impact:      Update Stalled
+  Reference:   https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/ClusterOperatorDegraded.md
+  Resources:
+    clusterversions.config.openshift.io: version
+  Description: Cluster operator machine-config is degraded
 
 Message: Node build0-gstfj-ci-tests-worker-c-jq5rk is unavailable
   Since:       -

--- a/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.output
+++ b/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.output
@@ -1,11 +1,5 @@
 An update is in progress for 4h3m46s: Error while reconciling 4.16.0-ec.3: the cluster operator machine-config is degraded
 
-Failing=True:
-
-  Reason: ClusterOperatorDegraded
-  Message: Cluster operator machine-config is degraded
-
-
 = Control Plane =
 Assessment:      Completed
 Completion:      100%
@@ -51,6 +45,7 @@ SINCE   LEVEL     IMPACT           MESSAGE
 -       Error     Update Stalled   Node build0-gstfj-ci-tests-worker-b-jv5bg is degraded
 -       Error     Update Stalled   Node build0-gstfj-ci-tests-worker-b-kj6gk is degraded
 -       Error     Update Stalled   Node build0-gstfj-ci-tests-worker-c-dcz9p is degraded
+0s      Warning   Update Stalled   Cluster Version version is failing to proceed with the update (ClusterOperatorDegraded)
 -       Warning   Update Speed     Node build0-gstfj-ci-tests-worker-c-jq5rk is unavailable
 
 Run with --details=health for additional description and links to related online documentation

--- a/pkg/cli/admin/upgrade/status/status.go
+++ b/pkg/cli/admin/upgrade/status/status.go
@@ -23,12 +23,6 @@ import (
 	"github.com/openshift/oc/pkg/cli/admin/upgrade/status/mco"
 )
 
-const (
-	// clusterStatusFailing is set on the ClusterVersion status when a cluster
-	// cannot reach the desired state.
-	clusterStatusFailing = configv1.ClusterStatusConditionType("Failing")
-)
-
 func newOptions(streams genericiooptions.IOStreams) *options {
 	return &options{
 		IOStreams: streams,
@@ -251,14 +245,6 @@ func (o *options) Run(ctx context.Context) error {
 	}
 	updatingFor := now.Sub(startedAt).Round(time.Second)
 	fmt.Fprintf(o.Out, "An update is in progress for %s: %s\n", updatingFor, progressing.Message)
-
-	if c := findClusterOperatorStatusCondition(cv.Status.Conditions, clusterStatusFailing); c != nil {
-		if c.Status != configv1.ConditionFalse {
-			fmt.Fprintf(o.Out, "\n%s=%s:\n\n  Reason: %s\n  Message: %s\n\n", c.Type, c.Status, c.Reason, strings.ReplaceAll(c.Message, "\n", "\n  "))
-		}
-	} else {
-		fmt.Fprintf(o.ErrOut, "warning: No current %s info, see `oc describe clusterversion` for more details.\n", clusterStatusFailing)
-	}
 
 	controlPlaneStatusData, insights := assessControlPlaneStatus(cv, operators.Items, now)
 	updateInsights = append(updateInsights, insights...)


### PR DESCRIPTION
Structure this output, so it gets all the usual pretty-printing, detail, etc. that the sad-ClusterOperator conditions are getting. Sometimes `Failing` will complain about sad ClusterOperators, and in that case we'll double up on that messaging.  But we're punting on "consolidate when multiple `updateInsights` complain about the same root cause" for now.  And sometimes `Failing` will complain about other resources, such as [`ProgressDeadlineExceeded` operator Deployments][1], and in that case the information is only flowing out through ClusterVersion, and not via the other resources we check when rendering status.

[1]: https://github.com/openshift/cluster-version-operator/blob/1acac06742fb0e3e49ffe2294864007f26a7799d/lib/resourcebuilder/apps.go#L122C124-L122C148