### PR TITLE
OCPBUGS-16418: Show more clear info about the DeploymentConfig is deprecated

### DIFF
--- a/pkg/cli/status/status.go
+++ b/pkg/cli/status/status.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/gonum/graph/encoding/dot"
 	"github.com/spf13/cobra"
-
 	kapierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericiooptions"

--- a/pkg/helpers/apps/warning_handler.go
+++ b/pkg/helpers/apps/warning_handler.go
@@ -1,0 +1,22 @@
+package apps
+
+import (
+	"strings"
+
+	"k8s.io/client-go/rest"
+)
+
+type ignoreDeploymentConfigWarningHandler struct {
+	handler rest.WarningHandler
+}
+
+func NewIgnoreDeploymentConfigWarningHandler(handler rest.WarningHandler) rest.WarningHandler {
+	return &ignoreDeploymentConfigWarningHandler{handler: handler}
+}
+
+func (h *ignoreDeploymentConfigWarningHandler) HandleWarningHeader(code int, agent string, text string) {
+	if h.handler == nil || strings.Contains(text, `apps.openshift.io/v1 DeploymentConfig is deprecated`) {
+		return
+	}
+	h.handler.HandleWarningHeader(code, agent, text)
+}

--- a/pkg/helpers/apps/warning_handler_test.go
+++ b/pkg/helpers/apps/warning_handler_test.go
@@ -1,0 +1,66 @@
+package apps
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestHandleWarningHeader(t *testing.T) {
+	testCases := []struct {
+		name         string
+		text         string
+		wraps        bool
+		expectOutput bool
+	}{
+		{
+			name:         "deprecated old",
+			text:         `apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+`,
+			wraps:        true,
+			expectOutput: false,
+		},
+		{
+			name:         "deprecated new",
+			text:         `apps.openshift.io/v1 DeploymentConfig is deprecated in v1.27+`,
+			wraps:        true,
+			expectOutput: false,
+		},
+		{
+			name: "do not panic no match",
+			text: `something else`,
+		},
+		{
+			name:  "do not panic match",
+			text:  `apps.openshift.io/v1 DeploymentConfig is deprecated in v1.27+`,
+			wraps: false,
+		},
+		{
+			name:         "not deprecation warning",
+			text:         `DeploymentConfig is not deprecated`,
+			wraps:        true,
+			expectOutput: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var wrappedHandler mockWarningHandler
+			if tc.wraps {
+				wrappedHandler = mockWarningHandler{}
+			}
+			h := NewIgnoreDeploymentConfigWarningHandler(&wrappedHandler)
+			h.HandleWarningHeader(http.StatusOK, "agent", tc.text)
+			if tc.wraps {
+				if tc.expectOutput != wrappedHandler.invoked {
+					t.Fatalf("Wrapped hander: invoke expected: %v, invoke actual: %v", tc.expectOutput, wrappedHandler.invoked)
+				}
+			}
+		})
+	}
+}
+
+type mockWarningHandler struct {
+	invoked bool
+}
+
+func (m *mockWarningHandler) HandleWarningHeader(warnStatusCode int, header string, text string) {
+	m.invoked = true
+}


### PR DESCRIPTION
Suppress the `DeploymentConfig` deprecation warning from `oc status` and `oc get all`.