### PR TITLE
WRKLDS-1318: flags for single node interface

### DIFF
--- a/pkg/cli/admin/nodeimage/create.go
+++ b/pkg/cli/admin/nodeimage/create.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -44,6 +45,15 @@ const (
 	nodeJoinerContainer         = "node-joiner"
 )
 
+const (
+	snFlagMacAddress     = "mac-address"
+	snFlagCpuArch        = "cpu-architecture"
+	snFlagSshKey         = "ssh-key"
+	snFlagHostname       = "hostname"
+	snFlagRootDeviceHint = "root-device-hint"
+	snFlagNetworkConfig  = "network-config-file"
+)
+
 var (
 	createLong = templates.LongDesc(`
 		Create an ISO image from an initial configuration for a given set of nodes,
@@ -54,12 +64,17 @@ var (
 		The downloaded ISO image could then be used to boot a previously selected
 		set of nodes, and add them to the target cluster in a fully automated way.
 
-		A nodes-config.yaml config file must be created to provide the required
-		initial configuration for the selected nodes.
-
 		The command also requires a connection to the target cluster, and a valid
 		registry credentials to retrieve the required information from the target
 		cluster release.
+
+		A nodes-config.yaml config file must be created to provide the required
+		initial configuration for the selected nodes. 
+		Alternatively, to support simpler configurations for adding just a single
+		node, it's also possible to use a set of flags to configure the host. In
+		such case the '--mac-address' is the only mandatory flag - while all the
+		others will be optional (note: any eventual configuration file present 
+		will be ignored).
 	`)
 
 	createExample = templates.Examples(`
@@ -71,6 +86,13 @@ var (
 
 		# Specify a custom image name
 		  oc adm node-image create --o=my-node.iso
+
+		# Create an ISO to add a single node without using the configuration file
+		  oc adm node-image create --mac-address=00:d8:e7:c7:4b:bb
+
+		# Create an ISO to add a single node with a root device hint and without
+		# using the configuration file
+		  oc adm node-image create --mac-address=00:d8:e7:c7:4b:bb --root-device-hint=deviceName:/dev/sda
 	`)
 
 	createCommand = "oc adm node-image create"
@@ -116,9 +138,20 @@ type CreateOptions struct {
 	AssetsDir string
 	// OutputName allows the user to specify the name of the generated image.
 	OutputName string
+	// Simpler interface for creating a single node
+	SingleNodeOpts *singleNodeCreateOptions
 
 	nodeJoinerExitCode int
 	rsyncRshCmd        string
+}
+
+type singleNodeCreateOptions struct {
+	MacAddress      string
+	CPUArchitecture string
+	SSHKey          string
+	Hostname        string
+	RootDeviceHints string
+	NetworkConfig   string
 }
 
 // AddFlags defined the required command flags.
@@ -127,6 +160,14 @@ func (o *CreateOptions) AddFlags(cmd *cobra.Command) {
 
 	flags.StringVar(&o.AssetsDir, "dir", o.AssetsDir, "The path containing the configuration file, used also to store the generated artifacts.")
 	flags.StringVarP(&o.OutputName, "output-name", "o", "node.iso", "The name of the output image.")
+
+	flags.StringP(snFlagMacAddress, "m", "", "Single node flag. MAC address used to identify the host to apply the configuration. If specified, the nodes-config.yaml config file will not be used.")
+	usageFmt := "Single node flag. %s. Valid only when `mac-address` is defined."
+	flags.StringP(snFlagCpuArch, "c", "", fmt.Sprintf(usageFmt, "The CPU architecture to be used to install the node"))
+	flags.StringP(snFlagSshKey, "k", "", fmt.Sprintf(usageFmt, "The SSH key used to access the node"))
+	flags.String(snFlagHostname, "", fmt.Sprintf(usageFmt, "The hostname to be set for the node"))
+	flags.String(snFlagRootDeviceHint, "", fmt.Sprintf(usageFmt, "Hint for specifying the storage location for the image root filesystem. Format accepted is <hint name>:<value>."))
+	flags.String(snFlagNetworkConfig, "", fmt.Sprintf(usageFmt, "YAML file containing the NMState configuration to be applied for the node"))
 }
 
 // Complete completes the required options for the create command.
@@ -149,14 +190,56 @@ func (o *CreateOptions) Complete(f kcmdutil.Factory, cmd *cobra.Command, args []
 	o.copyStrategy = func(o *rsync.RsyncOptions) rsync.CopyStrategy {
 		return rsync.NewDefaultCopyStrategy(o)
 	}
+
+	return o.completeSingleNodeOptions(cmd)
+}
+
+func (o *CreateOptions) completeSingleNodeOptions(cmd *cobra.Command) error {
+	snOpts := &singleNodeCreateOptions{}
+
+	if err := o.setSingleNodeFlag(cmd, snFlagMacAddress, &snOpts.MacAddress); err != nil {
+		return err
+	}
+
+	for name, field := range map[string]*string{
+		snFlagCpuArch:        &snOpts.CPUArchitecture,
+		snFlagSshKey:         &snOpts.SSHKey,
+		snFlagHostname:       &snOpts.Hostname,
+		snFlagRootDeviceHint: &snOpts.RootDeviceHints,
+		snFlagNetworkConfig:  &snOpts.NetworkConfig,
+	} {
+		if err := o.setSingleNodeFlag(cmd, name, field); err != nil {
+			return err
+		}
+		if *field != "" && snOpts.MacAddress == "" {
+			return fmt.Errorf("found flag `%s` configured, but it requires also flag `%s` to be set", name, snFlagMacAddress)
+		}
+	}
+
+	if snOpts.MacAddress != "" {
+		o.SingleNodeOpts = snOpts
+	}
+	return nil
+}
+
+func (o *CreateOptions) setSingleNodeFlag(cmd *cobra.Command, flagName string, dst *string) error {
+	v, err := cmd.Flags().GetString(flagName)
+	if err != nil {
+		return err
+	}
+	*dst = v
 	return nil
 }
 
 // Validate returns validation errors related to the create command.
 func (o *CreateOptions) Validate() error {
-	err := o.validateConfigFile()
-	if err != nil {
-		return err
+	// Validate the configuration file only if there isn't any
+	// single node flags set.
+	if o.SingleNodeOpts == nil {
+		err := o.validateConfigFile()
+		if err != nil {
+			return err
+		}
 	}
 
 	if o.OutputName == "" {
@@ -326,8 +409,63 @@ func (o *CreateOptions) waitForCompletion(ctx context.Context) error {
 		})
 }
 
+func (o *CreateOptions) createConfigFileFromFlags() ([]byte, error) {
+	host := map[string]interface{}{
+		"interfaces": []map[string]interface{}{
+			{
+				"name":       "eth0",
+				"macAddress": o.SingleNodeOpts.MacAddress,
+			},
+		},
+	}
+
+	if o.SingleNodeOpts.Hostname != "" {
+		host["hostname"] = o.SingleNodeOpts.Hostname
+	}
+	if o.SingleNodeOpts.CPUArchitecture != "" {
+		host["cpuArchitecture"] = o.SingleNodeOpts.CPUArchitecture
+	}
+	if o.SingleNodeOpts.SSHKey != "" {
+		host["sshKey"] = o.SingleNodeOpts.SSHKey
+	}
+	if o.SingleNodeOpts.RootDeviceHints != "" {
+		parts := strings.SplitN(o.SingleNodeOpts.RootDeviceHints, ":", 2)
+		host["rootDeviceHints"] = map[string]interface{}{
+			parts[0]: parts[1],
+		}
+	}
+	if o.SingleNodeOpts.NetworkConfig != "" {
+		networkConfigData, err := fs.ReadFile(o.FSys, o.SingleNodeOpts.NetworkConfig)
+		if err != nil {
+			return nil, err
+		}
+		var networkConfig map[string]interface{}
+		err = yaml.Unmarshal(networkConfigData, &networkConfig)
+		if err != nil {
+			return nil, err
+		}
+		host["networkConfig"] = networkConfig
+	}
+
+	config := map[string]interface{}{
+		"hosts": []map[string]interface{}{
+			host,
+		},
+	}
+
+	return yaml.Marshal(&config)
+}
+
 func (o *CreateOptions) createInputConfigMap(ctx context.Context) error {
-	data, err := fs.ReadFile(o.FSys, nodeJoinerConfigurationFile)
+	var data []byte
+	var err error
+
+	if o.SingleNodeOpts != nil {
+		klog.V(2).Info("Single node flags found, ignoring configuration file.")
+		data, err = o.createConfigFileFromFlags()
+	} else {
+		data, err = fs.ReadFile(o.FSys, nodeJoinerConfigurationFile)
+	}
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/admin/nodeimage/create_test.go
+++ b/pkg/cli/admin/nodeimage/create_test.go
@@ -514,3 +514,91 @@ func assertContainerImageAndErrors(t *testing.T, runErr error, fakeReg *fakeRegi
 		}
 	}
 }
+
+func TestCreateConfigFileFromFlags(t *testing.T) {
+	sshKeyContents := "ssh-key"
+	networkConfigContents := "interfaces:"
+	expectedConfigFile := `hosts:
+- cpuArchitecture: arm64
+  hostname: server1.example.org
+  interfaces:
+  - macAddress: fe:b1:7d:5b:86:e7
+    name: eth0
+  networkConfig:
+    interfaces: null
+  rootDeviceHints:
+    deviceName: /dev/sda
+  sshKey: ssh-key
+`
+	testCases := []struct {
+		name                    string
+		singleNodeCreateOptions *singleNodeCreateOptions
+		expectedConfigFile      string
+		expectedError           string
+	}{
+		{
+			name: "default",
+			singleNodeCreateOptions: &singleNodeCreateOptions{
+				MacAddress:        "fe:b1:7d:5b:86:e7",
+				CPUArchitecture:   "arm64",
+				SSHKeyPath:        "ssh-key.pub",
+				Hostname:          "server1.example.org",
+				RootDeviceHints:   "deviceName:/dev/sda",
+				NetworkConfigPath: "network-config.yaml",
+			},
+			expectedConfigFile: expectedConfigFile,
+		},
+		{
+			name: "ssh-key-path missing or incorrect",
+			singleNodeCreateOptions: &singleNodeCreateOptions{
+				SSHKeyPath: "wrong-ssh-key-file-name",
+			},
+			expectedError: "open wrong-ssh-key-file-name: file does not exist",
+		},
+		{
+			name: "network config path is missing or incorrect",
+			singleNodeCreateOptions: &singleNodeCreateOptions{
+				NetworkConfigPath: "wrong-network-config-file-name",
+			},
+			expectedError: "open wrong-network-config-file-name: file does not exist",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeFileSystem := fstest.MapFS{}
+			if tc.singleNodeCreateOptions.SSHKeyPath != "" {
+				fakeFileSystem["ssh-key.pub"] = &fstest.MapFile{
+					Data: []byte(sshKeyContents),
+				}
+			}
+			if tc.singleNodeCreateOptions.NetworkConfigPath != "" {
+				fakeFileSystem["network-config.yaml"] = &fstest.MapFile{
+					Data: []byte(networkConfigContents),
+				}
+			}
+			o := &CreateOptions{
+				FSys:           fakeFileSystem,
+				SingleNodeOpts: tc.singleNodeCreateOptions,
+			}
+
+			configFileBytes, err := o.createConfigFileFromFlags()
+
+			if tc.expectedError == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+
+				if !bytes.Equal(configFileBytes, []byte(tc.expectedConfigFile)) {
+					t.Fatalf("generated config file does not match expected: %v, actual: %v", tc.expectedConfigFile, string(configFileBytes))
+				}
+			} else {
+				if err == nil {
+					t.Fatalf("expected error not received: %s", tc.expectedError)
+				}
+				if !strings.Contains(err.Error(), tc.expectedError) {
+					t.Fatalf("expected error: %s, actual: %v", tc.expectedError, err.Error())
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This patch introduces a new set of flags to simplify simpler scenarios based on adding a single node. Instead of defining a complete yaml file (which could be more suitable and handy when handling multiples nodes), the user now can define a number of command line flags to finely configure the required parts of the single node to be added.
When single node flags will be used:

The only mandatory flag is mac-address, to identify the host to be added. All the others will be optional
The configuration file, if present in the working dir, will be ignored

Update of https://github.com/openshift/oc/pull/1833