### PR TITLE
OCPBUGS-32682: Fix the retrieval of API objects with an empty name

### DIFF
--- a/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining-node.yaml
+++ b/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining-node.yaml
@@ -1090,6 +1090,7 @@ items:
       annotations:
         cluster-autoscaler.kubernetes.io/scale-down-disabled: "true"
         machineconfiguration.openshift.io/controlPlaneTopology: HighlyAvailable
+        # This simulates ephemeral conditions when Nodes do not have all annotations we expect
         # machineconfiguration.openshift.io/currentConfig: rendered-worker-6b0cfe9b92e34c641ac59510e408b311
         machineconfiguration.openshift.io/desiredConfig: rendered-worker-6b0cfe9b92e34c641ac59510e408b311
         machineconfiguration.openshift.io/desiredDrain: uncordon-rendered-worker-6b0cfe9b92e34c641ac59510e408b311

--- a/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining-node.yaml
+++ b/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining-node.yaml
@@ -1090,7 +1090,7 @@ items:
       annotations:
         cluster-autoscaler.kubernetes.io/scale-down-disabled: "true"
         machineconfiguration.openshift.io/controlPlaneTopology: HighlyAvailable
-        machineconfiguration.openshift.io/currentConfig: rendered-worker-6b0cfe9b92e34c641ac59510e408b311
+        # machineconfiguration.openshift.io/currentConfig: rendered-worker-6b0cfe9b92e34c641ac59510e408b311
         machineconfiguration.openshift.io/desiredConfig: rendered-worker-6b0cfe9b92e34c641ac59510e408b311
         machineconfiguration.openshift.io/desiredDrain: uncordon-rendered-worker-6b0cfe9b92e34c641ac59510e408b311
         machineconfiguration.openshift.io/lastAppliedDrain: uncordon-rendered-worker-6b0cfe9b92e34c641ac59510e408b311

--- a/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.detailed-output
+++ b/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.detailed-output
@@ -29,7 +29,7 @@ build0-gstfj-ci-tests-worker-b-4h7pn                              Degraded      
 build0-gstfj-ci-tests-worker-b-jv5bg                              Degraded      Draining   4.16.0-ec.2   ?      failed to drain node: <node> after 1 hour. Please see machine-config-controller logs for more information
 build0-gstfj-ci-tests-worker-b-kj6gk                              Degraded      Draining   4.16.0-ec.2   ?      failed to drain node: <node> after 1 hour. Please see machine-config-controller logs for more information
 build0-gstfj-ci-tests-worker-c-dcz9p                              Degraded      Draining   4.16.0-ec.2   ?      failed to drain node: <node> after 1 hour. Please see machine-config-controller logs for more information
-build0-gstfj-ci-prowjobs-worker-d-ddnxd                           Unavailable   Pending    <unknown>     ?      Node is unavailable
+build0-gstfj-ci-prowjobs-worker-d-ddnxd                           Unavailable   Pending    ?             ?      Node is unavailable
 build0-gstfj-ci-tests-worker-c-jq5rk                              Unavailable   Updated    4.16.0-ec.3   -      Node is unavailable
 build0-gstfj-ci-tests-worker-c-2kz4m                              Progressing   Draining   4.16.0-ec.2   +30m   
 build0-gstfj-ci-tests-worker-c-55hpj                              Progressing   Draining   4.16.0-ec.2   +30m   

--- a/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.detailed-output
+++ b/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.detailed-output
@@ -18,7 +18,7 @@ build0-gstfj-m-2.c.openshift-ci-build-farm.internal   Completed    Updated   4.1
 Worker Pool:     worker
 Assessment:      Degraded
 Completion:      39%
-Worker Status:   59 Total, 46 Available, 5 Progressing, 36 Outdated, 12 Draining, 0 Excluded, 7 Degraded
+Worker Status:   59 Total, 45 Available, 5 Progressing, 36 Outdated, 12 Draining, 0 Excluded, 7 Degraded
 
 Worker Pool Nodes
 NAME                                                              ASSESSMENT    PHASE      VERSION       EST    MESSAGE
@@ -29,6 +29,7 @@ build0-gstfj-ci-tests-worker-b-4h7pn                              Degraded      
 build0-gstfj-ci-tests-worker-b-jv5bg                              Degraded      Draining   4.16.0-ec.2   ?      failed to drain node: <node> after 1 hour. Please see machine-config-controller logs for more information
 build0-gstfj-ci-tests-worker-b-kj6gk                              Degraded      Draining   4.16.0-ec.2   ?      failed to drain node: <node> after 1 hour. Please see machine-config-controller logs for more information
 build0-gstfj-ci-tests-worker-c-dcz9p                              Degraded      Draining   4.16.0-ec.2   ?      failed to drain node: <node> after 1 hour. Please see machine-config-controller logs for more information
+build0-gstfj-ci-prowjobs-worker-d-ddnxd                           Unavailable   Pending    <unknown>     ?      Node is unavailable
 build0-gstfj-ci-tests-worker-c-jq5rk                              Unavailable   Updated    4.16.0-ec.3   -      Node is unavailable
 build0-gstfj-ci-tests-worker-c-2kz4m                              Progressing   Draining   4.16.0-ec.2   +30m   
 build0-gstfj-ci-tests-worker-c-55hpj                              Progressing   Draining   4.16.0-ec.2   +30m   
@@ -41,7 +42,6 @@ build0-gstfj-ci-prowjobs-worker-c-f6dkk                           Outdated      
 build0-gstfj-ci-prowjobs-worker-c-kkm72                           Outdated      Pending    4.16.0-ec.2   ?      
 build0-gstfj-ci-prowjobs-worker-c-p5df7                           Outdated      Pending    4.16.0-ec.2   ?      
 build0-gstfj-ci-prowjobs-worker-c-tgrsc                           Outdated      Pending    4.16.0-ec.2   ?      
-build0-gstfj-ci-prowjobs-worker-d-ddnxd                           Outdated      Pending    4.16.0-ec.2   ?      
 build0-gstfj-ci-tests-worker-c-2c4vg                              Outdated      Pending    4.16.0-ec.2   ?      
 build0-gstfj-ci-tests-worker-c-5twk4                              Outdated      Pending    4.16.0-ec.2   ?      
 build0-gstfj-ci-tests-worker-c-65n48                              Outdated      Pending    4.16.0-ec.2   ?      
@@ -154,6 +154,15 @@ Message: Cluster Version version is failing to proceed with the update (ClusterO
   Resources:
     clusterversions.config.openshift.io: version
   Description: Cluster operator machine-config is degraded
+
+Message: Node build0-gstfj-ci-prowjobs-worker-d-ddnxd is unavailable
+  Since:       -
+  Level:       Warning
+  Impact:      Update Speed
+  Reference:   https://docs.openshift.com/container-platform/latest/post_installation_configuration/machine-configuration-tasks.html#understanding-the-machine-config-operator
+  Resources:
+    nodes: build0-gstfj-ci-prowjobs-worker-d-ddnxd
+  Description: Node is unavailable
 
 Message: Node build0-gstfj-ci-tests-worker-c-jq5rk is unavailable
   Since:       -

--- a/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.output
+++ b/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.output
@@ -18,7 +18,7 @@ build0-gstfj-m-2.c.openshift-ci-build-farm.internal   Completed    Updated   4.1
 Worker Pool:     worker
 Assessment:      Degraded
 Completion:      39%
-Worker Status:   59 Total, 46 Available, 5 Progressing, 36 Outdated, 12 Draining, 0 Excluded, 7 Degraded
+Worker Status:   59 Total, 45 Available, 5 Progressing, 36 Outdated, 12 Draining, 0 Excluded, 7 Degraded
 
 Worker Pool Nodes
 NAME                                      ASSESSMENT    PHASE      VERSION       EST    MESSAGE
@@ -29,11 +29,11 @@ build0-gstfj-ci-tests-worker-b-4h7pn      Degraded      Draining   4.16.0-ec.2  
 build0-gstfj-ci-tests-worker-b-jv5bg      Degraded      Draining   4.16.0-ec.2   ?      failed to drain node: <node> after 1 hour. Please see machine-config-controller logs for more information
 build0-gstfj-ci-tests-worker-b-kj6gk      Degraded      Draining   4.16.0-ec.2   ?      failed to drain node: <node> after 1 hour. Please see machine-config-controller logs for more information
 build0-gstfj-ci-tests-worker-c-dcz9p      Degraded      Draining   4.16.0-ec.2   ?      failed to drain node: <node> after 1 hour. Please see machine-config-controller logs for more information
+build0-gstfj-ci-prowjobs-worker-d-ddnxd   Unavailable   Pending    <unknown>     ?      Node is unavailable
 build0-gstfj-ci-tests-worker-c-jq5rk      Unavailable   Updated    4.16.0-ec.3   -      Node is unavailable
 build0-gstfj-ci-tests-worker-c-2kz4m      Progressing   Draining   4.16.0-ec.2   +30m   
-build0-gstfj-ci-tests-worker-c-55hpj      Progressing   Draining   4.16.0-ec.2   +30m   
 ...
-Omitted additional 49 Total, 22 Completed, 46 Available, 3 Progressing, 27 Outdated, 3 Draining, 0 Excluded, and 0 Degraded nodes.
+Omitted additional 49 Total, 22 Completed, 45 Available, 4 Progressing, 27 Outdated, 4 Draining, 0 Excluded, and 0 Degraded nodes.
 Pass along --details=nodes to see all information.
 
 = Update Health =
@@ -46,6 +46,7 @@ SINCE   LEVEL     IMPACT           MESSAGE
 -       Error     Update Stalled   Node build0-gstfj-ci-tests-worker-b-kj6gk is degraded
 -       Error     Update Stalled   Node build0-gstfj-ci-tests-worker-c-dcz9p is degraded
 0s      Warning   Update Stalled   Cluster Version version is failing to proceed with the update (ClusterOperatorDegraded)
+-       Warning   Update Speed     Node build0-gstfj-ci-prowjobs-worker-d-ddnxd is unavailable
 -       Warning   Update Speed     Node build0-gstfj-ci-tests-worker-c-jq5rk is unavailable
 
 Run with --details=health for additional description and links to related online documentation

--- a/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.output
+++ b/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.output
@@ -29,7 +29,7 @@ build0-gstfj-ci-tests-worker-b-4h7pn      Degraded      Draining   4.16.0-ec.2  
 build0-gstfj-ci-tests-worker-b-jv5bg      Degraded      Draining   4.16.0-ec.2   ?      failed to drain node: <node> after 1 hour. Please see machine-config-controller logs for more information
 build0-gstfj-ci-tests-worker-b-kj6gk      Degraded      Draining   4.16.0-ec.2   ?      failed to drain node: <node> after 1 hour. Please see machine-config-controller logs for more information
 build0-gstfj-ci-tests-worker-c-dcz9p      Degraded      Draining   4.16.0-ec.2   ?      failed to drain node: <node> after 1 hour. Please see machine-config-controller logs for more information
-build0-gstfj-ci-prowjobs-worker-d-ddnxd   Unavailable   Pending    <unknown>     ?      Node is unavailable
+build0-gstfj-ci-prowjobs-worker-d-ddnxd   Unavailable   Pending    ?             ?      Node is unavailable
 build0-gstfj-ci-tests-worker-c-jq5rk      Unavailable   Updated    4.16.0-ec.3   -      Node is unavailable
 build0-gstfj-ci-tests-worker-c-2kz4m      Progressing   Draining   4.16.0-ec.2   +30m   
 ...

--- a/pkg/cli/admin/upgrade/status/status.go
+++ b/pkg/cli/admin/upgrade/status/status.go
@@ -189,7 +189,11 @@ func (o *options) Run(ctx context.Context) error {
 		machineConfigs = &machineconfigv1.MachineConfigList{}
 		for _, node := range allNodes.Items {
 			for _, key := range []string{mco.CurrentMachineConfigAnnotationKey, mco.DesiredMachineConfigAnnotationKey} {
-				mc, err := getMachineConfig(ctx, o.MachineConfigClient, machineConfigs.Items, node.Annotations[key])
+				machineConfigName, ok := node.Annotations[key]
+				if !ok || machineConfigName == "" {
+					continue
+				}
+				mc, err := getMachineConfig(ctx, o.MachineConfigClient, machineConfigs.Items, machineConfigName)
 				if err != nil {
 					return err
 				}

--- a/pkg/cli/admin/upgrade/status/workerpool.go
+++ b/pkg/cli/admin/upgrade/status/workerpool.go
@@ -523,10 +523,15 @@ func (pool *poolDisplayData) WriteNodes(w io.Writer, detailed bool) {
 			}
 		}
 
+		version := node.Version
+		if version == "" {
+			version = "<unknown>"
+		}
+
 		_, _ = tabw.Write([]byte(node.Name + "\t"))
 		_, _ = tabw.Write([]byte(node.Assessment.String() + "\t"))
 		_, _ = tabw.Write([]byte(node.Phase.String() + "\t"))
-		_, _ = tabw.Write([]byte(node.Version + "\t"))
+		_, _ = tabw.Write([]byte(version + "\t"))
 		_, _ = tabw.Write([]byte(node.Estimate + "\t"))
 		_, _ = tabw.Write([]byte(node.Message + "\n"))
 	}

--- a/pkg/cli/admin/upgrade/status/workerpool.go
+++ b/pkg/cli/admin/upgrade/status/workerpool.go
@@ -147,16 +147,19 @@ func assessNodesStatus(cv *configv1.ClusterVersion, pool mcfgv1.MachineConfigPoo
 	var nodesStatusData []nodeDisplayData
 	var insights []updateInsight
 	for _, node := range nodes {
-		currentVersion := getOpenShiftVersionOfMachineConfig(machineConfigs, node.Annotations[mco.CurrentMachineConfigAnnotationKey])
-		desiredVersion := getOpenShiftVersionOfMachineConfig(machineConfigs, node.Annotations[mco.DesiredMachineConfigAnnotationKey])
+		currentVersion, foundCurrent := getOpenShiftVersionOfMachineConfig(machineConfigs, node.Annotations[mco.CurrentMachineConfigAnnotationKey])
+		desiredVersion, foundDesired := getOpenShiftVersionOfMachineConfig(machineConfigs, node.Annotations[mco.DesiredMachineConfigAnnotationKey])
 
 		isUnavailable := isNodeUnavailable(node, pool)
 		isDegraded := isNodeDegraded(node)
-		isUpdated := isNodeUpdated(cv, currentVersion)
-		isUpdating := isNodeUpdating(cv, currentVersion, desiredVersion)
+		isUpdated := foundCurrent && isLatestUpdateHistoryVersionEqualTo(cv.Status.History, currentVersion)
+
+		// foundCurrent makes sure we don't blip phase "updating" for nodes that we are not sure
+		// of their actual phase, even though the conservative assumption is that the node is
+		// at least updating or is updated.
+		isUpdating := !isUpdated && foundCurrent && foundDesired && isLatestUpdateHistoryVersionEqualTo(cv.Status.History, desiredVersion)
 
 		phase := calculatePhase(pool, node, isUpdating, isUpdated)
-
 		var estimate string
 		var assessment nodeAssessment
 		switch phase {
@@ -228,18 +231,24 @@ func assessNodesStatus(cv *configv1.ClusterVersion, pool mcfgv1.MachineConfigPoo
 	return nodesStatusData, insights
 }
 
-func getOpenShiftVersionOfMachineConfig(machineConfigs []mcfgv1.MachineConfig, name string) string {
+func getOpenShiftVersionOfMachineConfig(machineConfigs []mcfgv1.MachineConfig, name string) (string, bool) {
 	for _, mc := range machineConfigs {
 		if mc.Name == name {
-			return mc.Annotations[mco.ReleaseImageVersionAnnotationKey]
+			openshiftVersion := mc.Annotations[mco.ReleaseImageVersionAnnotationKey]
+			return openshiftVersion, openshiftVersion != ""
 		}
 	}
-	return "?"
+	return "", false
 }
 
 func isNodeDraining(node corev1.Node, isUpdating bool) bool {
 	desiredDrain := node.Annotations[mco.DesiredDrainerAnnotationKey]
 	appliedDrain := node.Annotations[mco.LastAppliedDrainerAnnotationKey]
+
+	if appliedDrain == "" || desiredDrain == "" {
+		return false
+	}
+
 	if desiredDrain != appliedDrain {
 		desiredVerb := strings.Split(desiredDrain, "-")[0]
 		if desiredVerb == mco.DrainerStateDrain {
@@ -248,7 +257,7 @@ func isNodeDraining(node corev1.Node, isUpdating bool) bool {
 	}
 
 	mcdState := node.Annotations[mco.MachineConfigDaemonStateAnnotationKey]
-	if isUpdating && mcdUpdatingStateToPhase(mcdState) == phaseStateUpdated {
+	if isUpdating && mcdState == mco.MachineConfigDaemonStateDone {
 		// Node is supposed to be updating but MCD hasn't had the time to update
 		// its state from original `Done` to `Working` and start the drain process.
 		// Default to drain process so that we don't report completed.
@@ -257,15 +266,11 @@ func isNodeDraining(node corev1.Node, isUpdating bool) bool {
 	return false
 }
 
-func isNodeUpdating(cv *configv1.ClusterVersion, currentNodeVersion string, desiredNodeVersion string) bool {
-	return !isNodeUpdated(cv, currentNodeVersion) && isNodeUpdated(cv, desiredNodeVersion)
-}
-
-func isNodeUpdated(cv *configv1.ClusterVersion, nodeVersion string) bool {
-	if len(cv.Status.History) > 0 {
+func isLatestUpdateHistoryVersionEqualTo(history []configv1.UpdateHistory, version string) bool {
+	if len(history) > 0 {
 		// Check the version of a node against the new entry in the history of CV
 		// A paused MCP will not contain the MC of the new history entry
-		return cv.Status.History[0].Version == nodeVersion
+		return history[0].Version == version
 	}
 	return false
 }


### PR DESCRIPTION
The main goal of this pull request is to fix an occurring error that resulted in the error
message: `error: resource name may not be empty`

This was caused by not checking the value of the
machineconfiguration.openshift.io/currentConfig and
machineconfiguration.openshift.io/desiredConfig annotations of nodes.

In the event, the annotation was not set or was empty, the command would
try to get a MachineConfig with an empty name from the API server.

The commit also adds additional functionalities and testing for cases
when different MCD annotations are missing.

The general strategy is to declare the states of nodes only when they
are provably in the specific states.

This pull request references https://issues.redhat.com//browse/OCPBUGS-32682