### PR TITLE
OCPBUGS-32108: stop loading legacy schemes on global scheme 

### DIFF
--- a/pkg/cli/create/build.go
+++ b/pkg/cli/create/build.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util"
 	"k8s.io/kubectl/pkg/util/templates"
 
@@ -214,7 +213,7 @@ func (o *CreateBuildOptions) Run() error {
 		}
 	}
 
-	if err := util.CreateOrUpdateAnnotation(o.CreateSubcommandOptions.CreateAnnotation, build, scheme.DefaultJSONEncoder()); err != nil {
+	if err := util.CreateOrUpdateAnnotation(o.CreateSubcommandOptions.CreateAnnotation, build, createCmdJSONEncoder()); err != nil {
 		return err
 	}
 

--- a/pkg/cli/create/clusterquota.go
+++ b/pkg/cli/create/clusterquota.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util"
 	"k8s.io/kubectl/pkg/util/templates"
 
@@ -132,7 +131,7 @@ func (o *CreateClusterQuotaOptions) Run() error {
 		clusterQuota.Spec.Quota.Hard[corev1.ResourceName(tokens[0])] = quantity
 	}
 
-	if err := util.CreateOrUpdateAnnotation(o.CreateSubcommandOptions.CreateAnnotation, clusterQuota, scheme.DefaultJSONEncoder()); err != nil {
+	if err := util.CreateOrUpdateAnnotation(o.CreateSubcommandOptions.CreateAnnotation, clusterQuota, createCmdJSONEncoder()); err != nil {
 		return err
 	}
 

--- a/pkg/cli/create/create.go
+++ b/pkg/cli/create/create.go
@@ -7,7 +7,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/scheme"
 )
 
 // CreateSubcommandOptions is an options struct to support create subcommands
@@ -29,7 +28,7 @@ type CreateSubcommandOptions struct {
 
 func NewCreateSubcommandOptions(ioStreams genericiooptions.IOStreams) *CreateSubcommandOptions {
 	return &CreateSubcommandOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(createCmdScheme),
 		IOStreams:  ioStreams,
 	}
 }
@@ -76,5 +75,4 @@ func NameFromCommandArgs(cmd *cobra.Command, args []string) (string, error) {
 		return "", cmdutil.UsageErrorf(cmd, "exactly one NAME is required, got %d", argsLen)
 	}
 	return args[0], nil
-
 }

--- a/pkg/cli/create/deploymentconfig.go
+++ b/pkg/cli/create/deploymentconfig.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util"
 	"k8s.io/kubectl/pkg/util/templates"
 
@@ -106,7 +105,7 @@ func (o *CreateDeploymentConfigOptions) Run() error {
 		},
 	}
 
-	if err := util.CreateOrUpdateAnnotation(o.CreateSubcommandOptions.CreateAnnotation, deploymentConfig, scheme.DefaultJSONEncoder()); err != nil {
+	if err := util.CreateOrUpdateAnnotation(o.CreateSubcommandOptions.CreateAnnotation, deploymentConfig, createCmdJSONEncoder()); err != nil {
 		return err
 	}
 

--- a/pkg/cli/create/identity.go
+++ b/pkg/cli/create/identity.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/discovery"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util"
 	"k8s.io/kubectl/pkg/util/templates"
 
@@ -107,7 +106,7 @@ func (o *CreateIdentityOptions) Run() error {
 		ProviderUserName: o.ProviderUserName,
 	}
 
-	if err := util.CreateOrUpdateAnnotation(o.CreateSubcommandOptions.CreateAnnotation, identity, scheme.DefaultJSONEncoder()); err != nil {
+	if err := util.CreateOrUpdateAnnotation(o.CreateSubcommandOptions.CreateAnnotation, identity, createCmdJSONEncoder()); err != nil {
 		return err
 	}
 

--- a/pkg/cli/create/imagestream.go
+++ b/pkg/cli/create/imagestream.go
@@ -9,7 +9,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util"
 	"k8s.io/kubectl/pkg/util/templates"
 
@@ -94,7 +93,7 @@ func (o *CreateImageStreamOptions) Run() error {
 		},
 	}
 
-	if err := util.CreateOrUpdateAnnotation(o.CreateSubcommandOptions.CreateAnnotation, imageStream, scheme.DefaultJSONEncoder()); err != nil {
+	if err := util.CreateOrUpdateAnnotation(o.CreateSubcommandOptions.CreateAnnotation, imageStream, createCmdJSONEncoder()); err != nil {
 		return err
 	}
 

--- a/pkg/cli/create/imagestreamtag.go
+++ b/pkg/cli/create/imagestreamtag.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util"
 	"k8s.io/kubectl/pkg/util/templates"
 
@@ -177,7 +176,7 @@ func (o *CreateImageStreamTagOptions) Run() error {
 		}
 	}
 
-	if err := util.CreateOrUpdateAnnotation(o.CreateSubcommandOptions.CreateAnnotation, isTag, scheme.DefaultJSONEncoder()); err != nil {
+	if err := util.CreateOrUpdateAnnotation(o.CreateSubcommandOptions.CreateAnnotation, isTag, createCmdJSONEncoder()); err != nil {
 		return err
 	}
 

--- a/pkg/cli/create/route.go
+++ b/pkg/cli/create/route.go
@@ -12,20 +12,17 @@ import (
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util/templates"
 
 	routev1client "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 )
 
-var (
-	routeLong = templates.LongDesc(`
+var routeLong = templates.LongDesc(`
 		Expose containers externally via secured routes.
 
 		Three types of secured routes are supported: edge, passthrough, and reencrypt.
 		If you want to create unsecured routes, see "oc expose -h".
 	`)
-)
 
 // NewCmdCreateRoute is a macro command to create a secured route.
 func NewCmdCreateRoute(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
@@ -69,7 +66,7 @@ type CreateRouteSubcommandOptions struct {
 
 func NewCreateRouteSubcommandOptions(ioStreams genericiooptions.IOStreams) *CreateRouteSubcommandOptions {
 	return &CreateRouteSubcommandOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(createCmdScheme),
 		IOStreams:  ioStreams,
 	}
 }

--- a/pkg/cli/create/routeedge.go
+++ b/pkg/cli/create/routeedge.go
@@ -11,7 +11,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util"
 	"k8s.io/kubectl/pkg/util/templates"
 
@@ -133,7 +132,7 @@ func (o *CreateEdgeRouteOptions) Run() error {
 		route.Spec.TLS.InsecureEdgeTerminationPolicy = routev1.InsecureEdgeTerminationPolicyType(o.InsecurePolicy)
 	}
 
-	if err := util.CreateOrUpdateAnnotation(o.CreateRouteSubcommandOptions.CreateAnnotation, route, scheme.DefaultJSONEncoder()); err != nil {
+	if err := util.CreateOrUpdateAnnotation(o.CreateRouteSubcommandOptions.CreateAnnotation, route, createCmdJSONEncoder()); err != nil {
 		return err
 	}
 

--- a/pkg/cli/create/routepassthrough.go
+++ b/pkg/cli/create/routepassthrough.go
@@ -8,7 +8,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util"
 	"k8s.io/kubectl/pkg/util/templates"
 
@@ -99,7 +98,7 @@ func (o *CreatePassthroughRouteOptions) Run() error {
 		route.Spec.TLS.InsecureEdgeTerminationPolicy = routev1.InsecureEdgeTerminationPolicyType(o.InsecurePolicy)
 	}
 
-	if err := util.CreateOrUpdateAnnotation(o.CreateRouteSubcommandOptions.CreateAnnotation, route, scheme.DefaultJSONEncoder()); err != nil {
+	if err := util.CreateOrUpdateAnnotation(o.CreateRouteSubcommandOptions.CreateAnnotation, route, createCmdJSONEncoder()); err != nil {
 		return err
 	}
 

--- a/pkg/cli/create/routereenecrypt.go
+++ b/pkg/cli/create/routereenecrypt.go
@@ -8,7 +8,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util"
 	"k8s.io/kubectl/pkg/util/templates"
 
@@ -148,7 +147,7 @@ func (o *CreateReencryptRouteOptions) Run() error {
 		route.Spec.TLS.InsecureEdgeTerminationPolicy = routev1.InsecureEdgeTerminationPolicyType(o.InsecurePolicy)
 	}
 
-	if err := util.CreateOrUpdateAnnotation(o.CreateRouteSubcommandOptions.CreateAnnotation, route, scheme.DefaultJSONEncoder()); err != nil {
+	if err := util.CreateOrUpdateAnnotation(o.CreateRouteSubcommandOptions.CreateAnnotation, route, createCmdJSONEncoder()); err != nil {
 		return err
 	}
 

--- a/pkg/cli/create/scheme.go
+++ b/pkg/cli/create/scheme.go
@@ -1,0 +1,37 @@
+package create
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	"github.com/openshift/api"
+	"github.com/openshift/api/quota"
+	"github.com/openshift/api/route"
+
+	schemehelper "github.com/openshift/oc/pkg/helpers/scheme"
+)
+
+var (
+	createCmdScheme = runtime.NewScheme()
+	createCmdCodecs = serializer.NewCodecFactory(createCmdScheme)
+)
+
+func init() {
+	utilruntime.Must(api.InstallKube(createCmdScheme))
+	schemehelper.InstallSchemes(createCmdScheme)
+	// All the other commands can use route object
+	// as CRD and there is no benefit installing route
+	// as native object which is normally managed
+	// by openshift-apiserver(microshift has no openshift-apiserver).
+	// However, the create command requires routes for PrintObj,
+	// so we define a custom scheme and install routes here.
+	// see https://github.com/openshift/oc/pull/1534 for background.
+	utilruntime.Must(route.Install(createCmdScheme))
+	utilruntime.Must(quota.Install(createCmdScheme))
+}
+
+func createCmdJSONEncoder() runtime.Encoder {
+	return unstructured.NewJSONFallbackEncoder(createCmdCodecs.LegacyCodec(createCmdScheme.PrioritizedVersionsAllGroups()...))
+}

--- a/pkg/cli/create/user.go
+++ b/pkg/cli/create/user.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util"
 	"k8s.io/kubectl/pkg/util/templates"
 
@@ -96,7 +95,7 @@ func (o *CreateUserOptions) Run() error {
 		FullName: o.FullName,
 	}
 
-	if err := util.CreateOrUpdateAnnotation(o.CreateSubcommandOptions.CreateAnnotation, user, scheme.DefaultJSONEncoder()); err != nil {
+	if err := util.CreateOrUpdateAnnotation(o.CreateSubcommandOptions.CreateAnnotation, user, createCmdJSONEncoder()); err != nil {
 		return err
 	}
 

--- a/pkg/cli/create/user_identity_mapping.go
+++ b/pkg/cli/create/user_identity_mapping.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util"
 	"k8s.io/kubectl/pkg/util/templates"
 
@@ -126,7 +125,7 @@ func (o *CreateUserIdentityMappingOptions) Run() error {
 		User:     corev1.ObjectReference{Name: o.User},
 	}
 
-	if err := util.CreateOrUpdateAnnotation(o.CreateSubcommandOptions.CreateAnnotation, mapping, scheme.DefaultJSONEncoder()); err != nil {
+	if err := util.CreateOrUpdateAnnotation(o.CreateSubcommandOptions.CreateAnnotation, mapping, createCmdJSONEncoder()); err != nil {
 		return err
 	}
 

--- a/pkg/cli/expose/expose.go
+++ b/pkg/cli/expose/expose.go
@@ -13,7 +13,6 @@ import (
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/kubectl/pkg/cmd/expose"
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util"
 	"k8s.io/kubectl/pkg/util/completion"
 	"k8s.io/kubectl/pkg/util/templates"
@@ -159,7 +158,7 @@ func (o *ExposeOptions) Validate() error {
 
 func (o *ExposeOptions) Run() error {
 	r := o.Builder.
-		WithScheme(scheme.Scheme, scheme.Scheme.PrioritizedVersionsAllGroups()...).
+		WithScheme(exposeCmdScheme, exposeCmdScheme.PrioritizedVersionsAllGroups()...).
 		ContinueOnError().
 		NamespaceParam(o.Namespace).DefaultNamespace().
 		FilenameParam(o.EnforceNamespace, &o.ExposeServiceOptions.FilenameOptions).
@@ -191,7 +190,7 @@ func (o *ExposeOptions) Run() error {
 		route.Spec.Host = o.Hostname
 		route.Spec.Path = o.Path
 		route.Spec.WildcardPolicy = routev1.WildcardPolicyType(o.WildcardPolicy)
-		if err := util.CreateOrUpdateAnnotation(kcmdutil.GetFlagBool(o.Cmd, kcmdutil.ApplyAnnotationsFlag), route, scheme.DefaultJSONEncoder()); err != nil {
+		if err := util.CreateOrUpdateAnnotation(kcmdutil.GetFlagBool(o.Cmd, kcmdutil.ApplyAnnotationsFlag), route, exposeCmdJSONEncoder()); err != nil {
 			return err
 		}
 

--- a/pkg/cli/expose/expose.go
+++ b/pkg/cli/expose/expose.go
@@ -8,6 +8,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -77,8 +78,10 @@ type ExposeOptions struct {
 }
 
 func NewExposeFlags(streams genericiooptions.IOStreams) *ExposeFlags {
+	flags := expose.NewExposeFlags(streams)
+	flags.PrintFlags = genericclioptions.NewPrintFlags("exposed").WithTypeSetter(exposeCmdScheme)
 	return &ExposeFlags{
-		ExposeServiceFlags: expose.NewExposeFlags(streams),
+		ExposeServiceFlags: flags,
 	}
 }
 

--- a/pkg/cli/expose/scheme.go
+++ b/pkg/cli/expose/scheme.go
@@ -6,6 +6,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
+	"github.com/openshift/api"
 	"github.com/openshift/api/route"
 
 	schemehelper "github.com/openshift/oc/pkg/helpers/scheme"
@@ -17,6 +18,7 @@ var (
 )
 
 func init() {
+	utilruntime.Must(api.InstallKube(exposeCmdScheme))
 	schemehelper.InstallSchemes(exposeCmdScheme)
 	// All the other commands can use route object
 	// as CRD and there is no benefit installing route

--- a/pkg/cli/expose/scheme.go
+++ b/pkg/cli/expose/scheme.go
@@ -1,0 +1,33 @@
+package expose
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	"github.com/openshift/api/route"
+
+	schemehelper "github.com/openshift/oc/pkg/helpers/scheme"
+)
+
+var (
+	exposeCmdScheme = runtime.NewScheme()
+	exposeCmdCodecs = serializer.NewCodecFactory(exposeCmdScheme)
+)
+
+func init() {
+	schemehelper.InstallSchemes(exposeCmdScheme)
+	// All the other commands can use route object
+	// as CRD and there is no benefit installing route
+	// as native object which is normally managed
+	// by openshift-apiserver(microshift has no openshift-apiserver).
+	// However, the expose command requires routes for PrintObj,
+	// so we define a custom scheme and install routes here.
+	// see https://github.com/openshift/oc/pull/1534 for background.
+	utilruntime.Must(route.Install(exposeCmdScheme))
+}
+
+func exposeCmdJSONEncoder() runtime.Encoder {
+	return unstructured.NewJSONFallbackEncoder(exposeCmdCodecs.LegacyCodec(exposeCmdScheme.PrioritizedVersionsAllGroups()...))
+}

--- a/pkg/helpers/scheme/scheme.go
+++ b/pkg/helpers/scheme/scheme.go
@@ -16,8 +16,6 @@ import (
 	securityv1 "github.com/openshift/api/security/v1"
 	"github.com/openshift/api/template"
 	"github.com/openshift/api/user"
-
-	"github.com/openshift/oc/pkg/helpers/legacy"
 )
 
 func InstallSchemes(scheme *apimachineryruntime.Scheme) {
@@ -31,7 +29,6 @@ func InstallSchemes(scheme *apimachineryruntime.Scheme) {
 	utilruntime.Must(InstallNonCRDSecurity(scheme))
 	utilruntime.Must(template.Install(scheme))
 	utilruntime.Must(user.Install(scheme))
-	legacy.InstallExternalLegacyAll(scheme)
 }
 
 func InstallNonCRDSecurity(scheme *apimachineryruntime.Scheme) error {


### PR DESCRIPTION
for some reason, when loading ungroupified legacy schemes `oc set env` overrides `apiVersion` values of openshift objects, removing the api group, which makes them invalid in recent versions of openshift.

### what changed
* remove global loading of legacy schemes
* create custom schemes for create and expose commands
* override upstream expose print flag type setter to use the custom expose scheme
 
### testing
* regression tests for `oc`
* ensure that `oc set env` no longer overrides the `apiVersion` of routes and deployment configs
* ensure we don't regress https://issues.redhat.com/browse/OCPBUGS-15772; in other words, make sure `oc set route-backends` and `oc edit route` work in microshift
* ?