### PR TITLE
OCPBUGS-33651: Add s390x based oc into extraction target

### DIFF
--- a/images/cli-artifacts/Dockerfile.rhel
+++ b/images/cli-artifacts/Dockerfile.rhel
@@ -21,10 +21,12 @@ RUN cd /usr/share/openshift && \
 COPY --from=builder /go/src/github.com/openshift/oc/_output/bin/linux_amd64/oc /usr/share/openshift/linux_amd64/oc.rhel8
 COPY --from=builder /go/src/github.com/openshift/oc/_output/bin/linux_arm64/oc /usr/share/openshift/linux_arm64/oc.rhel8
 COPY --from=builder /go/src/github.com/openshift/oc/_output/bin/linux_ppc64le/oc /usr/share/openshift/linux_ppc64le/oc.rhel8
+COPY --from=builder /go/src/github.com/openshift/oc/_output/bin/linux_s390x/oc /usr/share/openshift/linux_s390x/oc.rhel8
 
 COPY --from=builder-rhel-9 /go/src/github.com/openshift/oc/_output/bin/linux_amd64/oc /usr/share/openshift/linux_amd64/oc.rhel9
 COPY --from=builder-rhel-9 /go/src/github.com/openshift/oc/_output/bin/linux_arm64/oc /usr/share/openshift/linux_arm64/oc.rhel9
 COPY --from=builder-rhel-9 /go/src/github.com/openshift/oc/_output/bin/linux_ppc64le/oc /usr/share/openshift/linux_ppc64le/oc.rhel9
+COPY --from=builder-rhel-9 /go/src/github.com/openshift/oc/_output/bin/linux_s390x/oc /usr/share/openshift/linux_s390x/oc.rhel9
 
 COPY --from=builder /go/src/github.com/openshift/oc/LICENSE /usr/share/openshift/LICENSE
 

--- a/pkg/cli/admin/release/extract_tools.go
+++ b/pkg/cli/admin/release/extract_tools.go
@@ -367,6 +367,32 @@ func (o *ExtractOptions) extractCommand(command string) error {
 			TargetCommandName:    "oc",
 		},
 		{
+			OS:      "linux",
+			Arch:    "s390x",
+			Command: "oc.rhel9",
+			NewArch: true,
+			Mapping: extract.Mapping{Image: "cli-artifacts", From: "usr/share/openshift/linux_s390x/oc.rhel9"},
+
+			LinkTo:               []string{"kubectl"},
+			Readme:               readmeCLIUnix,
+			InjectReleaseVersion: true,
+			ArchiveFormat:        "openshift-client-linux-s390x-rhel9-%s.tar.gz",
+			TargetCommandName:    "oc",
+		},
+		{
+			OS:      "linux",
+			Arch:    "s390x",
+			Command: "oc.rhel8",
+			NewArch: true,
+			Mapping: extract.Mapping{Image: "cli-artifacts", From: "usr/share/openshift/linux_s390x/oc.rhel8"},
+
+			LinkTo:               []string{"kubectl"},
+			Readme:               readmeCLIUnix,
+			InjectReleaseVersion: true,
+			ArchiveFormat:        "openshift-client-linux-s390x-rhel8-%s.tar.gz",
+			TargetCommandName:    "oc",
+		},
+		{
 			OS:      "windows",
 			Arch:    "amd64",
 			Command: "oc",


### PR DESCRIPTION
Default oc compiled on s390x is only working on RHEL9 (after we have changed the base image to RHEL9). Therefore, users still on s390x RHEL8 are getting failures. 

This PR adds s390x based oc (both oc.rhel8 and oc.rhel9) into the extraction list. So that, users can explicitly use s390x based oc.rhel8.