### PR TITLE
WRKLDS-1316: Remove clusterversions from certificates api group

### DIFF
--- a/pkg/cli/admin/nodeimage/create.go
+++ b/pkg/cli/admin/nodeimage/create.go
@@ -630,7 +630,6 @@ func (c *BaseNodeImageCommand) createRolesAndBindings(ctx context.Context) error
 				},
 				Resources: []string{
 					"certificatesigningrequests",
-					"clusterversions",
 				},
 				Verbs: []string{
 					"get",


### PR DESCRIPTION
clusterversions is already part of the config.openshift.io API group. It does not belong in the certificates.k8s.io API group.