### PR TITLE
OTA-1292: upgrade-status: bubble up the reason for unavailable nodes

### DIFF
--- a/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.detailed-output
+++ b/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.detailed-output
@@ -25,8 +25,8 @@ build0-gstfj-ci-tests-worker-b-4h7pn                              Degraded      
 build0-gstfj-ci-tests-worker-b-jv5bg                              Degraded      Draining   4.16.0-ec.2   ?      failed to drain node: <node> after 1 hour. Please see machine-config-controller logs for more information
 build0-gstfj-ci-tests-worker-b-kj6gk                              Degraded      Draining   4.16.0-ec.2   ?      failed to drain node: <node> after 1 hour. Please see machine-config-controller logs for more information
 build0-gstfj-ci-tests-worker-c-dcz9p                              Degraded      Draining   4.16.0-ec.2   ?      failed to drain node: <node> after 1 hour. Please see machine-config-controller logs for more information
-build0-gstfj-ci-prowjobs-worker-d-ddnxd                           Unavailable   Pending    ?             ?      Node is unavailable
-build0-gstfj-ci-tests-worker-c-jq5rk                              Unavailable   Updated    4.16.0-ec.3   -      Node is unavailable
+build0-gstfj-ci-prowjobs-worker-d-ddnxd                           Unavailable   Pending    ?             ?      node's machine-config daemon state Done is neither Degraded nor Unreconcilable
+build0-gstfj-ci-tests-worker-c-jq5rk                              Unavailable   Updated    4.16.0-ec.3   -      node is reporting Unschedulable
 build0-gstfj-ci-tests-worker-c-2kz4m                              Progressing   Draining   4.16.0-ec.2   +10m   
 build0-gstfj-ci-tests-worker-c-55hpj                              Progressing   Draining   4.16.0-ec.2   +10m   
 build0-gstfj-ci-tests-worker-c-8tmjv                              Progressing   Draining   4.16.0-ec.2   +10m   
@@ -158,7 +158,7 @@ Message: Node build0-gstfj-ci-prowjobs-worker-d-ddnxd is unavailable
   Reference:   https://docs.openshift.com/container-platform/latest/post_installation_configuration/machine-configuration-tasks.html#understanding-the-machine-config-operator
   Resources:
     nodes: build0-gstfj-ci-prowjobs-worker-d-ddnxd
-  Description: Node is unavailable
+  Description: node's machine-config daemon state Done is neither Degraded nor Unreconcilable
 
 Message: Node build0-gstfj-ci-tests-worker-c-jq5rk is unavailable
   Since:       -
@@ -167,4 +167,4 @@ Message: Node build0-gstfj-ci-tests-worker-c-jq5rk is unavailable
   Reference:   https://docs.openshift.com/container-platform/latest/post_installation_configuration/machine-configuration-tasks.html#understanding-the-machine-config-operator
   Resources:
     nodes: build0-gstfj-ci-tests-worker-c-jq5rk
-  Description: Node is unavailable
+  Description: node is reporting Unschedulable

--- a/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.output
+++ b/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.output
@@ -25,8 +25,8 @@ build0-gstfj-ci-tests-worker-b-4h7pn      Degraded      Draining   4.16.0-ec.2  
 build0-gstfj-ci-tests-worker-b-jv5bg      Degraded      Draining   4.16.0-ec.2   ?      failed to drain node: <node> after 1 hour. Please see machine-config-controller logs for more information
 build0-gstfj-ci-tests-worker-b-kj6gk      Degraded      Draining   4.16.0-ec.2   ?      failed to drain node: <node> after 1 hour. Please see machine-config-controller logs for more information
 build0-gstfj-ci-tests-worker-c-dcz9p      Degraded      Draining   4.16.0-ec.2   ?      failed to drain node: <node> after 1 hour. Please see machine-config-controller logs for more information
-build0-gstfj-ci-prowjobs-worker-d-ddnxd   Unavailable   Pending    ?             ?      Node is unavailable
-build0-gstfj-ci-tests-worker-c-jq5rk      Unavailable   Updated    4.16.0-ec.3   -      Node is unavailable
+build0-gstfj-ci-prowjobs-worker-d-ddnxd   Unavailable   Pending    ?             ?      node's machine-config daemon state Done is neither Degraded nor Unreconcilable
+build0-gstfj-ci-tests-worker-c-jq5rk      Unavailable   Updated    4.16.0-ec.3   -      node is reporting Unschedulable
 build0-gstfj-ci-tests-worker-c-2kz4m      Progressing   Draining   4.16.0-ec.2   +10m   
 ...
 Omitted additional 49 Total, 22 Completed, 45 Available, 4 Progressing, 27 Outdated, 4 Draining, 0 Excluded, and 0 Degraded nodes.


### PR DESCRIPTION
This is a workaournd before https://issues.redhat.com/browse/MCO-1256 is implemented.