### PR TITLE
OCPBUGS-33905: pkg/cli/admin/upgrade/rollback: Gate on OC_ENABLE_CMD_UPGRADE_ROLLBACK

### DIFF
--- a/pkg/cli/admin/upgrade/rollback/rollback.go
+++ b/pkg/cli/admin/upgrade/rollback/rollback.go
@@ -33,11 +33,12 @@ func New(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command 
 		Long: templates.LongDesc(`
 			Rollback the cluster to the previous release.
 
-			Only patch version rollbacks within the same z stream, e.g. 4.y.newer to 4.y.older, are supported.
-			Minor version rollbacks from 4.newer to 4.older are not supported.  Updates to releases other than
-			the most-recent previous release that the cluster was attempting are not supported.  Rolling back
-			re-exposes the cluster to all the bugs which had been fixed from 4.y.older to 4.y.newer.  In most
-			cases, you probably want to understand what's having trouble and roll forward with fixes.
+			Only patch version rollbacks within the same z stream, e.g. 4.y.newer to 4.y.older, are accepted by
+			the cluster-version operator.  Minor version rollbacks from 4.newer to 4.older are not accepted.
+			Updates to releases other than the most-recent previous release that the cluster was attempting are
+			not accepted.  Rolling back re-exposes the cluster to all the bugs which had been fixed from
+			4.y.older to 4.y.newer.  In most cases, you probably want to understand what is having trouble and
+			roll forward with fixes.
 		`),
 
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cli/admin/upgrade/upgrade.go
+++ b/pkg/cli/admin/upgrade/upgrade.go
@@ -118,7 +118,10 @@ func New(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command 
 	}
 
 	cmd.AddCommand(channel.New(f, streams))
-	cmd.AddCommand(rollback.New(f, streams))
+
+	if kcmdutil.FeatureGate("OC_ENABLE_CMD_UPGRADE_ROLLBACK").IsEnabled() {
+		cmd.AddCommand(rollback.New(f, streams))
+	}
 
 	return cmd
 }


### PR DESCRIPTION
In case the hidden-ness from 73074c32ba (#1642) is not sufficient to scare users away, add a gating environment variable.  We also use a gating env. var. for `status` (701c2eee92, #1554) and `inspect-alerts` (229c2a8460, #1674).

Also reword the LongDesc to avoid saying "supported" (which readers might misconstrue as "what Red Hat support will do if we open a case").  I'm just trying to talk about "what the cluster-version operator will do if you request a rollback", and hopefully the new wording makes this more clear.