### PR TITLE
WRKLDS-1251: Switch cli image to RHEL9 base image

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.21-openshift-4.16
+  tag: rhel-9-release-golang-1.21-openshift-4.16

--- a/images/cli-artifacts/Dockerfile.rhel
+++ b/images/cli-artifacts/Dockerfile.rhel
@@ -12,7 +12,7 @@ RUN make cross-build --warn-undefined-variables
 
 FROM registry.ci.openshift.org/ocp/4.16:cli
 
-COPY --from=builder /go/src/github.com/openshift/oc/_output/bin/ /usr/share/openshift/
+COPY --from=builder-rhel-9 /go/src/github.com/openshift/oc/_output/bin/ /usr/share/openshift/
 
 RUN cd /usr/share/openshift && \
     ln -sf /usr/share/openshift/linux_$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/')/oc /usr/bin/oc && \

--- a/images/cli/Dockerfile.rhel
+++ b/images/cli/Dockerfile.rhel
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
 WORKDIR /go/src/github.com/openshift/oc
 COPY . .
 RUN make build --warn-undefined-variables
 
-FROM registry.ci.openshift.org/ocp/4.16:base
+FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/oc/oc /usr/bin/
 RUN for i in kubectl openshift-deploy openshift-docker-build openshift-sti-build openshift-git-clone openshift-manage-dockerfile openshift-extract-image-content openshift-recycle; do ln -sf /usr/bin/oc /usr/bin/$i; done
 LABEL io.k8s.display-name="OpenShift Client" \

--- a/pkg/cli/debug/debug.go
+++ b/pkg/cli/debug/debug.go
@@ -1041,8 +1041,8 @@ func (o *DebugOptions) approximatePodTemplateForObject(object runtime.Object) (*
 			}
 		}
 		if len(image) == 0 {
-			klog.V(2).Infof("Falling to 'registry.redhat.io/rhel8/support-tools' image")
-			image = "registry.redhat.io/rhel8/support-tools"
+			klog.V(2).Infof("Falling to 'registry.redhat.io/rhel9/support-tools' image")
+			image = "registry.redhat.io/rhel9/support-tools"
 		}
 		zero := int64(0)
 		isTrue := true


### PR DESCRIPTION
This PR bumps the base image of cli image to RHEL9. This is the last remaining piece after the bump of tools image in https://github.com/openshift/oc/pull/1652. 