### PR TITLE
Include must-gather image name in ENV

### DIFF
--- a/pkg/cli/admin/mustgather/mustgather.go
+++ b/pkg/cli/admin/mustgather/mustgather.go
@@ -988,6 +988,10 @@ func (o *MustGatherOptions) newPod(node, image string, hasMaster bool) *corev1.P
 								},
 							},
 						},
+						{
+							Name:  "MUST_GATHER_IMAGE",
+							Value: image,
+						},
 					},
 					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 					VolumeMounts: []corev1.VolumeMount{


### PR DESCRIPTION
The request for such feature came from a Bugzilla
for odf-must-gather.

We want the must-gather containers to be able to check the image being used. This is useful in cases where we want to deduce if the customer is using the image we ask them to.

While it is possible to call the k8s API internally (this is how it is implemented currently for odf-mg), it would be much efficient if the value is present inside the container as an ENV.

This patch sets an ENV var `MUST_GATHER_IMAGE` to reflect the image source of the pods.

Regards