### PR TITLE
NO-JIRA: Minor wording tweaks for CLI help

### DIFF
--- a/pkg/cli/admin/copytonode/command.go
+++ b/pkg/cli/admin/copytonode/command.go
@@ -20,7 +20,7 @@ var (
 	`)
 
 	copyToNodeExample = templates.Examples(`
-		# copy a new bootstrap kubeconfig file to node-0
+		# Copy a new bootstrap kubeconfig file to node-0
 		oc adm copy-to-node --copy=new-bootstrap-kubeconfig=/etc/kubernetes/kubeconfig node/node-0`)
 )
 
@@ -52,7 +52,7 @@ func NewCmdCopyToNode(restClientGetter genericclioptions.RESTClientGetter, strea
 	cmd := &cobra.Command{
 		Use:                   "copy-to-node",
 		DisableFlagsInUseLine: true,
-		Short:                 i18n.T("Copies specified files to the node."),
+		Short:                 i18n.T("Copy specified files to the node"),
 		Long:                  copyToNodeLong,
 		Example:               copyToNodeExample,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cli/admin/node/logs.go
+++ b/pkg/cli/admin/node/logs.go
@@ -45,13 +45,13 @@ var (
 	`)
 
 	logsExample = templates.Examples(`
-		# Show kubelet logs from all masters
+		# Show kubelet logs from all control plane nodes
 		oc adm node-logs --role master -u kubelet
 
-		# See what logs are available in masters in /var/log
+		# See what logs are available in control plane nodes in /var/log
 		oc adm node-logs --role master --path=/
 
-		# Display cron log file from all masters
+		# Display cron log file from all control plane nodes
 		oc adm node-logs --role master --path=cron
 	`)
 )

--- a/pkg/cli/admin/nodeimage/create.go
+++ b/pkg/cli/admin/nodeimage/create.go
@@ -45,15 +45,15 @@ const (
 
 var (
 	createLong = templates.LongDesc(`
-		Create an ISO image from an initial configuration for a given set of nodes, 
+		Create an ISO image from an initial configuration for a given set of nodes,
 		to add them to an existing on-prem cluster.
-		
+
 		This command creates a pod in a temporary namespace on the target cluster
-		to retrieve the required information for creating a customized ISO image. 
+		to retrieve the required information for creating a customized ISO image.
 		The downloaded ISO image could then be used to boot a previously selected
 		set of nodes, and add them to the target cluster in a fully automated way.
 
-		A nodes-config.yaml config file must be created to provide the required 
+		A nodes-config.yaml config file must be created to provide the required
 		initial configuration for the selected nodes.
 
 		The command also requires a connection to the target cluster, and a valid
@@ -62,7 +62,7 @@ var (
 	`)
 
 	createExample = templates.Examples(`
-		# Create the ISO image and downloads it in the current folder
+		# Create the ISO image and download it in the current folder
 		  oc adm node-image create
 
 		# Use a different assets folder

--- a/pkg/cli/admin/ocpcertificates/certregen/command.go
+++ b/pkg/cli/admin/ocpcertificates/certregen/command.go
@@ -17,7 +17,7 @@ import (
 var (
 	regenerateSignersLong = templates.LongDesc(`
 		Regenerate root certificates provided by an OCP v4 cluster.
-		
+
 		This command does not wait for changes to be acknowledged by the cluster.
 		Some may take a very long time to roll out into a cluster, with different operators and operands involved for each.
 
@@ -25,7 +25,7 @@ var (
 	`)
 
 	regenerateSignersExample = templates.Examples(`
-		# Regenerate the signing certificate contained in a particular secret.
+		# Regenerate the signing certificate contained in a particular secret
 		oc adm ocp-certificates regenerate-top-level -n openshift-kube-apiserver-operator secret/loadbalancer-serving-signer-key
 	`)
 
@@ -39,7 +39,7 @@ var (
 	`)
 
 	regenerateLeafExample = templates.Examples(`
-		# Regenerate a leaf certificate contained in a particular secret.
+		# Regenerate a leaf certificate contained in a particular secret
 		oc adm ocp-certificates regenerate-leaf -n openshift-config-managed secret/kube-controller-manager-client-cert-key
 	`)
 )

--- a/pkg/cli/admin/ocpcertificates/monitorregeneration/command.go
+++ b/pkg/cli/admin/ocpcertificates/monitorregeneration/command.go
@@ -18,12 +18,12 @@ import (
 var (
 	monitorCertificatesLong = templates.LongDesc(`
 		Watch the platform certificates in the cluster.
-		
+
 		Experimental: This command is under active development and may change without notice.
 	`)
 
 	monitorCertificatesExample = templates.Examples(`
-		# Watch platform certificates.
+		# Watch platform certificates
 		oc adm ocp-certificates monitor-certificates
 	`)
 )
@@ -48,7 +48,7 @@ func NewCmdMonitorCertificates(restClientGetter genericclioptions.RESTClientGett
 	cmd := &cobra.Command{
 		Use:                   "monitor-certificates",
 		DisableFlagsInUseLine: true,
-		Short:                 i18n.T("Watch platform certificates."),
+		Short:                 i18n.T("Watch platform certificates"),
 		Long:                  monitorCertificatesLong,
 		Example:               monitorCertificatesExample,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cli/admin/rebootmachineconfigpool/command.go
+++ b/pkg/cli/admin/rebootmachineconfigpool/command.go
@@ -27,7 +27,7 @@ var (
 		# Reboot all MachineConfigPools
 		oc adm reboot-machine-config-pool mcp/worker mcp/master
 
-		# Reboot all MachineConfigPools that inherit from worker.  This include all custom MachineConfigPools and infra. 
+		# Reboot all MachineConfigPools that inherit from worker.  This include all custom MachineConfigPools and infra.
 		oc adm reboot-machine-config-pool mcp/worker
 
 		# Reboot masters
@@ -62,7 +62,7 @@ func NewCmdRebootMachineConfigPool(restClientGetter genericclioptions.RESTClient
 	cmd := &cobra.Command{
 		Use:                   "reboot-machine-config-pool",
 		DisableFlagsInUseLine: true,
-		Short:                 i18n.T("Initiate reboot of the specified MachineConfigPool."),
+		Short:                 i18n.T("Initiate reboot of the specified MachineConfigPool"),
 		Long:                  rebootMachineConfigPoolLong,
 		Example:               rebootMachineConfigPoolExample,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cli/admin/restartkubelet/command.go
+++ b/pkg/cli/admin/restartkubelet/command.go
@@ -16,7 +16,7 @@ import (
 var (
 	regenerateSignersLong = templates.LongDesc(`
 		Regenerate certificates provided by an OCP v4 cluster.
-		
+
 		This command does not wait for changes to be acknowledged by the cluster.
 		Some may take a very long time to roll out into a cluster, with different operators and operands involved for each.
 
@@ -24,13 +24,13 @@ var (
 	`)
 
 	regenerateSignersExample = templates.Examples(`
-		# Restart all the nodes,  10% at a time
+		# Restart all the nodes, 10% at a time
 		oc adm restart-kubelet nodes --all --directive=RemoveKubeletKubeconfig
 
-		# Restart all the nodes,  20 nodes at a time
+		# Restart all the nodes, 20 nodes at a time
 		oc adm restart-kubelet nodes --all --parallelism=20 --directive=RemoveKubeletKubeconfig
 
-		# Restart all the nodes,  15% at a time
+		# Restart all the nodes, 15% at a time
 		oc adm restart-kubelet nodes --all --parallelism=15% --directive=RemoveKubeletKubeconfig
 
 		# Restart all the masters at the same time
@@ -65,7 +65,7 @@ func NewCmdRestartKubelet(restClientGetter genericclioptions.RESTClientGetter, s
 	cmd := &cobra.Command{
 		Use:                   "restart-kubelet",
 		DisableFlagsInUseLine: true,
-		Short:                 i18n.T("Restarts kubelet on the specified nodes"),
+		Short:                 i18n.T("Restart kubelet on the specified nodes"),
 		Long:                  regenerateSignersLong,
 		Example:               regenerateSignersExample,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cli/admin/waitforstable/command.go
+++ b/pkg/cli/admin/waitforstable/command.go
@@ -39,7 +39,7 @@ var (
 	`)
 
 	waitForStableExample = templates.Examples(`
-		# Wait for all clusteroperators to become stable
+		# Wait for all cluster operators to become stable
 		oc adm wait-for-stable-cluster
 
 		# Consider operators to be stable if they report as such for 5 minutes straight
@@ -64,7 +64,7 @@ func NewCmdWaitForStableClusterOperators(restClientGetter genericclioptions.REST
 
 	cmd := &cobra.Command{
 		Use:     "wait-for-stable-cluster",
-		Short:   "wait for the platform operators to become stable",
+		Short:   "Wait for the platform operators to become stable",
 		Long:    waitForStableLong,
 		Example: waitForStableExample,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cli/config/adminkubeconfig/new_admin_kubeconfig.go
+++ b/pkg/cli/config/adminkubeconfig/new_admin_kubeconfig.go
@@ -68,7 +68,7 @@ func NewCmdNewAdminKubeconfigOptions(restClientGetter genericclioptions.RESTClie
 	cmd := &cobra.Command{
 		Use:                   "new-admin-kubeconfig",
 		DisableFlagsInUseLine: true,
-		Short:                 i18n.T("Generate, make the server trust, and display a new admin.kubeconfig."),
+		Short:                 i18n.T("Generate, make the server trust, and display a new admin.kubeconfig"),
 		Long:                  newAdminKubeconfigLong,
 		Example:               newAdminKubeconfigExample,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cli/config/kubeletbootstrapkubeconfig/new_kubelet_bootstrap_kubeconfig.go
+++ b/pkg/cli/config/kubeletbootstrapkubeconfig/new_kubelet_bootstrap_kubeconfig.go
@@ -44,7 +44,7 @@ func NewCmdNewKubeletBootstrapKubeconfig(restClientGetter genericclioptions.REST
 	cmd := &cobra.Command{
 		Use:                   "new-kubelet-bootstrap-kubeconfig",
 		DisableFlagsInUseLine: true,
-		Short:                 i18n.T("Generate, make the server trust, and display a new kubelet /etc/kubernetes/kubeconfig."),
+		Short:                 i18n.T("Generate, make the server trust, and display a new kubelet /etc/kubernetes/kubeconfig"),
 		Long:                  i18n.T("Generate, make the server trust, and display a new kubelet /etc/kubernetes/kubeconfig."),
 		Example:               newKubeletBootstrapKubeconfigExample,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cli/config/refreshcabundle/refresh_ca_bundle.go
+++ b/pkg/cli/config/refreshcabundle/refresh_ca_bundle.go
@@ -42,7 +42,7 @@ var (
 		# Refresh the CA bundle for the cluster named e2e in your kubeconfig
 		oc config refresh-ca-bundle e2e
 
-		# Print the CA bundle from the current OpenShift cluster's apiserver.
+		# Print the CA bundle from the current OpenShift cluster's API server
 		oc config refresh-ca-bundle --dry-run`)
 )
 
@@ -60,7 +60,7 @@ func NewCmdConfigRefreshCABundle(restClientGetter genericclioptions.RESTClientGe
 	cmd := &cobra.Command{
 		Use:                   fmt.Sprintf("refresh-ca-bundle [NAME]"),
 		DisableFlagsInUseLine: true,
-		Short:                 i18n.T("Update the OpenShift CA bundle by contacting the apiserver."),
+		Short:                 i18n.T("Update the OpenShift CA bundle by contacting the API server"),
 		Long:                  setClusterLong,
 		Example:               setClusterExample,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cli/debug/debug.go
+++ b/pkg/cli/debug/debug.go
@@ -110,8 +110,8 @@ var (
 		# Debug a node as an administrator
 		oc debug node/master-1
 
-		# Debug a Windows Node
-		# Note: the chosen image must match the Windows Server version (2019, 2022) of the Node
+		# Debug a Windows node
+		# Note: the chosen image must match the Windows Server version (2019, 2022) of the node
 		oc debug node/win-worker-1 --image=mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022
 
 		# Launch a shell in a pod using the provided image stream tag

--- a/pkg/cli/gettoken/gettoken.go
+++ b/pkg/cli/gettoken/gettoken.go
@@ -37,10 +37,10 @@ var (
 	also supports getting client secret to behave as an confidential client.
 `)
 	getTokenExample = templates.Examples(`
-	# Starts an auth code flow to the issuer url with the client id and the given extra scopes
+	# Starts an auth code flow to the issuer URL with the client ID and the given extra scopes
 	oc get-token --client-id=client-id --issuer-url=test.issuer.url --extra-scopes=email,profile
 
-	# Starts an authe code flow to the issuer url with a different callback address.
+	# Starts an auth code flow to the issuer URL with a different callback address
 	oc get-token --client-id=client-id --issuer-url=test.issuer.url --callback-address=127.0.0.1:8343
 `)
 )

--- a/pkg/cli/image/mirror/mirror.go
+++ b/pkg/cli/image/mirror/mirror.go
@@ -97,8 +97,7 @@ var (
 
 		# Copy specific os/arch manifest of a multi-architecture image
 		# Run 'oc image info myregistry.com/myimage:latest' to see available os/arch for multi-arch images
-		# Note that with multi-arch images, this results in a new manifest list digest that includes only
-		# the filtered manifests
+		# Note that with multi-arch images, this results in a new manifest list digest that includes only the filtered manifests
 		oc image mirror myregistry.com/myimage:latest=myregistry.com/other:test \
 			--filter-by-os=os/arch
 
@@ -113,8 +112,8 @@ var (
 
 		# Copy specific os/arch manifest of a multi-architecture image
 		# Run 'oc image info myregistry.com/myimage:latest' to see available os/arch for multi-arch images
-		# Note that the target registry may reject a manifest list if the platform specific images do not all
-		# exist. You must use a registry with sparse registry support enabled.
+		# Note that the target registry may reject a manifest list if the platform specific images do not all exist
+		# You must use a registry with sparse registry support enabled
 		oc image mirror myregistry.com/myimage:latest=myregistry.com/other:test \
 			--filter-by-os=linux/386 \
 			--keep-manifest-list=true

--- a/pkg/cli/login/login.go
+++ b/pkg/cli/login/login.go
@@ -48,7 +48,7 @@ var (
 		# Log in to the given server through a browser
 		oc login localhost:8443 --web --callback-port 8280
 
-		# Log in to the external OIDC issuer through Auth Code + PKCE by starting a local server listening port 8080
+		# Log in to the external OIDC issuer through Auth Code + PKCE by starting a local server listening on port 8080
 		oc login localhost:8443 --exec-plugin=oc-oidc --client-id=client-id --extra-scopes=email,profile --callback-port=8080
 	`)
 )

--- a/pkg/cli/version/version.go
+++ b/pkg/cli/version/version.go
@@ -40,7 +40,7 @@ var (
 		# Print the OpenShift client, kube-apiserver, and openshift-apiserver version information for the current context
 		oc version
 
-		# Print the OpenShift client, kube-apiserver, and openshift-apiserver version numbers for the current context in json format
+		# Print the OpenShift client, kube-apiserver, and openshift-apiserver version numbers for the current context in JSON format
 		oc version --output json
 
 		# Print the OpenShift client version information for the current context


### PR DESCRIPTION
Minor updates to the CLI text for grammar and consistency (since this is pulled into product docs as the CLI reference docs).

For example, short names and example comments should have no ending punctuation, but long descriptions should.