### PR TITLE
OTA-1275: cli/admin/release/git: use optimized git flags

### DIFF
--- a/pkg/cli/admin/release/extract.go
+++ b/pkg/cli/admin/release/extract.go
@@ -636,7 +636,7 @@ func (o *ExtractOptions) extractGit(dir string) error {
 				case "":
 					klog.V(2).Infof("Checkout %s from %s ...", commit, repo)
 					buf.Reset()
-					if err := extractedRepo.CheckoutCommit(repo, commit); err != nil {
+					if err := extractedRepo.CheckoutCommit(repo, commit, buf, buf); err != nil {
 						once.Do(func() { hadErrors = true })
 						fmt.Fprintf(o.ErrOut, "error: checking out commit for %s: %v\n%s\n", repo, err, buf.String())
 						return

--- a/pkg/cli/admin/release/git.go
+++ b/pkg/cli/admin/release/git.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/url"
 	"os"
 	"os/exec"
@@ -68,7 +69,7 @@ func (g *git) ChangeContext(path string) (*git, error) {
 }
 
 func (g *git) Clone(repository string, out, errOut io.Writer) error {
-	cmd := exec.Command("git", "clone", repository, g.path)
+	cmd := exec.Command("git", "clone", "--filter=blob:none", "--bare", "--origin="+remoteNameForRepo(repository), repository, g.path)
 	cmd.Stdout = out
 	cmd.Stderr = errOut
 	return cmd.Run()
@@ -97,7 +98,13 @@ func (g *git) VerifyCommit(repo, commit string) (bool, error) {
 	return err == nil, nil
 }
 
-func (g *git) CheckoutCommit(repo, commit string) error {
+func (g *git) CheckoutCommit(repo, commit string, out, errOut io.Writer) error {
+	// to reduce size requirements, clones are normally bare; to checkout a git commit, we must convert it to a normal
+	// git directory
+	if err := g.ensureFullClone(out, errOut); err != nil {
+		return err
+	}
+
 	_, err := g.exec("checkout", commit)
 	if err == nil {
 		return nil
@@ -114,6 +121,46 @@ func (g *git) CheckoutCommit(repo, commit string) error {
 	}
 
 	return fmt.Errorf("could not locate commit %s", commit)
+}
+
+func (g *git) ensureFullClone(out, errOut io.Writer) error {
+	isBare, err := g.exec("config", "core.bare")
+	if err != nil {
+		return err
+	}
+	if isBare == "false\n" {
+		return nil
+	}
+	// move all files to a `.git` subdirectory
+	if err := os.Mkdir(filepath.Join(g.path, ".git"), 0755); err != nil {
+		return fmt.Errorf("Failed to create .git subdirectory: %v", err)
+	}
+	if err := filepath.WalkDir(g.path, func(path string, d fs.DirEntry, err error) error {
+		if path == g.path {
+			return nil
+		}
+		if d.Name() == ".git" {
+			return fs.SkipDir
+		}
+		if err := os.Rename(filepath.Join(path), filepath.Join(g.path, ".git", d.Name())); err != nil {
+			return fmt.Errorf("Failed to move bare git contents to .git subdirectory: %v", err)
+		}
+		if d.IsDir() {
+			return fs.SkipDir
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	if out, err := g.exec("config", "core.bare", "false"); err != nil {
+		return fmt.Errorf("Failed to mark git directory as not bare: %s", out)
+	}
+	out.Write([]byte(fmt.Sprintf("Converting %s to a non-bare git repo", g.path)))
+	cmd := exec.Command("git", "reset", "--hard")
+	cmd.Dir = g.path
+	cmd.Stdout = out
+	cmd.Stderr = errOut
+	return cmd.Run()
 }
 
 var reMatch = regexp.MustCompile(`^([a-zA-Z0-9\-\_]+)@([^:]+):(.+)$`)
@@ -303,7 +350,7 @@ func ensureCloneForRepo(dir string, repo string, alternateRepos []string, out, e
 			return nil, err
 		}
 	} else {
-		if err := ensureRemoteForRepo(extractedRepo, repo); err != nil {
+		if err := ensureFetchedRemoteForRepo(extractedRepo, repo); err != nil {
 			return nil, err
 		}
 	}
@@ -312,7 +359,7 @@ func ensureCloneForRepo(dir string, repo string, alternateRepos []string, out, e
 		if altRepo == repo {
 			continue
 		}
-		if err := ensureRemoteForRepo(extractedRepo, altRepo); err != nil {
+		if err := ensureFetchedRemoteForRepo(extractedRepo, altRepo); err != nil {
 			return nil, err
 		}
 	}
@@ -326,21 +373,16 @@ func remoteNameForRepo(repo string) string {
 	return repoName
 }
 
-func ensureRemoteForRepo(g *git, repo string) error {
-	repoName := remoteNameForRepo(repo)
-	if out, err := g.exec("remote", "add", repoName, repo); err != nil && !strings.Contains(out, "already exists") {
-		return gitOutputToError(err, out)
-	}
-	return nil
-}
-
 func ensureFetchedRemoteForRepo(g *git, repo string) error {
 	repoName := remoteNameForRepo(repo)
-	if out, err := g.exec("remote", "add", repoName, repo); err != nil && !strings.Contains(out, "already exists") {
-		return gitOutputToError(err, out)
-	}
-	if out, err := g.exec("fetch", repoName); err != nil {
-		return gitOutputToError(err, out)
+	remoteOut, err := g.exec("remote", "add", repoName, repo)
+	if !strings.Contains(remoteOut, "already exists") {
+		if err != nil {
+			return gitOutputToError(err, remoteOut)
+		}
+		if out, err := g.exec("fetch", "--filter=blob:none", repoName); err != nil {
+			return gitOutputToError(err, out)
+		}
 	}
 	return nil
 }

--- a/pkg/cli/admin/release/info.go
+++ b/pkg/cli/admin/release/info.go
@@ -93,7 +93,7 @@ func NewInfo(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Comm
 			a tag when verifying an image is recommended since it ensures an attacker cannot trick you
 			into installing an older, potentially vulnerable version.
 
-			The --bugs and --changelog flags will use git to clone the source of the release and display
+			The --bugs and --changelog flags will use git to clone the git history of the release and display
 			the code changes that occurred between the two release arguments. This operation is slow
 			and requires sufficient disk space on the selected drive to clone all repositories.
 


### PR DESCRIPTION
This commit adds back the code changes from #1708 now that the `tools` image is based on RHEL 9 and can properly run git with these flags.