### PR TITLE
OCPBUGS-33896: `upgrade status`: polish alert insights

### DIFF
--- a/pkg/cli/admin/upgrade/status/alerts.go
+++ b/pkg/cli/admin/upgrade/status/alerts.go
@@ -31,6 +31,7 @@ type AlertAnnotations struct {
 	Description string `json:"description,omitempty"`
 	Summary     string `json:"summary,omitempty"`
 	Runbook     string `json:"runbook_url,omitempty"`
+	Message     string `json:"message,omitempty"`
 }
 
 type Alert struct {
@@ -57,27 +58,72 @@ func parseAlertDataToInsights(alertData AlertData, startedAt time.Time) []update
 	var updateInsights []updateInsight
 
 	for _, alert := range alerts {
-		if startedAt.After(alert.ActiveAt) && !allowedAlerts.Contains(alert.Labels.AlertName) {
+		var alertName string
+		if alertName = alert.Labels.AlertName; alertName == "" {
 			continue
 		}
+
+		var description string
+		startedDuringUpdate := startedAt.Before(alert.ActiveAt)
+		affectsUpdates := allowedAlerts.Contains(alertName)
+
+		if affectsUpdates {
+			if startedDuringUpdate {
+				description = "Alert known to affect updates started firing during the update."
+			} else {
+				description = "Alert known to affect updates has been firing since before the update started."
+			}
+		} else if startedDuringUpdate {
+			description = "Alert started firing during the update."
+		} else {
+			// Do not show alerts that were firing before the update started unless they are on the allowlist
+			continue
+		}
+
 		if alert.State == "pending" {
 			continue
 		}
+		var level impactLevel
+		if level = alertImpactLevel(alert.Labels.Severity); level < warningImpactLevel {
+			continue
+		}
+
+		var runbook string
+		if runbook = alert.Annotations.Runbook; runbook == "" {
+			runbook = "<alert does not have a runbook_url annotation>"
+		}
+
+		switch {
+		case alert.Annotations.Message != "" && alert.Annotations.Description != "":
+			description += " The alert description is: " + alert.Annotations.Description + " | " + alert.Annotations.Message
+		case alert.Annotations.Description != "":
+			description += " The alert description is: " + alert.Annotations.Description
+		case alert.Annotations.Message != "":
+			description += " The alert description is: " + alert.Annotations.Message
+		default:
+			description += " The alert has no description."
+		}
+
+		var summary string
+		if summary = alert.Annotations.Summary; summary == "" {
+			summary = alertName
+		}
+
 		updateInsights = append(updateInsights, updateInsight{
 			startedAt: alert.ActiveAt,
 			impact: updateInsightImpact{
-				level:       alertImpactLevel(alert.Labels.Severity),
+				level:       level,
 				impactType:  unknownImpactType,
-				summary:     "Alert: " + alert.Annotations.Summary,
-				description: alert.Annotations.Description,
+				summary:     "Alert is firing: " + summary,
+				description: description,
 			},
-			remediation: updateInsightRemediation{reference: alert.Annotations.Runbook},
+			remediation: updateInsightRemediation{reference: runbook},
 			scope: updateInsightScope{
 				scopeType: scopeTypeCluster,
 				resources: []scopeResource{{
 					kind:      scopeGroupKind{group: configv1.GroupName, kind: "Alert"},
 					namespace: alert.Labels.Namespace,
-					name:      alert.Labels.AlertName,
+					name:      alertName,
 				}},
 			},
 		})

--- a/pkg/cli/admin/upgrade/status/examples/4.14.1-degraded.detailed-output
+++ b/pkg/cli/admin/upgrade/status/examples/4.14.1-degraded.detailed-output
@@ -74,7 +74,7 @@ Message: Cluster Operator control-plane-machine-set is unavailable (UnavailableR
   Description: Missing 1 available replica(s)
 
 Message: Cluster Version version is failing to proceed with the update (ClusterOperatorsDegraded)
-  Since:       0s
+  Since:       now
   Level:       Warning
   Impact:      Update Stalled
   Reference:   https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/ClusterOperatorDegraded.md

--- a/pkg/cli/admin/upgrade/status/examples/4.14.1-degraded.output
+++ b/pkg/cli/admin/upgrade/status/examples/4.14.1-degraded.output
@@ -32,6 +32,6 @@ SINCE     LEVEL     IMPACT             MESSAGE
 58m18s    Error     API Availability   Cluster Operator kube-scheduler is degraded (NodeController_MasterNodesReady)
 58m38s    Error     API Availability   Cluster Operator etcd is degraded (EtcdEndpoints_ErrorUpdatingEtcdEndpoints::EtcdMembers_UnhealthyMembers::NodeController_MasterNodesReady)
 1h0m17s   Error     API Availability   Cluster Operator control-plane-machine-set is unavailable (UnavailableReplicas)
-0s        Warning   Update Stalled     Cluster Version version is failing to proceed with the update (ClusterOperatorsDegraded)
+now       Warning   Update Stalled     Cluster Version version is failing to proceed with the update (ClusterOperatorsDegraded)
 
 Run with --details=health for additional description and links to related online documentation

--- a/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-unavailable-mco-20m-alerts.json
+++ b/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-unavailable-mco-20m-alerts.json
@@ -178,12 +178,45 @@
                     "severity": "warning"
                 },
                 "annotations": {
-                    "description": "PodDisruptionBudgetAtLimit. in namespace <>",
+                    "description": "PodDisruptionBudgetAtLimit in namespace <>",
                     "runbook_url": "https://<mock_data>/PDB.md",
                     "summary": "PodDisruptionBudgetAtLimit for pods <>"
                 },
                 "state": "firing",
                 "activeAt": "2023-11-23T15:39:33.014999722Z",
+                "value": "6.708842592592593e-01",
+                "partialResponseStrategy": "WARN"
+            },
+            {
+                "labels": {
+                    "alertname": "PodDisruptionBudgetAtLimit",
+                    "controller": "alertmanager",
+                    "namespace": "openshift-monitoring",
+                    "severity": "warning"
+                },
+                "annotations": {
+                    "summary": "PodDisruptionBudgetAtLimit for some reason does not have runbook and description"
+                },
+                "state": "firing",
+                "activeAt": "2023-11-23T15:39:33.014999722Z",
+                "value": "6.708842592592593e-01",
+                "partialResponseStrategy": "WARN"
+            },
+            {
+                "labels": {
+                    "alertname": "PodDisruptionBudgetAtLimitWithMessage",
+                    "controller": "alertmanager",
+                    "namespace": "openshift-monitoring",
+                    "severity": "warning"
+                },
+                "annotations": {
+                    "summary": "This alert has a message, description, runbook and summary",
+                    "description": "This alert has a description",
+                    "runbook_url": "https://<mock_data>/runbook.md",
+                    "message": "This alert has a message, too"
+                },
+                "state": "firing",
+                "activeAt": "2023-11-24T15:31:52.75038242Z",
                 "value": "6.708842592592593e-01",
                 "partialResponseStrategy": "WARN"
             },

--- a/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-unavailable-mco-20m.detailed-output
+++ b/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-unavailable-mco-20m.detailed-output
@@ -35,20 +35,38 @@ Message: Cluster Operator machine-config is unavailable (MachineConfigController
     clusteroperators.config.openshift.io: machine-config
   Description: Cluster not available for [{operator 4.14.0-rc.3}]: ControllerConfig.machineconfiguration.openshift.io "machine-config-controller" is invalid: [status.controllerCertificates[0].notAfter: Required value, status.controllerCertificates[0].notBefore: Required value, status.controllerCertificates[1].notAfter: Required value, status.controllerCertificates[1].notBefore: Required value, status.controllerCertificates[2].notAfter: Required value, status.controllerCertificates[2].notBefore: Required value, status.controllerCertificates[3].notAfter: Required value, status.controllerCertificates[3].notBefore: Required value, status.controllerCertificates[4].notAfter: Required value, status.controllerCertificates[4].notBefore: Required value, status.controllerCertificates[5].notAfter: Required value, status.controllerCertificates[5].notBefore: Required value, status.controllerCertificates[6].notAfter: Required value, status.controllerCertificates[6].notBefore: Required value, status.controllerCertificates[7].notAfter: Required value, status.controllerCertificates[7].notBefore: Required value, status.controllerCertificates[8].notAfter: Required value, status.controllerCertificates[8].notBefore: Required value, status.controllerCertificates[9].notAfter: Required value, status.controllerCertificates[9].notBefore: Required value, <nil>: Invalid value: "null": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation]
 
-Message: Alert: Pod has been in a non-ready state for more than 15 minutes.
+Message: Alert is firing: Pod has been in a non-ready state for more than 15 minutes.
   Since:       6m35s
   Level:       Warning
   Impact:      Unknown
   Reference:   https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/KubePodNotReady.md
   Resources:
     alerts.config.openshift.io: openshift-kube-apiserver/KubePodNotReady
-  Description: Pod openshift-kube-apiserver/kube-apiserver-startup-monitor-ip-10-0-60-26.us-west-1.compute.internal has been in a non-ready state for longer than 15 minutes.
+  Description: Alert started firing during the update. The alert description is: Pod openshift-kube-apiserver/kube-apiserver-startup-monitor-ip-10-0-60-26.us-west-1.compute.internal has been in a non-ready state for longer than 15 minutes.
 
-Message: Alert: PodDisruptionBudgetAtLimit for pods <>
+Message: Alert is firing: This alert has a message, description, runbook and summary
+  Since:       16m35s
+  Level:       Warning
+  Impact:      Unknown
+  Reference:   https://<mock_data>/runbook.md
+  Resources:
+    alerts.config.openshift.io: openshift-monitoring/PodDisruptionBudgetAtLimitWithMessage
+  Description: Alert started firing during the update. The alert description is: This alert has a description | This alert has a message, too
+
+Message: Alert is firing: PodDisruptionBudgetAtLimit for pods <>
   Since:       24h8m54s
   Level:       Warning
   Impact:      Unknown
   Reference:   https://<mock_data>/PDB.md
   Resources:
     alerts.config.openshift.io: openshift-monitoring/PodDisruptionBudgetAtLimit
-  Description: PodDisruptionBudgetAtLimit. in namespace <>
+  Description: Alert known to affect updates has been firing since before the update started. The alert description is: PodDisruptionBudgetAtLimit in namespace <>
+
+Message: Alert is firing: PodDisruptionBudgetAtLimit for some reason does not have runbook and description
+  Since:       24h8m54s
+  Level:       Warning
+  Impact:      Unknown
+  Reference:   <alert does not have a runbook_url annotation>
+  Resources:
+    alerts.config.openshift.io: openshift-monitoring/PodDisruptionBudgetAtLimit
+  Description: Alert known to affect updates has been firing since before the update started. The alert has no description.

--- a/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-unavailable-mco-20m.output
+++ b/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-unavailable-mco-20m.output
@@ -28,7 +28,9 @@ ip-10-0-99-40.us-east-2.compute.internal    Outdated     Pending   4.14.0-rc.3  
 = Update Health =
 SINCE      LEVEL     IMPACT             MESSAGE
 20m24s     Error     API Availability   Cluster Operator machine-config is unavailable (MachineConfigControllerFailed)
-6m35s      Warning   Unknown            Alert: Pod has been in a non-ready state for more than 15 minutes.
-24h8m54s   Warning   Unknown            Alert: PodDisruptionBudgetAtLimit for pods <>
+6m35s      Warning   Unknown            Alert is firing: Pod has been in a non-ready state for more than 15 minutes.
+16m35s     Warning   Unknown            Alert is firing: This alert has a message, description, runbook and summary
+24h8m54s   Warning   Unknown            Alert is firing: PodDisruptionBudgetAtLimit for pods <>
+24h8m54s   Warning   Unknown            Alert is firing: PodDisruptionBudgetAtLimit for some reason does not have runbook and description
 
 Run with --details=health for additional description and links to related online documentation

--- a/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.detailed-output
+++ b/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.detailed-output
@@ -146,7 +146,7 @@ Message: Node build0-gstfj-ci-tests-worker-c-dcz9p is degraded
   Description: failed to drain node: build0-gstfj-ci-tests-worker-c-dcz9p after 1 hour. Please see machine-config-controller logs for more information
 
 Message: Cluster Version version is failing to proceed with the update (ClusterOperatorDegraded)
-  Since:       0s
+  Since:       now
   Level:       Warning
   Impact:      Update Stalled
   Reference:   https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/ClusterOperatorDegraded.md

--- a/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.output
+++ b/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.output
@@ -44,7 +44,7 @@ SINCE   LEVEL     IMPACT           MESSAGE
 -       Error     Update Stalled   Node build0-gstfj-ci-tests-worker-b-jv5bg is degraded
 -       Error     Update Stalled   Node build0-gstfj-ci-tests-worker-b-kj6gk is degraded
 -       Error     Update Stalled   Node build0-gstfj-ci-tests-worker-c-dcz9p is degraded
-0s      Warning   Update Stalled   Cluster Version version is failing to proceed with the update (ClusterOperatorDegraded)
+now     Warning   Update Stalled   Cluster Version version is failing to proceed with the update (ClusterOperatorDegraded)
 -       Warning   Update Speed     Node build0-gstfj-ci-prowjobs-worker-d-ddnxd is unavailable
 -       Warning   Update Speed     Node build0-gstfj-ci-tests-worker-c-jq5rk is unavailable
 

--- a/pkg/cli/admin/upgrade/status/health.go
+++ b/pkg/cli/admin/upgrade/status/health.go
@@ -172,9 +172,9 @@ func assessUpdateInsights(insights []updateInsight, upgradingFor time.Duration, 
 func shortDuration(d time.Duration) string {
 	orig := d.String()
 	switch {
-	case orig == "0h0m0s":
+	case orig == "0h0m0s" || orig == "0s":
 		return "now"
-	case strings.HasSuffix(orig, "0m0s"):
+	case strings.HasSuffix(orig, "h0m0s"):
 		return orig[:len(orig)-4]
 	case strings.HasSuffix(orig, "m0s"):
 		return orig[:len(orig)-2]


### PR DESCRIPTION
- skip alerts without required labels
- add context on why we show the insight (started firing during update or is known to affect updates)
- skip alerts with info level
- explicitly mention the alert does not have a runbook
