### PR TITLE
OTA-1174: `update status`: unify on `--details`

### DIFF
--- a/pkg/cli/admin/upgrade/status/examples/README.md
+++ b/pkg/cli/admin/upgrade/status/examples/README.md
@@ -7,7 +7,7 @@ Each example consists of five inputs and two outputs, matched by a common substr
 4.  `TESTCASE-mcp.yaml`(input): list of MachineConfigPools (created by `oc get machineconfigpools -o yaml`)
 5.  `TESTCASE-node.yaml`(input): list of Nodes (created by `oc get nodes -o yaml`)
 6. `TESTCASE.output`(output): expected output of `oc adm upgrade status`
-7. `TESTCASE.detailed-output`(output): expected output of `oc adm upgrade status --detailed=all`
+7. `TESTCASE.detailed-output`(output): expected output of `oc adm upgrade status --details=all`
 
 The `TestExamples` test in `examples_test.go` file above validates all examples. When the testcase
 is executed with a non-empty `UPDATE` environmental variable, it will update the `TESTCASE.out`

--- a/pkg/cli/admin/upgrade/status/status.go
+++ b/pkg/cli/admin/upgrade/status/status.go
@@ -59,7 +59,7 @@ func New(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command 
 	// TODO: We can remove these flags once the idea about `oc adm upgrade status` stabilizes and the command
 	//       is promoted out of the OC_ENABLE_CMD_UPGRADE_STATUS feature gate
 	flags.StringVar(&o.mockData.cvPath, "mock-clusterversion", "", "Path to a YAML ClusterVersion object to use for testing (will be removed later). Files in the same directory with the same name and suffixes -co.yaml, -mcp.yaml, -mc.yaml, and -node.yaml are required.")
-	flags.StringVar(&o.detailedOutput, "detailed", "none", fmt.Sprintf("Show detailed output in selected section. One of: %s", strings.Join(detailedOutputAllValues, ", ")))
+	flags.StringVar(&o.detailedOutput, "details", "none", fmt.Sprintf("Show detailed output in selected section. One of: %s", strings.Join(detailedOutputAllValues, ", ")))
 
 	return cmd
 }
@@ -85,7 +85,7 @@ func (o *options) Complete(f kcmdutil.Factory, cmd *cobra.Command, args []string
 	}
 
 	if !sets.New[string](detailedOutputAllValues...).Has(o.detailedOutput) {
-		return fmt.Errorf("invalid value for --detailed: %s (must be one of %s)", o.detailedOutput, strings.Join(detailedOutputAllValues, ", "))
+		return fmt.Errorf("invalid value for --details: %s (must be one of %s)", o.detailedOutput, strings.Join(detailedOutputAllValues, ", "))
 	}
 
 	cvSuffix := "-cv.yaml"


### PR DESCRIPTION
Previous commits used `--details` and `--detailed` inconsistently, lets unify on `--details` everywhere.
