### PR TITLE
[release-4.16] OCPBUGS-33917: add alert data to upgrade health in oc adm upgrade status 

### DIFF
--- a/pkg/cli/admin/inspectalerts/inspectalerts.go
+++ b/pkg/cli/admin/inspectalerts/inspectalerts.go
@@ -2,7 +2,9 @@
 package inspectalerts
 
 import (
+	"bytes"
 	"context"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
@@ -13,6 +15,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/transport"
+	"k8s.io/klog/v2"
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
 
 	routev1 "github.com/openshift/api/route/v1"
@@ -100,7 +104,7 @@ func GetAlerts(ctx context.Context, getRoute RouteGetter, bearerToken string) ([
 	return alertBytes, nil
 }
 
-// getWithBearer gets a Route by namespace/name, contructs a URI using
+// getWithBearer gets a Route by namespace/name, constructs a URI using
 // status.ingress[].host and the path argument, and performs GETs on that
 // URI using Bearer authentication with the token argument.
 func getWithBearer(ctx context.Context, getRoute RouteGetter, namespace, name string, baseURI *url.URL, bearerToken string) ([]byte, error) {
@@ -113,7 +117,18 @@ func getWithBearer(ctx context.Context, getRoute RouteGetter, namespace, name st
 		return nil, err
 	}
 
-	client := &http.Client{}
+	withDebugWrappers, err := transport.HTTPWrappersForConfig(
+		&transport.Config{
+			UserAgent:   rest.DefaultKubernetesUserAgent() + "(inspect-alerts)",
+			BearerToken: bearerToken,
+		},
+		http.DefaultTransport,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &http.Client{Transport: withDebugWrappers}
 	uris := make([]string, 0, len(route.Status.Ingress))
 	for _, ingress := range route.Status.Ingress {
 		uri := *baseURI
@@ -123,8 +138,6 @@ func getWithBearer(ctx context.Context, getRoute RouteGetter, namespace, name st
 		if err != nil {
 			return nil, err
 		}
-
-		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", bearerToken))
 
 		resp, err := client.Do(req)
 		if err != nil {
@@ -137,6 +150,8 @@ func getWithBearer(ctx context.Context, getRoute RouteGetter, namespace, name st
 			return nil, err
 		}
 
+		glogBody("Response Body", body)
+
 		if resp.StatusCode != http.StatusOK {
 			return body, fmt.Errorf("failed to get alerts from Thanos (GET status code=%d)", resp.StatusCode)
 		}
@@ -145,4 +160,41 @@ func getWithBearer(ctx context.Context, getRoute RouteGetter, namespace, name st
 	}
 
 	return nil, fmt.Errorf("unable to get %s from any of %d URIs in the %s Route in the %s namespace: %s", baseURI.Path, len(uris), name, namespace, strings.Join(uris, ", "))
+}
+
+// glogBody and truncateBody taken from client-go Request
+// https://github.com/openshift/oc/blob/4be3c8609f101a8c5867abc47bda33caae629113/vendor/k8s.io/client-go/rest/request.go#L1183-L1215
+
+// truncateBody decides if the body should be truncated, based on the glog Verbosity.
+func truncateBody(body string) string {
+	max := 0
+	switch {
+	case bool(klog.V(10).Enabled()):
+		return body
+	case bool(klog.V(9).Enabled()):
+		max = 10240
+	case bool(klog.V(8).Enabled()):
+		max = 1024
+	}
+
+	if len(body) <= max {
+		return body
+	}
+
+	return body[:max] + fmt.Sprintf(" [truncated %d chars]", len(body)-max)
+}
+
+// glogBody logs a body output that could be either JSON or protobuf. It explicitly guards against
+// allocating a new string for the body output unless necessary. Uses a simple heuristic to determine
+// whether the body is printable.
+func glogBody(prefix string, body []byte) {
+	if klogV := klog.V(8); klogV.Enabled() {
+		if bytes.IndexFunc(body, func(r rune) bool {
+			return r < 0x0a
+		}) != -1 {
+			klogV.Infof("%s:\n%s", prefix, truncateBody(hex.Dump(body)))
+		} else {
+			klogV.Infof("%s: %s", prefix, truncateBody(string(body)))
+		}
+	}
 }

--- a/pkg/cli/admin/inspectalerts/inspectalerts.go
+++ b/pkg/cli/admin/inspectalerts/inspectalerts.go
@@ -137,6 +137,10 @@ func getWithBearer(ctx context.Context, getRoute RouteGetter, namespace, name st
 			return nil, err
 		}
 
+		if resp.StatusCode != http.StatusOK {
+			return body, fmt.Errorf("failed to get alerts from Thanos (GET status code=%d)", resp.StatusCode)
+		}
+
 		return body, err
 	}
 

--- a/pkg/cli/admin/upgrade/status/alerts.go
+++ b/pkg/cli/admin/upgrade/status/alerts.go
@@ -1,0 +1,93 @@
+package status
+
+import (
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+// Alerts that will be included in the health upgrade evaluation, even if they were triggered before the upgrade began.
+type AllowedAlerts map[string]struct{}
+
+var allowedAlerts AllowedAlerts = map[string]struct{}{
+	"PodDisruptionBudgetLimit":   {},
+	"PodDisruptionBudgetAtLimit": {},
+}
+
+func (al AllowedAlerts) Contains(alert string) bool {
+	_, exists := al[alert]
+	return exists
+}
+
+type AlertLabels struct {
+	AlertName string `json:"alertname,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+	Reason    string `json:"reason,omitempty"`
+	Severity  string `json:"severity,omitempty"`
+}
+
+type AlertAnnotations struct {
+	Description string `json:"description,omitempty"`
+	Summary     string `json:"summary,omitempty"`
+}
+
+type Alert struct {
+	Labels                  AlertLabels      `json:"labels,omitempty"`
+	Annotations             AlertAnnotations `json:"annotations,omitempty"`
+	State                   string           `json:"state,omitempty"`
+	Value                   string           `json:"value,omitempty"`
+	ActiveAt                time.Time        `json:"activeAt,omitempty"`
+	PartialResponseStrategy string           `json:"partialResponseStrategy,omitempty"`
+}
+
+// Stores alert data returned by thanos
+type AlertData struct {
+	Status string `json:"status"`
+	Data   Data   `json:"data"`
+}
+
+type Data struct {
+	Alerts []Alert `json:"alerts"`
+}
+
+func parseAlertDataToInsights(alertData AlertData, startedAt time.Time) []updateInsight {
+	var alerts []Alert = alertData.Data.Alerts
+	var updateInsights []updateInsight = []updateInsight{}
+
+	for _, alert := range alerts {
+		if startedAt.After(alert.ActiveAt) && !allowedAlerts.Contains(alert.Labels.AlertName) {
+			continue
+		}
+		updateInsights = append(updateInsights, updateInsight{
+			startedAt: alert.ActiveAt,
+			impact: updateInsightImpact{
+				level:      alertImpactLevel(alert.Labels.Severity),
+				impactType: unknownImpactType,
+				summary:    "Alert: " + alert.Annotations.Summary,
+			},
+			scope: updateInsightScope{
+				scopeType: scopeTypeCluster,
+				resources: []scopeResource{{
+					kind:      scopeGroupKind{group: configv1.GroupName, kind: "Alert"},
+					namespace: alert.Labels.Namespace,
+					name:      alert.Labels.AlertName,
+				}},
+			},
+		})
+	}
+	return updateInsights
+}
+
+func alertImpactLevel(ail string) impactLevel {
+	switch ail {
+	case "warning":
+		return warningImpactLevel
+	case "critical":
+		return criticalInfoLevel
+	case "info":
+		return infoImpactLevel
+	default:
+		return infoImpactLevel
+	}
+}

--- a/pkg/cli/admin/upgrade/status/alerts_test.go
+++ b/pkg/cli/admin/upgrade/status/alerts_test.go
@@ -1,0 +1,156 @@
+package status
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+func TestParseAlertDataToInsights(t *testing.T) {
+	now := time.Now()
+
+	// Define test cases
+	tests := []struct {
+		name          string
+		alertData     AlertData
+		startedAt     time.Time
+		expectedCount int
+	}{
+		{
+			name: "Empty Alerts",
+			alertData: AlertData{
+				Data: Data{Alerts: []Alert{}},
+			},
+			startedAt:     now,
+			expectedCount: 0,
+		},
+		{
+			name: "Alert Active After Start Time",
+			alertData: AlertData{
+				Data: Data{
+					Alerts: []Alert{
+						{ActiveAt: now.Add(10 * time.Minute), Labels: AlertLabels{Severity: "critical", Namespace: "default", AlertName: "NodeDown"}, Annotations: AlertAnnotations{Summary: "Node is down"}},
+						{ActiveAt: now.Add(-10 * time.Minute), Labels: AlertLabels{Severity: "warning", Namespace: "default", AlertName: "DiskSpaceLow"}, Annotations: AlertAnnotations{Summary: "Disk space low"}},
+					},
+				},
+			},
+			startedAt:     now,
+			expectedCount: 1,
+		},
+		{
+			name: "Alert Active Before Start Time",
+			alertData: AlertData{
+				Data: Data{
+					Alerts: []Alert{
+						{ActiveAt: now.Add(-10 * time.Minute), Labels: AlertLabels{Severity: "warning", Namespace: "default", AlertName: "DiskSpaceLow"}, Annotations: AlertAnnotations{Summary: "Disk space low"}},
+					},
+				},
+			},
+			startedAt:     now,
+			expectedCount: 0,
+		},
+		{
+			name: "Alert Active Before Start Time, Allowed",
+			alertData: AlertData{
+				Data: Data{
+					Alerts: []Alert{
+						{ActiveAt: now.Add(-20 * time.Minute), Labels: AlertLabels{Severity: "info", Namespace: "default", AlertName: "PodDisruptionBudgetAtLimit"}, Annotations: AlertAnnotations{Summary: "PodDisruptionBudgetAtLimit is at limit"}},
+						{ActiveAt: now.Add(-20 * time.Minute), Labels: AlertLabels{Severity: "info", Namespace: "default", AlertName: "AlertmanagerReceiversNotConfigured"}, Annotations: AlertAnnotations{Summary: "Receivers (notification integrations) are not configured on Alertmanager"}},
+					},
+				},
+			},
+			startedAt:     now,
+			expectedCount: 1,
+		},
+		{
+			name: "Alert Active Before Start Time, Not Allowed",
+			alertData: AlertData{
+				Data: Data{
+					Alerts: []Alert{
+						{ActiveAt: now.Add(-20 * time.Minute), Labels: AlertLabels{Severity: "info", Namespace: "default", AlertName: "AlertmanagerReceiversNotConfigured"}, Annotations: AlertAnnotations{Summary: "Receivers (notification integrations) are not configured on Alertmanager"}},
+					},
+				},
+			},
+			startedAt:     now,
+			expectedCount: 0,
+		},
+	}
+
+	// Execute test cases
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			insights := parseAlertDataToInsights(tt.alertData, tt.startedAt)
+			if got := len(insights); got != tt.expectedCount {
+				t.Errorf("parseAlertDataToInsights() = %v, want %v", got, tt.expectedCount)
+			}
+		})
+	}
+}
+
+func TestParseAlertDataToInsightsWithData(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name             string
+		alertData        AlertData
+		startedAt        time.Time
+		expectedInsights []updateInsight
+	}{
+		{
+			name: "Alert Active After Start Time",
+			alertData: AlertData{
+				Data: Data{
+					Alerts: []Alert{
+						{ActiveAt: now.Add(10 * time.Minute), Labels: AlertLabels{Severity: "critical", Namespace: "default", AlertName: "NodeDown"}, Annotations: AlertAnnotations{Summary: "Node is down"}},
+					},
+				},
+			},
+			startedAt: now,
+			expectedInsights: []updateInsight{
+				{
+					startedAt: now.Add(10 * time.Minute),
+					impact: updateInsightImpact{
+						level:      alertImpactLevel("critical"),
+						impactType: unknownImpactType,
+						summary:    "Alert: Node is down",
+					},
+					scope: updateInsightScope{
+						scopeType: scopeTypeCluster,
+						resources: []scopeResource{
+							{
+								kind:      scopeGroupKind{group: configv1.GroupName, kind: "Alert"},
+								namespace: "default",
+								name:      "NodeDown",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Alert Active Before Start Time",
+			alertData: AlertData{
+				Data: Data{
+					Alerts: []Alert{
+						{ActiveAt: now.Add(-10 * time.Minute), Labels: AlertLabels{Severity: "warning", Namespace: "default", AlertName: "DiskSpaceLow"}, Annotations: AlertAnnotations{Summary: "Disk space low"}},
+					},
+				},
+			},
+			startedAt:        now,
+			expectedInsights: []updateInsight{},
+		},
+	}
+
+	// Execute test cases
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			insights := parseAlertDataToInsights(tt.alertData, tt.startedAt)
+			if !reflect.DeepEqual(insights, tt.expectedInsights) {
+				t.Errorf("parseAlertDataToInsights() got %#v, want %#v", insights, tt.expectedInsights)
+			}
+		})
+	}
+
+}

--- a/pkg/cli/admin/upgrade/status/examples/4.14.1-degraded.detailed-output
+++ b/pkg/cli/admin/upgrade/status/examples/4.14.1-degraded.detailed-output
@@ -74,7 +74,7 @@ Message: Cluster Operator control-plane-machine-set is unavailable (UnavailableR
   Description: Missing 1 available replica(s)
 
 Message: Cluster Version version is failing to proceed with the update (ClusterOperatorsDegraded)
-  Since:       0s
+  Since:       now
   Level:       Warning
   Impact:      Update Stalled
   Reference:   https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/ClusterOperatorDegraded.md

--- a/pkg/cli/admin/upgrade/status/examples/4.14.1-degraded.output
+++ b/pkg/cli/admin/upgrade/status/examples/4.14.1-degraded.output
@@ -32,6 +32,6 @@ SINCE     LEVEL     IMPACT             MESSAGE
 58m18s    Error     API Availability   Cluster Operator kube-scheduler is degraded (NodeController_MasterNodesReady)
 58m38s    Error     API Availability   Cluster Operator etcd is degraded (EtcdEndpoints_ErrorUpdatingEtcdEndpoints::EtcdMembers_UnhealthyMembers::NodeController_MasterNodesReady)
 1h0m17s   Error     API Availability   Cluster Operator control-plane-machine-set is unavailable (UnavailableReplicas)
-0s        Warning   Update Stalled     Cluster Version version is failing to proceed with the update (ClusterOperatorsDegraded)
+now       Warning   Update Stalled     Cluster Version version is failing to proceed with the update (ClusterOperatorsDegraded)
 
 Run with --details=health for additional description and links to related online documentation

--- a/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-unavailable-mco-20m-alerts.json
+++ b/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-unavailable-mco-20m-alerts.json
@@ -178,12 +178,45 @@
                     "severity": "warning"
                 },
                 "annotations": {
-                    "description": "PodDisruptionBudgetAtLimit. in namespace <>",
+                    "description": "PodDisruptionBudgetAtLimit in namespace <>",
                     "runbook_url": "https://<mock_data>/PDB.md",
                     "summary": "PodDisruptionBudgetAtLimit for pods <>"
                 },
                 "state": "firing",
                 "activeAt": "2023-11-23T15:39:33.014999722Z",
+                "value": "6.708842592592593e-01",
+                "partialResponseStrategy": "WARN"
+            },
+            {
+                "labels": {
+                    "alertname": "PodDisruptionBudgetAtLimit",
+                    "controller": "alertmanager",
+                    "namespace": "openshift-monitoring",
+                    "severity": "warning"
+                },
+                "annotations": {
+                    "summary": "PodDisruptionBudgetAtLimit for some reason does not have runbook and description"
+                },
+                "state": "firing",
+                "activeAt": "2023-11-23T15:39:33.014999722Z",
+                "value": "6.708842592592593e-01",
+                "partialResponseStrategy": "WARN"
+            },
+            {
+                "labels": {
+                    "alertname": "PodDisruptionBudgetAtLimitWithMessage",
+                    "controller": "alertmanager",
+                    "namespace": "openshift-monitoring",
+                    "severity": "warning"
+                },
+                "annotations": {
+                    "summary": "This alert has a message, description, runbook and summary",
+                    "description": "This alert has a description",
+                    "runbook_url": "https://<mock_data>/runbook.md",
+                    "message": "This alert has a message, too"
+                },
+                "state": "firing",
+                "activeAt": "2023-11-24T15:31:52.75038242Z",
                 "value": "6.708842592592593e-01",
                 "partialResponseStrategy": "WARN"
             },

--- a/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-unavailable-mco-20m-alerts.json
+++ b/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-unavailable-mco-20m-alerts.json
@@ -1,0 +1,224 @@
+{
+    "status": "success",
+    "data": {
+        "alerts": [
+            {
+                "labels": {
+                    "alertname": "ClusterOperatorDegraded",
+                    "name": "kube-apiserver",
+                    "namespace": "openshift-cluster-version",
+                    "reason": "NodeInstaller_InstallerPodFailed",
+                    "severity": "warning"
+                },
+                "annotations": {
+                    "description": "The kube-apiserver operator is degraded because NodeInstaller_InstallerPodFailed, and the components it manages may have reduced quality of service.  Cluster upgrades may not complete. For more information refer to 'oc get -o yaml clusteroperator kube-apiserver' or https://console-openshift-console.apps.ci-ln-kwszvwk-76ef8.aws-2.ci.openshift.org/settings/cluster/.",
+                    "summary": "Cluster operator has been degraded for 30 minutes."
+                },
+                "state": "pending",
+                "activeAt": "2023-11-24T15:43:23.156620559Z",
+                "value": "1e+00",
+                "partialResponseStrategy": "WARN"
+            },
+            {
+                "labels": {
+                    "alertname": "ClusterOperatorDown",
+                    "name": "authentication",
+                    "namespace": "openshift-cluster-version",
+                    "reason": "WellKnown_NotReady",
+                    "severity": "critical"
+                },
+                "annotations": {
+                    "description": "The authentication operator may be down or disabled because WellKnown_NotReady, and the components it manages may be unavailable or degraded.  Cluster upgrades may not complete. For more information refer to 'oc get -o yaml clusteroperator authentication' or https://console-openshift-console.apps.ci-ln-kwszvwk-76ef8.aws-2.ci.openshift.org/settings/cluster/.",
+                    "summary": "Cluster operator has not been available for 10 minutes."
+                },
+                "state": "pending",
+                "activeAt": "2023-11-24T15:53:23.156620559Z",
+                "value": "0e+00",
+                "partialResponseStrategy": "WARN"
+            },
+            {
+                "labels": {
+                    "alertname": "UpdateAvailable",
+                    "channel": "candidate-4.15",
+                    "namespace": "openshift-cluster-version",
+                    "severity": "info",
+                    "upstream": "https://api.integration.openshift.com/api/upgrades_info/graph"
+                },
+                "annotations": {
+                    "description": "For more information refer to 'oc adm upgrade' or https://console-openshift-console.apps.ci-ln-kwszvwk-76ef8.aws-2.ci.openshift.org/settings/cluster/.",
+                    "summary": "Your upstream update recommendation service recommends you update your cluster."
+                },
+                "state": "firing",
+                "activeAt": "2023-11-24T15:31:53.183007399Z",
+                "value": "1e+00",
+                "partialResponseStrategy": "WARN"
+            },
+            {
+                "labels": {
+                    "alertname": "Watchdog",
+                    "namespace": "openshift-monitoring",
+                    "severity": "none"
+                },
+                "annotations": {
+                    "description": "This is an alert meant to ensure that the entire alerting pipeline is functional.\nThis alert is always firing, therefore it should always be firing in Alertmanager\nand always fire against a receiver. There are integrations with various notification\nmechanisms that send a notification when this alert is not firing. For example the\n\"DeadMansSnitch\" integration in PagerDuty.\n",
+                    "summary": "An alert that should always be firing to certify that Alertmanager is working properly."
+                },
+                "state": "firing",
+                "activeAt": "2023-11-24T15:27:54.164800319Z",
+                "value": "1e+00",
+                "partialResponseStrategy": "WARN"
+            },
+            {
+                "labels": {
+                    "alertname": "TargetDown",
+                    "job": "marketplace-operator-metrics",
+                    "namespace": "openshift-marketplace",
+                    "service": "marketplace-operator-metrics",
+                    "severity": "warning"
+                },
+                "annotations": {
+                    "description": "100% of the marketplace-operator-metrics/marketplace-operator-metrics targets in openshift-marketplace namespace have been unreachable for more than 15 minutes. This may be a symptom of network connectivity issues, down nodes, or failures within these components. Assess the health of the infrastructure and nodes running these targets and then contact support.",
+                    "summary": "Some targets were not reachable from the monitoring server for an extended period of time."
+                },
+                "state": "pending",
+                "activeAt": "2023-11-24T15:53:23.163229601Z",
+                "value": "1e+02",
+                "partialResponseStrategy": "WARN"
+            },
+            {
+                "labels": {
+                    "alertname": "AlertmanagerReceiversNotConfigured",
+                    "namespace": "openshift-monitoring",
+                    "severity": "warning"
+                },
+                "annotations": {
+                    "description": "Alerts are not configured to be sent to a notification system, meaning that you may not be notified in a timely fashion when important failures occur. Check the OpenShift documentation to learn how to configure notifications with Alertmanager.",
+                    "summary": "Receivers (notification integrations) are not configured on Alertmanager",
+                    "runbook_url": "https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/AlertManager.md"
+                },
+                "state": "firing",
+                "activeAt": "2023-11-23T15:47:42Z",
+                "value": "0e+00",
+                "partialResponseStrategy": "WARN"
+            },
+            {
+                "labels": {
+                    "alertname": "KubeStateMetricsWatchErrors",
+                    "namespace": "openshift-monitoring",
+                    "severity": "warning"
+                },
+                "annotations": {
+                    "description": "kube-state-metrics is experiencing errors at an elevated rate in watch operations. This is likely causing it to not be able to expose metrics about Kubernetes objects correctly or at all.",
+                    "summary": "kube-state-metrics is experiencing errors in watch operations."
+                },
+                "state": "pending",
+                "activeAt": "2023-11-24T15:42:13.192504153Z",
+                "value": "4.166666666666665e-01",
+                "partialResponseStrategy": "WARN"
+            },
+            {
+                "labels": {
+                    "alertname": "KubePodNotReady",
+                    "namespace": "openshift-kube-apiserver",
+                    "pod": "kube-apiserver-startup-monitor-ip-10-0-60-26.us-west-1.compute.internal",
+                    "severity": "warning"
+                },
+                "annotations": {
+                    "description": "Pod openshift-kube-apiserver/kube-apiserver-startup-monitor-ip-10-0-60-26.us-west-1.compute.internal has been in a non-ready state for longer than 15 minutes.",
+                    "runbook_url": "https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/KubePodNotReady.md",
+                    "summary": "Pod has been in a non-ready state for more than 15 minutes."
+                },
+                "state": "firing",
+                "activeAt": "2023-11-24T15:41:52.75038242Z",
+                "value": "1e+00",
+                "partialResponseStrategy": "WARN"
+            },
+            {
+                "labels": {
+                    "alertname": "KubeAPIDown",
+                    "severity": "critical"
+                },
+                "annotations": {
+                    "description": "KubeAPI has disappeared from Prometheus target discovery.",
+                    "runbook_url": "https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/KubeAPIDown.md",
+                    "summary": "Target disappeared from Prometheus target discovery."
+                },
+                "state": "pending",
+                "activeAt": "2023-11-24T15:45:26.218594457Z",
+                "value": "1e+00",
+                "partialResponseStrategy": "WARN"
+            },
+            {
+                "labels": {
+                    "alertmanager": "https://10.128.0.127:9095/api/v2/alerts",
+                    "alertname": "PrometheusErrorSendingAlertsToSomeAlertmanagers",
+                    "container": "kube-rbac-proxy",
+                    "endpoint": "metrics",
+                    "instance": "10.128.0.132:9092",
+                    "job": "prometheus-k8s",
+                    "namespace": "openshift-monitoring",
+                    "pod": "prometheus-k8s-0",
+                    "service": "prometheus-k8s",
+                    "severity": "warning"
+                },
+                "annotations": {
+                    "description": "21.7% errors while sending alerts from Prometheus openshift-monitoring/prometheus-k8s-0 to Alertmanager https://10.128.0.127:9095/api/v2/alerts.",
+                    "summary": "Prometheus has encountered more than 1% errors sending alerts to a specific Alertmanager."
+                },
+                "state": "pending",
+                "activeAt": "2023-11-24T15:42:43.329697712Z",
+                "value": "2.1701925925925927e+01",
+                "partialResponseStrategy": "WARN"
+            },
+            {
+                "labels": {
+                    "alertname": "PodDisruptionBudgetAtLimit",
+                    "controller": "alertmanager",
+                    "namespace": "openshift-monitoring",
+                    "severity": "warning"
+                },
+                "annotations": {
+                    "description": "PodDisruptionBudgetAtLimit. in namespace <>",
+                    "runbook_url": "https://<mock_data>/PDB.md",
+                    "summary": "PodDisruptionBudgetAtLimit for pods <>"
+                },
+                "state": "firing",
+                "activeAt": "2023-11-23T15:39:33.014999722Z",
+                "value": "6.708842592592593e-01",
+                "partialResponseStrategy": "WARN"
+            },
+            {
+                "labels": {
+                    "alertname": "PrometheusOperatorWatchErrors",
+                    "controller": "prometheus",
+                    "namespace": "openshift-monitoring",
+                    "severity": "warning"
+                },
+                "annotations": {
+                    "description": "Errors while performing watch operations in controller prometheus in openshift-monitoring namespace.",
+                    "summary": "Errors while performing watch operations in controller."
+                },
+                "state": "pending",
+                "activeAt": "2023-11-24T15:39:33.014999722Z",
+                "value": "7.103480392156862e-01",
+                "partialResponseStrategy": "WARN"
+            },
+            {
+                "labels": {
+                    "alertname": "PrometheusOperatorWatchErrors",
+                    "controller": "thanos",
+                    "namespace": "openshift-monitoring",
+                    "severity": "warning"
+                },
+                "annotations": {
+                    "description": "Errors while performing watch operations in controller thanos in openshift-monitoring namespace.",
+                    "summary": "Errors while performing watch operations in controller."
+                },
+                "state": "pending",
+                "activeAt": "2023-11-24T15:39:33.014999722Z",
+                "value": "6.557058823529411e-01",
+                "partialResponseStrategy": "WARN"
+            }
+        ]
+    }
+}

--- a/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-unavailable-mco-20m.detailed-output
+++ b/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-unavailable-mco-20m.detailed-output
@@ -35,20 +35,38 @@ Message: Cluster Operator machine-config is unavailable (MachineConfigController
     clusteroperators.config.openshift.io: machine-config
   Description: Cluster not available for [{operator 4.14.0-rc.3}]: ControllerConfig.machineconfiguration.openshift.io "machine-config-controller" is invalid: [status.controllerCertificates[0].notAfter: Required value, status.controllerCertificates[0].notBefore: Required value, status.controllerCertificates[1].notAfter: Required value, status.controllerCertificates[1].notBefore: Required value, status.controllerCertificates[2].notAfter: Required value, status.controllerCertificates[2].notBefore: Required value, status.controllerCertificates[3].notAfter: Required value, status.controllerCertificates[3].notBefore: Required value, status.controllerCertificates[4].notAfter: Required value, status.controllerCertificates[4].notBefore: Required value, status.controllerCertificates[5].notAfter: Required value, status.controllerCertificates[5].notBefore: Required value, status.controllerCertificates[6].notAfter: Required value, status.controllerCertificates[6].notBefore: Required value, status.controllerCertificates[7].notAfter: Required value, status.controllerCertificates[7].notBefore: Required value, status.controllerCertificates[8].notAfter: Required value, status.controllerCertificates[8].notBefore: Required value, status.controllerCertificates[9].notAfter: Required value, status.controllerCertificates[9].notBefore: Required value, <nil>: Invalid value: "null": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation]
 
-Message: Alert: Pod has been in a non-ready state for more than 15 minutes.
+Message: Alert is firing: Pod has been in a non-ready state for more than 15 minutes.
   Since:       6m35s
   Level:       Warning
   Impact:      Unknown
   Reference:   https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/KubePodNotReady.md
   Resources:
     alerts.config.openshift.io: openshift-kube-apiserver/KubePodNotReady
-  Description: Pod openshift-kube-apiserver/kube-apiserver-startup-monitor-ip-10-0-60-26.us-west-1.compute.internal has been in a non-ready state for longer than 15 minutes.
+  Description: Alert started firing during the update. The alert description is: Pod openshift-kube-apiserver/kube-apiserver-startup-monitor-ip-10-0-60-26.us-west-1.compute.internal has been in a non-ready state for longer than 15 minutes.
 
-Message: Alert: PodDisruptionBudgetAtLimit for pods <>
+Message: Alert is firing: This alert has a message, description, runbook and summary
+  Since:       16m35s
+  Level:       Warning
+  Impact:      Unknown
+  Reference:   https://<mock_data>/runbook.md
+  Resources:
+    alerts.config.openshift.io: openshift-monitoring/PodDisruptionBudgetAtLimitWithMessage
+  Description: Alert started firing during the update. The alert description is: This alert has a description | This alert has a message, too
+
+Message: Alert is firing: PodDisruptionBudgetAtLimit for pods <>
   Since:       24h8m54s
   Level:       Warning
   Impact:      Unknown
   Reference:   https://<mock_data>/PDB.md
   Resources:
     alerts.config.openshift.io: openshift-monitoring/PodDisruptionBudgetAtLimit
-  Description: PodDisruptionBudgetAtLimit. in namespace <>
+  Description: Alert known to affect updates has been firing since before the update started. The alert description is: PodDisruptionBudgetAtLimit in namespace <>
+
+Message: Alert is firing: PodDisruptionBudgetAtLimit for some reason does not have runbook and description
+  Since:       24h8m54s
+  Level:       Warning
+  Impact:      Unknown
+  Reference:   <alert does not have a runbook_url annotation>
+  Resources:
+    alerts.config.openshift.io: openshift-monitoring/PodDisruptionBudgetAtLimit
+  Description: Alert known to affect updates has been firing since before the update started. The alert has no description.

--- a/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-unavailable-mco-20m.detailed-output
+++ b/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-unavailable-mco-20m.detailed-output
@@ -34,3 +34,21 @@ Message: Cluster Operator machine-config is unavailable (MachineConfigController
   Resources:
     clusteroperators.config.openshift.io: machine-config
   Description: Cluster not available for [{operator 4.14.0-rc.3}]: ControllerConfig.machineconfiguration.openshift.io "machine-config-controller" is invalid: [status.controllerCertificates[0].notAfter: Required value, status.controllerCertificates[0].notBefore: Required value, status.controllerCertificates[1].notAfter: Required value, status.controllerCertificates[1].notBefore: Required value, status.controllerCertificates[2].notAfter: Required value, status.controllerCertificates[2].notBefore: Required value, status.controllerCertificates[3].notAfter: Required value, status.controllerCertificates[3].notBefore: Required value, status.controllerCertificates[4].notAfter: Required value, status.controllerCertificates[4].notBefore: Required value, status.controllerCertificates[5].notAfter: Required value, status.controllerCertificates[5].notBefore: Required value, status.controllerCertificates[6].notAfter: Required value, status.controllerCertificates[6].notBefore: Required value, status.controllerCertificates[7].notAfter: Required value, status.controllerCertificates[7].notBefore: Required value, status.controllerCertificates[8].notAfter: Required value, status.controllerCertificates[8].notBefore: Required value, status.controllerCertificates[9].notAfter: Required value, status.controllerCertificates[9].notBefore: Required value, <nil>: Invalid value: "null": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation]
+
+Message: Alert: Pod has been in a non-ready state for more than 15 minutes.
+  Since:       6m35s
+  Level:       Warning
+  Impact:      Unknown
+  Reference:   https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/KubePodNotReady.md
+  Resources:
+    alerts.config.openshift.io: openshift-kube-apiserver/KubePodNotReady
+  Description: Pod openshift-kube-apiserver/kube-apiserver-startup-monitor-ip-10-0-60-26.us-west-1.compute.internal has been in a non-ready state for longer than 15 minutes.
+
+Message: Alert: PodDisruptionBudgetAtLimit for pods <>
+  Since:       24h8m54s
+  Level:       Warning
+  Impact:      Unknown
+  Reference:   https://<mock_data>/PDB.md
+  Resources:
+    alerts.config.openshift.io: openshift-monitoring/PodDisruptionBudgetAtLimit
+  Description: PodDisruptionBudgetAtLimit. in namespace <>

--- a/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-unavailable-mco-20m.output
+++ b/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-unavailable-mco-20m.output
@@ -26,7 +26,9 @@ ip-10-0-4-159.us-east-2.compute.internal    Outdated     Pending   4.14.0-rc.3  
 ip-10-0-99-40.us-east-2.compute.internal    Outdated     Pending   4.14.0-rc.3   ?     
 
 = Update Health =
-SINCE    LEVEL   IMPACT             MESSAGE
-20m24s   Error   API Availability   Cluster Operator machine-config is unavailable (MachineConfigControllerFailed)
+SINCE      LEVEL     IMPACT             MESSAGE
+20m24s     Error     API Availability   Cluster Operator machine-config is unavailable (MachineConfigControllerFailed)
+6m35s      Warning   Unknown            Alert: Pod has been in a non-ready state for more than 15 minutes.
+24h8m54s   Warning   Unknown            Alert: PodDisruptionBudgetAtLimit for pods <>
 
 Run with --details=health for additional description and links to related online documentation

--- a/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-unavailable-mco-20m.output
+++ b/pkg/cli/admin/upgrade/status/examples/4.15.0-ec2-unavailable-mco-20m.output
@@ -28,7 +28,9 @@ ip-10-0-99-40.us-east-2.compute.internal    Outdated     Pending   4.14.0-rc.3  
 = Update Health =
 SINCE      LEVEL     IMPACT             MESSAGE
 20m24s     Error     API Availability   Cluster Operator machine-config is unavailable (MachineConfigControllerFailed)
-6m35s      Warning   Unknown            Alert: Pod has been in a non-ready state for more than 15 minutes.
-24h8m54s   Warning   Unknown            Alert: PodDisruptionBudgetAtLimit for pods <>
+6m35s      Warning   Unknown            Alert is firing: Pod has been in a non-ready state for more than 15 minutes.
+16m35s     Warning   Unknown            Alert is firing: This alert has a message, description, runbook and summary
+24h8m54s   Warning   Unknown            Alert is firing: PodDisruptionBudgetAtLimit for pods <>
+24h8m54s   Warning   Unknown            Alert is firing: PodDisruptionBudgetAtLimit for some reason does not have runbook and description
 
 Run with --details=health for additional description and links to related online documentation

--- a/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.detailed-output
+++ b/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.detailed-output
@@ -146,7 +146,7 @@ Message: Node build0-gstfj-ci-tests-worker-c-dcz9p is degraded
   Description: failed to drain node: build0-gstfj-ci-tests-worker-c-dcz9p after 1 hour. Please see machine-config-controller logs for more information
 
 Message: Cluster Version version is failing to proceed with the update (ClusterOperatorDegraded)
-  Since:       0s
+  Since:       now
   Level:       Warning
   Impact:      Update Stalled
   Reference:   https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/ClusterOperatorDegraded.md

--- a/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.output
+++ b/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.output
@@ -44,7 +44,7 @@ SINCE   LEVEL     IMPACT           MESSAGE
 -       Error     Update Stalled   Node build0-gstfj-ci-tests-worker-b-jv5bg is degraded
 -       Error     Update Stalled   Node build0-gstfj-ci-tests-worker-b-kj6gk is degraded
 -       Error     Update Stalled   Node build0-gstfj-ci-tests-worker-c-dcz9p is degraded
-0s      Warning   Update Stalled   Cluster Version version is failing to proceed with the update (ClusterOperatorDegraded)
+now     Warning   Update Stalled   Cluster Version version is failing to proceed with the update (ClusterOperatorDegraded)
 -       Warning   Update Speed     Node build0-gstfj-ci-prowjobs-worker-d-ddnxd is unavailable
 -       Warning   Update Speed     Node build0-gstfj-ci-tests-worker-c-jq5rk is unavailable
 

--- a/pkg/cli/admin/upgrade/status/health.go
+++ b/pkg/cli/admin/upgrade/status/health.go
@@ -172,9 +172,9 @@ func assessUpdateInsights(insights []updateInsight, upgradingFor time.Duration, 
 func shortDuration(d time.Duration) string {
 	orig := d.String()
 	switch {
-	case orig == "0h0m0s":
+	case orig == "0h0m0s" || orig == "0s":
 		return "now"
-	case strings.HasSuffix(orig, "0m0s"):
+	case strings.HasSuffix(orig, "h0m0s"):
 		return orig[:len(orig)-4]
 	case strings.HasSuffix(orig, "m0s"):
 		return orig[:len(orig)-2]

--- a/pkg/cli/admin/upgrade/status/health.go
+++ b/pkg/cli/admin/upgrade/status/health.go
@@ -14,6 +14,7 @@ type scopeType string
 const (
 	scopeTypeControlPlane scopeType = "ControlPlane"
 	scopeTypeWorkerPool   scopeType = "WorkerPool"
+	scopeTypeCluster      scopeType = "Cluster"
 )
 
 type scopeGroupKind struct {
@@ -83,6 +84,7 @@ type impactType string
 // considered whether these are exactly the ones that we need.
 const (
 	noneImpactType                    impactType = "None"
+	unknownImpactType                 impactType = "Unknown"
 	apiAvailabilityImpactType         impactType = "API Availability"
 	clusterCapacityImpactType         impactType = "Cluster Capacity"
 	applicationAvailabilityImpactType impactType = "Application Availability"

--- a/pkg/cli/admin/upgrade/status/mockresources.go
+++ b/pkg/cli/admin/upgrade/status/mockresources.go
@@ -17,6 +17,7 @@ type mockData struct {
 	machineConfigPoolsPath string
 	machineConfigsPath     string
 	nodesPath              string
+	alertsPath             string
 	clusterVersion         *configv1.ClusterVersion
 	clusterOperators       *configv1.ClusterOperatorList
 	machineConfigPools     *machineconfigv1.MachineConfigPoolList

--- a/pkg/cli/admin/upgrade/status/status.go
+++ b/pkg/cli/admin/upgrade/status/status.go
@@ -3,7 +3,9 @@ package status
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -18,8 +20,11 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	machineconfigv1 "github.com/openshift/api/machineconfiguration/v1"
+	routev1 "github.com/openshift/api/route/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned"
 	machineconfigv1client "github.com/openshift/client-go/machineconfiguration/clientset/versioned"
+	routev1client "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
+	"github.com/openshift/oc/pkg/cli/admin/inspectalerts"
 	"github.com/openshift/oc/pkg/cli/admin/upgrade/status/mco"
 )
 
@@ -67,6 +72,8 @@ type options struct {
 	ConfigClient        configv1client.Interface
 	CoreClient          corev1client.CoreV1Interface
 	MachineConfigClient machineconfigv1client.Interface
+	RouteClient         routev1client.RouteV1Interface
+	getAlerts           func(ctx context.Context) ([]byte, error)
 }
 
 func (o *options) enabledDetailed(what string) bool {
@@ -88,6 +95,7 @@ func (o *options) Complete(f kcmdutil.Factory, cmd *cobra.Command, args []string
 		o.mockData.machineConfigPoolsPath = strings.Replace(o.mockData.cvPath, cvSuffix, "-mcp.yaml", 1)
 		o.mockData.machineConfigsPath = strings.Replace(o.mockData.cvPath, cvSuffix, "-mc.yaml", 1)
 		o.mockData.nodesPath = strings.Replace(o.mockData.cvPath, cvSuffix, "-node.yaml", 1)
+		o.mockData.alertsPath = strings.Replace(o.mockData.cvPath, cvSuffix, "-alerts.json", 1)
 	}
 
 	if o.mockData.cvPath == "" {
@@ -110,6 +118,19 @@ func (o *options) Complete(f kcmdutil.Factory, cmd *cobra.Command, args []string
 			return err
 		}
 		o.CoreClient = coreClient
+
+		routeClient, err := routev1client.NewForConfig(cfg)
+		if err != nil {
+			return err
+		}
+		o.RouteClient = routeClient
+
+		routeGetter := func(ctx context.Context, namespace string, name string, opts metav1.GetOptions) (*routev1.Route, error) {
+			return routeClient.Routes(namespace).Get(ctx, name, opts)
+		}
+		o.getAlerts = func(ctx context.Context) ([]byte, error) {
+			return inspectalerts.GetAlerts(ctx, routeGetter, cfg.BearerToken)
+		}
 	} else {
 		err := o.mockData.load()
 		if err != nil {
@@ -241,6 +262,27 @@ func (o *options) Run(ctx context.Context) error {
 		startedAt = cv.Status.History[0].StartedTime.Time
 	}
 	updatingFor := now.Sub(startedAt).Round(time.Second)
+
+	// get the alerts for the cluster. if we're unable to fetch the alerts, we'll let the user know that alerts
+	// are not being fetched, but rest of the command should work.
+	var alertData AlertData
+	var alertBytes []byte
+	var err error
+	if ap := o.mockData.alertsPath; ap != "" {
+		alertBytes, err = os.ReadFile(o.mockData.alertsPath)
+	} else {
+		alertBytes, err = o.getAlerts(ctx)
+	}
+	if err != nil {
+		fmt.Println("Unable to fetch alerts, ignoring alerts in 'Update Health': ", err)
+	} else {
+		// Unmarshal the JSON data into the struct
+		if err := json.Unmarshal(alertBytes, &alertData); err != nil {
+			fmt.Println("Ignoring alerts in 'Update Health'. Error unmarshaling alerts: %w", err)
+		}
+
+		updateInsights = append(updateInsights, parseAlertDataToInsights(alertData, startedAt)...)
+	}
 
 	controlPlaneStatusData, insights := assessControlPlaneStatus(cv, operators.Items, now)
 	updateInsights = append(updateInsights, insights...)

--- a/pkg/cli/admin/upgrade/status/status.go
+++ b/pkg/cli/admin/upgrade/status/status.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	// "sort"
 	"strings"
 	"time"
 
@@ -280,7 +281,6 @@ func (o *options) Run(ctx context.Context) error {
 		if err := json.Unmarshal(alertBytes, &alertData); err != nil {
 			fmt.Println("Ignoring alerts in 'Update Health'. Error unmarshaling alerts: %w", err)
 		}
-
 		updateInsights = append(updateInsights, parseAlertDataToInsights(alertData, startedAt)...)
 	}
 


### PR DESCRIPTION
Replaces automated #1771 because multiple PRs were needed for OCPBUGS-33896.

Backports #1771 #1782 and #1787 to release 4.16:

- **add alerts to update health in oc adm upgrade status**
- **add mock tests for alerts in oc adm upgrade status**
- **OCPBUGS-33896: `status/inspect-alerts`: handle non-200 by Thanos**
- **inspectalerts: use client-go wrappers for thanos call debugging**
- **inspectalerts: refactor `getWithBearer` to try all urls in route**
- **`upgrade status`: polish alert insights**
