### PR TITLE
OCPBUGS-33898: `adm update status`: Show information about the upgrade target version

### DIFF
--- a/pkg/cli/admin/upgrade/status/controlplane.go
+++ b/pkg/cli/admin/upgrade/status/controlplane.go
@@ -42,11 +42,25 @@ func (o operators) StatusSummary() string {
 	return strings.Join(res, ", ")
 }
 
+type versions struct {
+	target            string
+	previous          string
+	isPreviousPartial bool
+}
+
+func (v versions) String() string {
+	if v.isPreviousPartial {
+		return fmt.Sprintf("%s (from incomplete %s)", v.target, v.previous)
+	}
+	return fmt.Sprintf("%s (from %s)", v.target, v.previous)
+}
+
 type controlPlaneStatusDisplayData struct {
-	Assessment assessmentState
-	Completion float64
-	Duration   time.Duration
-	Operators  operators
+	Assessment    assessmentState
+	Completion    float64
+	Duration      time.Duration
+	Operators     operators
+	TargetVersion versions
 }
 
 const (
@@ -112,11 +126,12 @@ func assessControlPlaneStatus(cv *v1.ClusterVersion, operators []v1.ClusterOpera
 	targetVersion := cv.Status.Desired.Version
 	cvGvk := cv.GroupVersionKind()
 	cvGroupKind := scopeGroupKind{group: cvGvk.Group, kind: cvGvk.Kind}
+	cvScope := scopeResource{kind: cvGroupKind, name: cv.Name}
 
 	if c := findClusterOperatorStatusCondition(cv.Status.Conditions, clusterStatusFailing); c == nil {
 		insight := updateInsight{
 			startedAt: at,
-			scope:     updateInsightScope{scopeType: scopeTypeControlPlane, resources: []scopeResource{{kind: cvGroupKind, name: cv.Name}}},
+			scope:     updateInsightScope{scopeType: scopeTypeControlPlane, resources: []scopeResource{cvScope}},
 			impact: updateInsightImpact{
 				level:       warningImpactLevel,
 				impactType:  updateStalledImpactType,
@@ -182,7 +197,8 @@ func assessControlPlaneStatus(cv *v1.ClusterVersion, operators []v1.ClusterOpera
 		insights = append(insights, coInsights(operator.Name, available, degraded, at)...)
 	}
 
-	if completed == displayData.Operators.Total {
+	controlPlaneCompleted := completed == displayData.Operators.Total
+	if controlPlaneCompleted {
 		displayData.Assessment = assessmentStateCompleted
 	} else {
 		displayData.Assessment = assessmentStateProgressing
@@ -197,8 +213,59 @@ func assessControlPlaneStatus(cv *v1.ClusterVersion, operators []v1.ClusterOpera
 		}
 	}
 
+	versionData, versionInsights := versionsFromHistory(cv.Status.History, cvScope, controlPlaneCompleted)
+	displayData.TargetVersion = versionData
+	insights = append(insights, versionInsights...)
+
 	displayData.Completion = float64(completed) / float64(displayData.Operators.Total) * 100.0
 	return displayData, insights
+}
+
+func versionsFromHistory(history []v1.UpdateHistory, cvScope scopeResource, controlPlaneCompleted bool) (versions, []updateInsight) {
+	versionData := versions{
+		target:   "unknown",
+		previous: "unknown",
+	}
+	if len(history) > 0 {
+		versionData.target = history[0].Version
+	}
+	if len(history) > 1 {
+		versionData.previous = history[1].Version
+		versionData.isPreviousPartial = history[1].State == v1.PartialUpdate
+	}
+
+	var insights []updateInsight
+	if !controlPlaneCompleted && versionData.isPreviousPartial {
+		lastComplete := "unknown"
+		if len(history) > 2 {
+			for _, item := range history[2:] {
+				if item.State == v1.CompletedUpdate {
+					lastComplete = item.Version
+					break
+				}
+			}
+		}
+		insights = []updateInsight{
+			{
+				startedAt: history[0].StartedTime.Time,
+				scope: updateInsightScope{
+					scopeType: scopeTypeControlPlane,
+					resources: []scopeResource{cvScope},
+				},
+				impact: updateInsightImpact{
+					level:       warningImpactLevel,
+					impactType:  noneImpactType,
+					summary:     fmt.Sprintf("Previous update to %s never completed, last complete update was %s", versionData.previous, lastComplete),
+					description: fmt.Sprintf("Current update to %s was initiated while the previous update to version %s was still in progress", versionData.target, versionData.previous),
+				},
+				remediation: updateInsightRemediation{
+					reference: "https://docs.openshift.com/container-platform/latest/updating/troubleshooting_updates/gathering-data-cluster-update.html#gathering-clusterversion-history-cli_troubleshooting_updates",
+				},
+			},
+		}
+	}
+
+	return versionData, insights
 }
 
 var controlPlaneStatusTemplate = template.Must(template.New("controlPlaneStatus").Parse(controlPlaneStatusTemplateRaw))
@@ -209,6 +276,7 @@ func (d *controlPlaneStatusDisplayData) Write(f io.Writer) error {
 
 const controlPlaneStatusTemplateRaw = `= Control Plane =
 Assessment:      {{ .Assessment }}
+Target Version:  {{ .TargetVersion }}
 Completion:      {{ printf "%.0f" .Completion }}%
 Duration:        {{ .Duration }}
 Operator Status: {{ .Operators.StatusSummary }}

--- a/pkg/cli/admin/upgrade/status/controlplane.go
+++ b/pkg/cli/admin/upgrade/status/controlplane.go
@@ -45,10 +45,14 @@ func (o operators) StatusSummary() string {
 type versions struct {
 	target            string
 	previous          string
+	isTargetInstall   bool
 	isPreviousPartial bool
 }
 
 func (v versions) String() string {
+	if v.isTargetInstall {
+		return fmt.Sprintf("%s (a new install)", v.target)
+	}
 	if v.isPreviousPartial {
 		return fmt.Sprintf("%s (from incomplete %s)", v.target, v.previous)
 	}
@@ -228,6 +232,10 @@ func versionsFromHistory(history []v1.UpdateHistory, cvScope scopeResource, cont
 	}
 	if len(history) > 0 {
 		versionData.target = history[0].Version
+	}
+	if len(history) == 1 {
+		versionData.isTargetInstall = true
+		return versionData, nil
 	}
 	if len(history) > 1 {
 		versionData.previous = history[1].Version

--- a/pkg/cli/admin/upgrade/status/controlplane_test.go
+++ b/pkg/cli/admin/upgrade/status/controlplane_test.go
@@ -602,6 +602,7 @@ func Test_versionsFromHistory(t *testing.T) {
 				target:            "X.Y.Z",
 				previous:          "unknown",
 				isPreviousPartial: false,
+				isTargetInstall:   true,
 			},
 		},
 		{
@@ -618,6 +619,7 @@ func Test_versionsFromHistory(t *testing.T) {
 				target:            "X.Y.Z",
 				previous:          "unknown",
 				isPreviousPartial: false,
+				isTargetInstall:   true,
 			},
 		},
 		{

--- a/pkg/cli/admin/upgrade/status/examples/4.14.1-degraded.detailed-output
+++ b/pkg/cli/admin/upgrade/status/examples/4.14.1-degraded.detailed-output
@@ -1,5 +1,6 @@
 = Control Plane =
 Assessment:      Progressing
+Target Version:  4.14.1 (from 4.14.0-rc.3)
 Completion:      97%
 Duration:        1h58m50s
 Operator Status: 28 Healthy, 1 Unavailable, 4 Available but degraded

--- a/pkg/cli/admin/upgrade/status/examples/4.14.1-degraded.output
+++ b/pkg/cli/admin/upgrade/status/examples/4.14.1-degraded.output
@@ -1,5 +1,6 @@
 = Control Plane =
 Assessment:      Progressing
+Target Version:  4.14.1 (from 4.14.0-rc.3)
 Completion:      97%
 Duration:        1h58m50s
 Operator Status: 28 Healthy, 1 Unavailable, 4 Available but degraded

--- a/pkg/cli/admin/upgrade/status/examples/4.14.1-paused-worker-pool.detailed-output
+++ b/pkg/cli/admin/upgrade/status/examples/4.14.1-paused-worker-pool.detailed-output
@@ -1,5 +1,6 @@
 = Control Plane =
 Assessment:      Progressing
+Target Version:  4.14.1 (from 4.14.0)
 Completion:      12%
 Duration:        6s
 Operator Status: 33 Healthy

--- a/pkg/cli/admin/upgrade/status/examples/4.14.1-paused-worker-pool.output
+++ b/pkg/cli/admin/upgrade/status/examples/4.14.1-paused-worker-pool.output
@@ -1,5 +1,6 @@
 = Control Plane =
 Assessment:      Progressing
+Target Version:  4.14.1 (from 4.14.0)
 Completion:      12%
 Duration:        6s
 Operator Status: 33 Healthy

--- a/pkg/cli/admin/upgrade/status/examples/4.14.1-workers-started-updating-multiple-pools.detailed-output
+++ b/pkg/cli/admin/upgrade/status/examples/4.14.1-workers-started-updating-multiple-pools.detailed-output
@@ -1,5 +1,6 @@
 = Control Plane =
 Assessment:      Progressing
+Target Version:  4.14.1 (from 4.14.0)
 Completion:      97%
 Duration:        14m4s
 Operator Status: 32 Healthy, 1 Unavailable

--- a/pkg/cli/admin/upgrade/status/examples/4.14.1-workers-started-updating-multiple-pools.output
+++ b/pkg/cli/admin/upgrade/status/examples/4.14.1-workers-started-updating-multiple-pools.output
@@ -1,5 +1,6 @@
 = Control Plane =
 Assessment:      Progressing
+Target Version:  4.14.1 (from 4.14.0)
 Completion:      97%
 Duration:        14m4s
 Operator Status: 32 Healthy, 1 Unavailable

--- a/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-b02-cos-not-annotated.detailed-output
+++ b/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-b02-cos-not-annotated.detailed-output
@@ -1,5 +1,6 @@
 = Control Plane =
 Assessment:      Progressing
+Target Version:  4.15.0-ec.2 (from 4.15.0-ec.1)
 Completion:      43%
 Duration:        52m56s
 Operator Status: 7 Healthy

--- a/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-b02-cos-not-annotated.output
+++ b/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-b02-cos-not-annotated.output
@@ -1,5 +1,6 @@
 = Control Plane =
 Assessment:      Progressing
+Target Version:  4.15.0-ec.2 (from 4.15.0-ec.1)
 Completion:      43%
 Duration:        52m56s
 Operator Status: 7 Healthy

--- a/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-early-cv.yaml
+++ b/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-early-cv.yaml
@@ -86,7 +86,7 @@ status:
   - completionTime: "2023-11-01T12:29:27Z"
     image: quay.io/openshift-release-dev/ocp-release@sha256:05ba8e63f8a76e568afe87f182334504a01d47342b6ad5b4c3ff83a2463018bd
     startedTime: "2023-11-01T11:55:20Z"
-    state: Completed
+    state: Partial
     verified: true
     version: 4.14.1
   - completionTime: "2023-10-25T13:34:28Z"

--- a/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-early.detailed-output
+++ b/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-early.detailed-output
@@ -1,5 +1,6 @@
 = Control Plane =
 Assessment:      Progressing
+Target Version:  4.15.0-ec.2 (from incomplete 4.14.1)
 Completion:      3%
 Duration:        1m29s
 Operator Status: 33 Healthy
@@ -25,5 +26,11 @@ ip-10-0-4-159.us-east-2.compute.internal    Outdated     Pending   4.14.1    ?
 ip-10-0-99-40.us-east-2.compute.internal    Outdated     Pending   4.14.1    ?     
 
 = Update Health =
-SINCE   LEVEL   IMPACT   MESSAGE
-1m29s   Info    None     Upgrade is proceeding well
+Message: Previous update to 4.14.1 never completed, last complete update was 4.14.0-rc.7
+  Since:       1m29s
+  Level:       Warning
+  Impact:      None
+  Reference:   https://docs.openshift.com/container-platform/latest/updating/troubleshooting_updates/gathering-data-cluster-update.html#gathering-clusterversion-history-cli_troubleshooting_updates
+  Resources:
+    clusterversions.config.openshift.io: version
+  Description: Current update to 4.15.0-ec.2 was initiated while the previous update to version 4.14.1 was still in progress

--- a/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-early.output
+++ b/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-early.output
@@ -1,5 +1,6 @@
 = Control Plane =
 Assessment:      Progressing
+Target Version:  4.15.0-ec.2 (from incomplete 4.14.1)
 Completion:      3%
 Duration:        1m29s
 Operator Status: 33 Healthy
@@ -25,5 +26,7 @@ ip-10-0-4-159.us-east-2.compute.internal    Outdated     Pending   4.14.1    ?
 ip-10-0-99-40.us-east-2.compute.internal    Outdated     Pending   4.14.1    ?     
 
 = Update Health =
-SINCE   LEVEL   IMPACT   MESSAGE
-1m29s   Info    None     Upgrade is proceeding well
+SINCE   LEVEL     IMPACT   MESSAGE
+1m29s   Warning   None     Previous update to 4.14.1 never completed, last complete update was 4.14.0-rc.7
+
+Run with --details=health for additional description and links to related online documentation

--- a/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-unavailable-mco-20m.detailed-output
+++ b/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-unavailable-mco-20m.detailed-output
@@ -1,5 +1,6 @@
 = Control Plane =
 Assessment:      Progressing
+Target Version:  4.15.0-ec.2 (from 4.14.0-rc.3)
 Completion:      97%
 Duration:        58m53s
 Operator Status: 30 Healthy, 2 Unavailable, 1 Available but degraded

--- a/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-unavailable-mco-20m.output
+++ b/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-unavailable-mco-20m.output
@@ -1,5 +1,6 @@
 = Control Plane =
 Assessment:      Progressing
+Target Version:  4.15.0-ec.2 (from 4.14.0-rc.3)
 Completion:      97%
 Duration:        58m53s
 Operator Status: 30 Healthy, 2 Unavailable, 1 Available but degraded

--- a/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.detailed-output
+++ b/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.detailed-output
@@ -1,5 +1,6 @@
 = Control Plane =
 Assessment:      Completed
+Target Version:  4.16.0-ec.3 (from 4.16.0-ec.2)
 Completion:      100%
 Duration:        3h30m31s
 Operator Status: 35 Healthy, 1 Available but degraded

--- a/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.output
+++ b/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.output
@@ -1,5 +1,6 @@
 = Control Plane =
 Assessment:      Completed
+Target Version:  4.16.0-ec.3 (from 4.16.0-ec.2)
 Completion:      100%
 Duration:        3h30m31s
 Operator Status: 35 Healthy, 1 Available but degraded


### PR DESCRIPTION
This pull request will show additional information regarding the upgrade.

A new line in the control plane section shows information regarding the upgrade target version and the previous version.

For example:
```text
= Control Plane =
Assessment:      Progressing
Target Version:  4.14.1 (from 4.14.0)
Completion:      97%
Duration:        14m4s
Operator Status: 32 Healthy, 1 Unavailable
```

In the event that the previous update was an incomplete update (a partial update) and the control plane is currently updating, a new insight is generated, as this fact may influence the upgrade.

This pull request references https://issues.redhat.com/browse/OTA-1156