### PR TITLE
NO-JIRA: README: Remove freenode

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ OpenShift cluster.
 All contributions are welcome - oc uses the Apache 2 license and does not require
 any contributor agreement to submit patches.  Please open issues for any bugs
 or problems you encounter, ask questions on the OpenShift IRC channel
-(#openshift-dev on freenode), or get involved in the [kubectl](https://github.com/kubernetes/kubectl)
+(#openshift-dev on Libera Chat), or get involved in the [kubectl](https://github.com/kubernetes/kubectl)
 and [kubernetes project](https://github.com/kubernetes/kubernetes) at the container
 runtime layer.
 


### PR DESCRIPTION
Hey! 

I just joined the irc channel #openshift-dev on freenode and it was just me and another person. 

When I joined the channel of the same name on libra.chat, there were a few more people in the channel compared to the freenode instance, including some people likely from Red Hat. Because the README hasn't been updated since the incident on freenode, I think its more appropriate to direct users to libera.chat instead.

If we want to avoid IRC, some alternatives include:
- #openshift-users on the [Kubernetes Slack](https://slack.k8s.io/)
- The [OKD discussion board](https://github.com/okd-project/okd/discussions) on GitHub

What do y'all think? :)