### PR TITLE
OTA-1154: pkg/cli/admin/upgrade/status: Drop free-form Progressing output line

### DIFF
--- a/pkg/cli/admin/upgrade/status/examples/4.14.1-degraded.detailed-output
+++ b/pkg/cli/admin/upgrade/status/examples/4.14.1-degraded.detailed-output
@@ -1,5 +1,3 @@
-An update is in progress for 1h58m50s: Unable to apply 4.14.1: wait has exceeded 40 minutes for these operators: etcd, kube-apiserver
-
 = Control Plane =
 Assessment:      Progressing
 Completion:      97%

--- a/pkg/cli/admin/upgrade/status/examples/4.14.1-degraded.output
+++ b/pkg/cli/admin/upgrade/status/examples/4.14.1-degraded.output
@@ -1,5 +1,3 @@
-An update is in progress for 1h58m50s: Unable to apply 4.14.1: wait has exceeded 40 minutes for these operators: etcd, kube-apiserver
-
 = Control Plane =
 Assessment:      Progressing
 Completion:      97%

--- a/pkg/cli/admin/upgrade/status/examples/4.14.1-paused-worker-pool.detailed-output
+++ b/pkg/cli/admin/upgrade/status/examples/4.14.1-paused-worker-pool.detailed-output
@@ -1,5 +1,3 @@
-An update is in progress for 6s: Working towards 4.14.1: 139 of 859 done (16% complete), waiting on kube-scheduler
-
 = Control Plane =
 Assessment:      Progressing
 Completion:      12%

--- a/pkg/cli/admin/upgrade/status/examples/4.14.1-paused-worker-pool.output
+++ b/pkg/cli/admin/upgrade/status/examples/4.14.1-paused-worker-pool.output
@@ -1,5 +1,3 @@
-An update is in progress for 6s: Working towards 4.14.1: 139 of 859 done (16% complete), waiting on kube-scheduler
-
 = Control Plane =
 Assessment:      Progressing
 Completion:      12%

--- a/pkg/cli/admin/upgrade/status/examples/4.14.1-workers-started-updating-multiple-pools.detailed-output
+++ b/pkg/cli/admin/upgrade/status/examples/4.14.1-workers-started-updating-multiple-pools.detailed-output
@@ -1,5 +1,3 @@
-An update is in progress for 14m4s: Working towards 4.14.1: 734 of 859 done (85% complete), waiting on machine-config
-
 = Control Plane =
 Assessment:      Progressing
 Completion:      97%

--- a/pkg/cli/admin/upgrade/status/examples/4.14.1-workers-started-updating-multiple-pools.output
+++ b/pkg/cli/admin/upgrade/status/examples/4.14.1-workers-started-updating-multiple-pools.output
@@ -1,5 +1,3 @@
-An update is in progress for 14m4s: Working towards 4.14.1: 734 of 859 done (85% complete), waiting on machine-config
-
 = Control Plane =
 Assessment:      Progressing
 Completion:      97%

--- a/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-b02-cos-not-annotated.detailed-output
+++ b/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-b02-cos-not-annotated.detailed-output
@@ -1,5 +1,3 @@
-An update is in progress for 52m56s: Working towards 4.15.0-ec.2: 357 of 1021 done (34% complete), waiting up to 40 minutes on cluster-api
-
 = Control Plane =
 Assessment:      Progressing
 Completion:      43%

--- a/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-b02-cos-not-annotated.output
+++ b/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-b02-cos-not-annotated.output
@@ -1,5 +1,3 @@
-An update is in progress for 52m56s: Working towards 4.15.0-ec.2: 357 of 1021 done (34% complete), waiting up to 40 minutes on cluster-api
-
 = Control Plane =
 Assessment:      Progressing
 Completion:      43%

--- a/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-early.detailed-output
+++ b/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-early.detailed-output
@@ -1,5 +1,3 @@
-An update is in progress for 1m29s: Working towards 4.15.0-ec.2: 106 of 863 done (12% complete), waiting on etcd, kube-apiserver
-
 = Control Plane =
 Assessment:      Progressing
 Completion:      3%

--- a/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-early.output
+++ b/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-early.output
@@ -1,5 +1,3 @@
-An update is in progress for 1m29s: Working towards 4.15.0-ec.2: 106 of 863 done (12% complete), waiting on etcd, kube-apiserver
-
 = Control Plane =
 Assessment:      Progressing
 Completion:      3%

--- a/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-unavailable-mco-20m.detailed-output
+++ b/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-unavailable-mco-20m.detailed-output
@@ -1,5 +1,3 @@
-An update is in progress for 58m53s: Working towards 4.15.0-ec.2: 110 of 863 done (12% complete), waiting up to 40 minutes on etcd
-
 = Control Plane =
 Assessment:      Progressing
 Completion:      97%

--- a/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-unavailable-mco-20m.output
+++ b/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-unavailable-mco-20m.output
@@ -1,5 +1,3 @@
-An update is in progress for 58m53s: Working towards 4.15.0-ec.2: 110 of 863 done (12% complete), waiting up to 40 minutes on etcd
-
 = Control Plane =
 Assessment:      Progressing
 Completion:      97%

--- a/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.detailed-output
+++ b/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.detailed-output
@@ -1,5 +1,3 @@
-An update is in progress for 4h3m46s: Error while reconciling 4.16.0-ec.3: the cluster operator machine-config is degraded
-
 = Control Plane =
 Assessment:      Completed
 Completion:      100%

--- a/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.output
+++ b/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.output
@@ -1,5 +1,3 @@
-An update is in progress for 4h3m46s: Error while reconciling 4.16.0-ec.3: the cluster operator machine-config is degraded
-
 = Control Plane =
 Assessment:      Completed
 Completion:      100%

--- a/pkg/cli/admin/upgrade/status/status.go
+++ b/pkg/cli/admin/upgrade/status/status.go
@@ -244,11 +244,9 @@ func (o *options) Run(ctx context.Context) error {
 		startedAt = cv.Status.History[0].StartedTime.Time
 	}
 	updatingFor := now.Sub(startedAt).Round(time.Second)
-	fmt.Fprintf(o.Out, "An update is in progress for %s: %s\n", updatingFor, progressing.Message)
 
 	controlPlaneStatusData, insights := assessControlPlaneStatus(cv, operators.Items, now)
 	updateInsights = append(updateInsights, insights...)
-	fmt.Fprintf(o.Out, "\n")
 	_ = controlPlaneStatusData.Write(o.Out)
 	controlPlanePoolStatusData.WriteNodes(o.Out, o.enabledDetailed(detailedOutputNodes))
 


### PR DESCRIPTION
Following up on 7977ec94ea (#1744), drop the remaining free-form output.  With this change, all happy-case stdout output should be via structured `updateInsight`.  The `Update Health` section at the end of the output is now the only cluster-scoped summary of overall update progress.  Generated the updated fixtures with:

```console
$ export OC_ENABLE_CMD_UPGRADE_STATUS=true
$ for X in pkg/cli/admin/upgrade/status/examples/*-cv.yaml; do ./oc adm upgrade status --mock-clusterversion "${X}" > "${X/-cv.yaml/.output}"; ./oc adm upgrade status --details=all --mock-clusterversion "${X}" > "${X/-cv.yaml/.detailed-output}"; done
```