### PR TITLE
OCPBUGS-33762: Hardcode resource groups/kinds for now

### DIFF
--- a/pkg/cli/admin/upgrade/status/alerts.go
+++ b/pkg/cli/admin/upgrade/status/alerts.go
@@ -6,7 +6,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 )
 
-// Alerts that will be included in the health upgrade evaluation, even if they were triggered before the upgrade began.
+// AllowedAlerts will be included in the health upgrade evaluation, even if they were triggered before the upgrade began.
 type AllowedAlerts map[string]struct{}
 
 var allowedAlerts AllowedAlerts = map[string]struct{}{
@@ -42,7 +42,7 @@ type Alert struct {
 	PartialResponseStrategy string           `json:"partialResponseStrategy,omitempty"`
 }
 
-// Stores alert data returned by thanos
+// AlertData stores alert data returned by thanos
 type AlertData struct {
 	Status string `json:"status"`
 	Data   Data   `json:"data"`
@@ -53,8 +53,8 @@ type Data struct {
 }
 
 func parseAlertDataToInsights(alertData AlertData, startedAt time.Time) []updateInsight {
-	var alerts []Alert = alertData.Data.Alerts
-	var updateInsights []updateInsight = []updateInsight{}
+	var alerts = alertData.Data.Alerts
+	var updateInsights []updateInsight
 
 	for _, alert := range alerts {
 		if startedAt.After(alert.ActiveAt) && !allowedAlerts.Contains(alert.Labels.AlertName) {

--- a/pkg/cli/admin/upgrade/status/alerts_test.go
+++ b/pkg/cli/admin/upgrade/status/alerts_test.go
@@ -139,7 +139,7 @@ func TestParseAlertDataToInsightsWithData(t *testing.T) {
 				},
 			},
 			startedAt:        now,
-			expectedInsights: []updateInsight{},
+			expectedInsights: nil,
 		},
 	}
 

--- a/pkg/cli/admin/upgrade/status/controlplane.go
+++ b/pkg/cli/admin/upgrade/status/controlplane.go
@@ -22,6 +22,9 @@ const (
 	// clusterStatusFailing is set on the ClusterVersion status when a cluster
 	// cannot reach the desired state.
 	clusterStatusFailing = v1.ClusterStatusConditionType("Failing")
+
+	clusterVersionKind  string = "ClusterVersion"
+	clusterOperatorKind string = "ClusterOperator"
 )
 
 type operators struct {
@@ -75,7 +78,7 @@ const (
 )
 
 func coInsights(name string, available *v1.ClusterOperatorStatusCondition, degraded *v1.ClusterOperatorStatusCondition, evaluated time.Time) []updateInsight {
-	coGroupKind := scopeGroupKind{group: v1.GroupName, kind: "ClusterOperator"}
+	coGroupKind := scopeGroupKind{group: v1.GroupName, kind: clusterOperatorKind}
 	var insights []updateInsight
 	if available != nil && available.Status == v1.ConditionFalse && evaluated.After(available.LastTransitionTime.Time.Add(unavailableWarningThreshold)) {
 		insight := updateInsight{
@@ -128,8 +131,7 @@ func assessControlPlaneStatus(cv *v1.ClusterVersion, operators []v1.ClusterOpera
 	var insights []updateInsight
 
 	targetVersion := cv.Status.Desired.Version
-	cvGvk := cv.GroupVersionKind()
-	cvGroupKind := scopeGroupKind{group: cvGvk.Group, kind: cvGvk.Kind}
+	cvGroupKind := scopeGroupKind{group: v1.GroupName, kind: clusterVersionKind}
 	cvScope := scopeResource{kind: cvGroupKind, name: cv.Name}
 
 	if c := findClusterOperatorStatusCondition(cv.Status.Conditions, clusterStatusFailing); c == nil {

--- a/pkg/cli/admin/upgrade/status/workerpool.go
+++ b/pkg/cli/admin/upgrade/status/workerpool.go
@@ -59,6 +59,9 @@ const (
 	nodeAssessmentExcluded
 	nodeAssessmentOutdated
 	nodeAssessmentCompleted
+
+	nodeKind string = "Node"
+	mcpKind  string = "MachineConfigPool"
 )
 
 func (assessment nodeAssessment) String() string {
@@ -337,8 +340,7 @@ func nodeInsights(pool mcfgv1.MachineConfigPool, node corev1.Node, reason string
 	if pool.Name == "master" {
 		scope = scopeTypeControlPlane
 	}
-	nodeGvk := node.GroupVersionKind()
-	nodeGroupKind := scopeGroupKind{group: nodeGvk.Group, kind: nodeGvk.Kind}
+	nodeGroupKind := scopeGroupKind{kind: nodeKind}
 	if isUnavailable && !isUpdating {
 		insights = append(insights, updateInsight{
 			startedAt: time.Time{},
@@ -449,12 +451,12 @@ func machineConfigPoolInsights(poolDisplay poolDisplayData, pool mcfgv1.MachineC
 	// TODO: Only generate this insight if the pool has some work remaining that will not finish
 	// Depends on how MCO actually works: will it stop updating a node that already started e.g. draining?)
 	if poolDisplay.NodesOverview.Excluded > 0 && pool.Spec.Paused {
-		poolGvk := pool.GroupVersionKind()
+
 		insights = append(insights, updateInsight{
 			startedAt: time.Time{},
 			scope: updateInsightScope{
 				scopeType: scopeTypeWorkerPool,
-				resources: []scopeResource{{kind: scopeGroupKind{group: poolGvk.Group, kind: poolGvk.Kind}, name: pool.Name}},
+				resources: []scopeResource{{kind: scopeGroupKind{group: mcfgv1.GroupName, kind: mcpKind}, name: pool.Name}},
 			},
 			impact: updateInsightImpact{
 				level:       warningImpactLevel,


### PR DESCRIPTION
Previous code used `GroupVersionKind` method on actual resources to determine group/kind strings for them, but client-go unfortunately drops `TypeMeta` on resources processed by typed client (https://github.com/kubernetes/client-go/issues/1328, https://github.com/kubernetes/client-go/issues/541). Fortunately we know what types we build insights for, so we can use appropriate strings from client code for groups and hardcode kinds ourselves.
