### PR TITLE
NO-JIRA: upgrade-status: fix HasOSImage function

### DIFF
--- a/pkg/cli/admin/upgrade/status/mco/layered_pool_state.go
+++ b/pkg/cli/admin/upgrade/status/mco/layered_pool_state.go
@@ -45,10 +45,6 @@ func (l *LayeredPoolState) GetOSImage() string {
 // Determines if a given MachineConfigPool has an available OS image. Returns
 // false if the annotation is missing or set to an empty string.
 func (l *LayeredPoolState) HasOSImage() bool {
-	if l.pool.Labels == nil {
-		return false
-	}
-
 	val, ok := l.pool.Annotations[ExperimentalNewestLayeredImageEquivalentConfigAnnotationKey]
 	return ok && val != ""
 }


### PR DESCRIPTION
From the comment above and the code below (using annotations), it feels like it should be `annotations` instead of `labels`.

/cc @Davoska @petr-muller 