### PR TITLE
Tinify artifacts image

### DIFF
--- a/images/cli-artifacts/Dockerfile.rhel
+++ b/images/cli-artifacts/Dockerfile.rhel
@@ -3,30 +3,39 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16 AS builder
 WORKDIR /go/src/github.com/openshift/oc
 COPY . .
-RUN make cross-build --warn-undefined-variables
+
+RUN make build --warn-undefined-variables
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder-rhel-9
 WORKDIR /go/src/github.com/openshift/oc
 COPY . .
-RUN make cross-build --warn-undefined-variables
 
-FROM registry.ci.openshift.org/ocp/4.16:cli
+RUN make cross-build-linux-$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/') --warn-undefined-variables
 
+RUN if [ "$(uname -m)" == x86_64 ]; then \
+      make cross-build-darwin-amd64 --warn-undefined-variables && \
+      make cross-build-windows-amd64 --warn-undefined-variables; \
+    elif [ "$(uname -m)" == aarch64 ]; then \
+      make cross-build-darwin-arm64 --warn-undefined-variables; \
+    fi
+
+FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
+
+COPY --from=builder-rhel-9 /go/src/github.com/openshift/oc/LICENSE /usr/share/openshift/LICENSE
 COPY --from=builder-rhel-9 /go/src/github.com/openshift/oc/_output/bin/ /usr/share/openshift/
+COPY --from=builder /go/src/github.com/openshift/oc/oc /tmp/oc
 
 RUN cd /usr/share/openshift && \
-    ln -sf /usr/share/openshift/linux_$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/')/oc /usr/bin/oc && \
-    mv windows_amd64 windows && mv darwin_amd64 mac && mv darwin_arm64 mac_arm64
-
-COPY --from=builder /go/src/github.com/openshift/oc/_output/bin/linux_amd64/oc /usr/share/openshift/linux_amd64/oc.rhel8
-COPY --from=builder /go/src/github.com/openshift/oc/_output/bin/linux_arm64/oc /usr/share/openshift/linux_arm64/oc.rhel8
-COPY --from=builder /go/src/github.com/openshift/oc/_output/bin/linux_ppc64le/oc /usr/share/openshift/linux_ppc64le/oc.rhel8
-
-COPY --from=builder-rhel-9 /go/src/github.com/openshift/oc/_output/bin/linux_amd64/oc /usr/share/openshift/linux_amd64/oc.rhel9
-COPY --from=builder-rhel-9 /go/src/github.com/openshift/oc/_output/bin/linux_arm64/oc /usr/share/openshift/linux_arm64/oc.rhel9
-COPY --from=builder-rhel-9 /go/src/github.com/openshift/oc/_output/bin/linux_ppc64le/oc /usr/share/openshift/linux_ppc64le/oc.rhel9
-
-COPY --from=builder /go/src/github.com/openshift/oc/LICENSE /usr/share/openshift/LICENSE
+    arch=$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/') && \
+    mv /tmp/oc /usr/share/openshift/linux_$arch/oc.rhel8 && \
+    cp linux_$arch/oc linux_$arch/oc.rhel9 && \
+    ln -sf /usr/share/openshift/linux_$arch/oc.rhel9 /usr/bin/oc && \
+    for i in kubectl openshift-deploy openshift-docker-build openshift-sti-build openshift-git-clone openshift-manage-dockerfile openshift-extract-image-content openshift-recycle; do \
+      ln -sf /usr/bin/oc /usr/bin/$i; \
+    done && \
+    if [ -d windows_$arch ]; then mv windows_$arch windows; fi && \
+    if [ -d darwin_$arch ]; then mv darwin_$arch mac_$arch; fi && \
+    find /usr/share/openshift -type f
 
 LABEL io.k8s.display-name="OpenShift Clients" \
       io.k8s.description="OpenShift is a platform for developing, building, and deploying containerized applications." \


### PR DESCRIPTION
Currently, the cli-artifacts image compiles all of make-crossbuild targts on all arches. This means that on, say, the s390x image, the mac-arm and ppc64le artifacts are present. 

This change also proposes to not depend on the cli image, which will make image builds run in parallel.

To have a look at the `/usr/share/openshift` directory of the current image. In the end result, e.g. `current/amd64/` means the contents of the linux/amd64 version of the multi-arch brew image.

<details><summary>Current contents of cli-artifacts images</summary>


```
image=registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cli-artifacts-rhel9:v4.16.0-202405130811.p0.ge63d210.assembly.stream.el9
rm -rf current
for arch in amd64 arm64 ppc64le s390x; do
  mkdir -p current/$arch
  oc image extract --filter-by-os linux/$arch --path /usr/share/openshift/:$(pwd)/current/$arch $image
done
find current -type f | sort
```

```
current/amd64/LICENSE
current/amd64/linux_amd64/oc
current/amd64/linux_amd64/oc.rhel8
current/amd64/linux_amd64/oc.rhel9
current/amd64/linux_arm64/oc
current/amd64/linux_arm64/oc.rhel8
current/amd64/linux_arm64/oc.rhel9
current/amd64/linux_ppc64le/oc
current/amd64/linux_ppc64le/oc.rhel8
current/amd64/linux_ppc64le/oc.rhel9
current/amd64/linux_s390x/oc
current/amd64/mac_arm64/oc
current/amd64/mac/oc
current/amd64/windows/oc.exe
current/arm64/LICENSE
current/arm64/linux_amd64/oc
current/arm64/linux_amd64/oc.rhel8
current/arm64/linux_amd64/oc.rhel9
current/arm64/linux_arm64/oc
current/arm64/linux_arm64/oc.rhel8
current/arm64/linux_arm64/oc.rhel9
current/arm64/linux_ppc64le/oc
current/arm64/linux_ppc64le/oc.rhel8
current/arm64/linux_ppc64le/oc.rhel9
current/arm64/linux_s390x/oc
current/arm64/mac_arm64/oc
current/arm64/mac/oc
current/arm64/windows/oc.exe
current/ppc64le/LICENSE
current/ppc64le/linux_amd64/oc
current/ppc64le/linux_amd64/oc.rhel8
current/ppc64le/linux_amd64/oc.rhel9
current/ppc64le/linux_arm64/oc
current/ppc64le/linux_arm64/oc.rhel8
current/ppc64le/linux_arm64/oc.rhel9
current/ppc64le/linux_ppc64le/oc
current/ppc64le/linux_ppc64le/oc.rhel8
current/ppc64le/linux_ppc64le/oc.rhel9
current/ppc64le/linux_s390x/oc
current/ppc64le/mac_arm64/oc
current/ppc64le/mac/oc
current/ppc64le/windows/oc.exe
current/s390x/LICENSE
current/s390x/linux_amd64/oc
current/s390x/linux_amd64/oc.rhel8
current/s390x/linux_amd64/oc.rhel9
current/s390x/linux_arm64/oc
current/s390x/linux_arm64/oc.rhel8
current/s390x/linux_arm64/oc.rhel9
current/s390x/linux_ppc64le/oc
current/s390x/linux_ppc64le/oc.rhel8
current/s390x/linux_ppc64le/oc.rhel9
current/s390x/linux_s390x/oc
current/s390x/mac_arm64/oc
current/s390x/mac/oc
current/s390x/windows/oc.exe
```
</details>


This PR proposes to change that. It runs `make-cross-build-linux$(arch)` for rhel8 and rhel9, the windows and mac targets are only run when appropriately. [Test build](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3061553).


<details>
<summary>The new layout on disk with this change</summary>


```
image=registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cli-artifacts-rhel9:v4.16.0-202405160620.p0.gb12057f.assembly.test.el9
rm -rf tinified
for arch in amd64 arm64 ppc64le s390x; do
  mkdir -p tinified/$arch  oc image extract --filter-by-os linux/$arch --path /usr/share/openshift/:$(pwd)/tinified/$arch $image
done
find tinified -type f | sort
```

```
tinified/amd64/LICENSE
tinified/amd64/linux_amd64/oc
tinified/amd64/linux_amd64/oc.rhel8
tinified/amd64/linux_amd64/oc.rhel9
tinified/amd64/mac_amd64/oc
tinified/amd64/windows/oc.exe
tinified/arm64/LICENSE
tinified/arm64/linux_arm64/oc
tinified/arm64/linux_arm64/oc.rhel8
tinified/arm64/linux_arm64/oc.rhel9
tinified/arm64/mac_arm64/oc
tinified/ppc64le/LICENSE
tinified/ppc64le/linux_ppc64le/oc
tinified/ppc64le/linux_ppc64le/oc.rhel8
tinified/ppc64le/linux_ppc64le/oc.rhel9
tinified/s390x/LICENSE
tinified/s390x/linux_s390x/oc
tinified/s390x/linux_s390x/oc.rhel8
tinified/s390x/linux_s390x/oc.rhel9
```
</details>


With this, the combined size of the images gets reduced with more than half:
```
du -hs */*
1.7G	current/amd64
1.7G	current/arm64
1.7G	current/ppc64le
1.6G	current/s390x
701M	tinified/amd64
601M	tinified/arm64
455M	tinified/ppc64le
474M	tinified/s390x
```
