### PR TITLE
AGENT-854: add the required role to support platform type validation

### DIFF
--- a/pkg/cli/admin/nodeimage/create.go
+++ b/pkg/cli/admin/nodeimage/create.go
@@ -617,6 +617,7 @@ func (c *BaseNodeImageCommand) createRolesAndBindings(ctx context.Context) error
 				},
 				Resources: []string{
 					"clusterversions",
+					"infrastructures",
 					"proxies",
 				},
 				Verbs: []string{


### PR DESCRIPTION
This patch is required by https://github.com/openshift/installer/pull/8740 to retrieve the `infrastructures.config.openshift.io/cluster` [resource](https://github.com/openshift/installer/pull/8740/files#diff-b6c0ec51beec87580161335112657421a6874afa61790f8300295cbae1a90c96R377) for validating the supported platform types in node-joiner