### PR TITLE
Potential fix for openshift/oc/issues/1814.

### DIFF
--- a/vendor/github.com/openshift/library-go/pkg/security/ldapquery/query.go
+++ b/vendor/github.com/openshift/library-go/pkg/security/ldapquery/query.go
@@ -112,9 +112,9 @@ func (o *LDAPQueryOnAttribute) NewSearchRequest(attributeValue string, attribute
 		if err != nil {
 			return nil, fmt.Errorf("could not search by dn, invalid dn value: %v", err)
 		}
-		if !baseDN.AncestorOf(dn) && !baseDN.Equal(dn) {
-			return nil, NewQueryOutOfBoundsError(attributeValue, o.BaseDN)
-		}
+                if !baseDN.AncestorOfFold(dn) && !baseDN.EqualFold(dn) {
+                        return nil, NewQueryOutOfBoundsError(attributeValue, o.BaseDN)
+                }
 		return o.buildDNQuery(attributeValue, attributes), nil
 
 	} else {


### PR DESCRIPTION
oc adm groups sync is comparing dn's / basedn's case sensitive when it should not be in ldap.
