### PR TITLE
NO-JIRA: `upgrade status`: improve tests for missing annotations

### DIFF
--- a/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining-node.yaml
+++ b/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining-node.yaml
@@ -1091,6 +1091,8 @@ items:
         cluster-autoscaler.kubernetes.io/scale-down-disabled: "true"
         machineconfiguration.openshift.io/controlPlaneTopology: HighlyAvailable
         # This simulates ephemeral conditions when Nodes do not have all annotations we expect
+        # Not having a single annotation is weird and should not happen except for bugs, someone manually
+        # messing with annotations and similar things.
         # machineconfiguration.openshift.io/currentConfig: rendered-worker-6b0cfe9b92e34c641ac59510e408b311
         machineconfiguration.openshift.io/desiredConfig: rendered-worker-6b0cfe9b92e34c641ac59510e408b311
         machineconfiguration.openshift.io/desiredDrain: uncordon-rendered-worker-6b0cfe9b92e34c641ac59510e408b311
@@ -1200,14 +1202,16 @@ items:
       annotations:
         cluster-autoscaler.kubernetes.io/scale-down-disabled: "true"
         machineconfiguration.openshift.io/controlPlaneTopology: HighlyAvailable
-        machineconfiguration.openshift.io/currentConfig: rendered-worker-55c03f1f59ad9bd3b224c96a3618ce1d
-        machineconfiguration.openshift.io/desiredConfig: rendered-worker-55c03f1f59ad9bd3b224c96a3618ce1d
-        machineconfiguration.openshift.io/desiredDrain: uncordon-rendered-worker-55c03f1f59ad9bd3b224c96a3618ce1d
-        machineconfiguration.openshift.io/lastAppliedDrain: uncordon-rendered-worker-55c03f1f59ad9bd3b224c96a3618ce1d
-        machineconfiguration.openshift.io/lastSyncedControllerConfigResourceVersion: "4865176381"
-        machineconfiguration.openshift.io/post-config-action: ""
-        machineconfiguration.openshift.io/reason: ""
-        machineconfiguration.openshift.io/state: Done
+        # This simulates a node that was recently provisioned and MCO did not yet set annotations on it
+        # This is a common situation in scaling clusters. Such node is typically also not Ready yet.
+        # machineconfiguration.openshift.io/currentConfig: rendered-worker-55c03f1f59ad9bd3b224c96a3618ce1d
+        # machineconfiguration.openshift.io/desiredConfig: rendered-worker-55c03f1f59ad9bd3b224c96a3618ce1d
+        # machineconfiguration.openshift.io/desiredDrain: uncordon-rendered-worker-55c03f1f59ad9bd3b224c96a3618ce1d
+        # machineconfiguration.openshift.io/lastAppliedDrain: uncordon-rendered-worker-55c03f1f59ad9bd3b224c96a3618ce1d
+        # machineconfiguration.openshift.io/lastSyncedControllerConfigResourceVersion: "4865176381"
+        # machineconfiguration.openshift.io/post-config-action: ""
+        # machineconfiguration.openshift.io/reason: ""
+        # machineconfiguration.openshift.io/state: Done
       creationTimestamp: "2024-02-27T13:28:38Z"
       labels:
         ci-workload: tests
@@ -1216,7 +1220,10 @@ items:
       name: build0-gstfj-ci-tests-worker-b-d9vz2
       resourceVersion: "4865640672"
       uid: 3feb5598-1c68-489e-83a8-7bb65464d87e
-    spec: {}
+    spec:
+      taints:
+      - effect: NoSchedule
+        key: node.kubernetes.io/not-ready
     status:
       conditions:
         - lastHeartbeatTime: "2024-02-27T13:28:38Z"
@@ -1245,9 +1252,9 @@ items:
           type: PIDPressure
         - lastHeartbeatTime: "2024-02-27T16:19:15Z"
           lastTransitionTime: "2024-02-27T15:53:29Z"
-          message: kubelet is posting ready status
-          reason: KubeletReady
-          status: "True"
+          message: kubelet is still setting up stuff
+          reason: KubeletNotReady
+          status: "False"
           type: Ready
   - apiVersion: v1
     kind: Node

--- a/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.detailed-output
+++ b/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.detailed-output
@@ -14,7 +14,7 @@ build0-gstfj-m-2.c.openshift-ci-build-farm.internal   Completed    Updated   4.1
 = Worker Upgrade =
 
 WORKER POOL   ASSESSMENT   COMPLETION   STATUS
-worker        Degraded     39%          59 Total, 45 Available, 5 Progressing, 36 Outdated, 12 Draining, 0 Excluded, 7 Degraded
+worker        Degraded     37%          59 Total, 44 Available, 5 Progressing, 37 Outdated, 12 Draining, 0 Excluded, 7 Degraded
 
 Worker Pool Nodes: worker
 NAME                                                              ASSESSMENT    PHASE      VERSION       EST    MESSAGE
@@ -26,6 +26,7 @@ build0-gstfj-ci-tests-worker-b-jv5bg                              Degraded      
 build0-gstfj-ci-tests-worker-b-kj6gk                              Degraded      Draining   4.16.0-ec.2   ?      failed to drain node: <node> after 1 hour. Please see machine-config-controller logs for more information
 build0-gstfj-ci-tests-worker-c-dcz9p                              Degraded      Draining   4.16.0-ec.2   ?      failed to drain node: <node> after 1 hour. Please see machine-config-controller logs for more information
 build0-gstfj-ci-prowjobs-worker-d-ddnxd                           Unavailable   Pending    ?             ?      node's machine-config daemon state Done is neither Degraded nor Unreconcilable
+build0-gstfj-ci-tests-worker-b-d9vz2                              Unavailable   Pending    ?             ?      node is reporting NotReady=False with message="kubelet is still setting up stuff"
 build0-gstfj-ci-tests-worker-c-jq5rk                              Unavailable   Updated    4.16.0-ec.3   -      node is reporting Unschedulable
 build0-gstfj-ci-tests-worker-c-2kz4m                              Progressing   Draining   4.16.0-ec.2   +10m   
 build0-gstfj-ci-tests-worker-c-55hpj                              Progressing   Draining   4.16.0-ec.2   +10m   
@@ -66,7 +67,6 @@ build0-gstfj-ci-builds-worker-c-ng8s5                             Completed     
 build0-gstfj-ci-builds-worker-c-vmmfj                             Completed     Updated    4.16.0-ec.3   -      
 build0-gstfj-ci-builds-worker-d-4pjlz                             Completed     Updated    4.16.0-ec.3   -      
 build0-gstfj-ci-builds-worker-d-z49wm                             Completed     Updated    4.16.0-ec.3   -      
-build0-gstfj-ci-tests-worker-b-d9vz2                              Completed     Updated    4.16.0-ec.3   -      
 build0-gstfj-ci-tests-worker-b-fkn28                              Completed     Updated    4.16.0-ec.3   -      
 build0-gstfj-ci-tests-worker-b-mc7fm                              Completed     Updated    4.16.0-ec.3   -      
 build0-gstfj-ci-tests-worker-b-pqz8t                              Completed     Updated    4.16.0-ec.3   -      
@@ -159,6 +159,15 @@ Message: Node build0-gstfj-ci-prowjobs-worker-d-ddnxd is unavailable
   Resources:
     nodes: build0-gstfj-ci-prowjobs-worker-d-ddnxd
   Description: node's machine-config daemon state Done is neither Degraded nor Unreconcilable
+
+Message: Node build0-gstfj-ci-tests-worker-b-d9vz2 is unavailable
+  Since:       -
+  Level:       Warning
+  Impact:      Update Speed
+  Reference:   https://docs.openshift.com/container-platform/latest/post_installation_configuration/machine-configuration-tasks.html#understanding-the-machine-config-operator
+  Resources:
+    nodes: build0-gstfj-ci-tests-worker-b-d9vz2
+  Description: node is reporting NotReady=False with message="kubelet is still setting up stuff"
 
 Message: Node build0-gstfj-ci-tests-worker-c-jq5rk is unavailable
   Since:       -

--- a/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.output
+++ b/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.output
@@ -14,22 +14,22 @@ build0-gstfj-m-2.c.openshift-ci-build-farm.internal   Completed    Updated   4.1
 = Worker Upgrade =
 
 WORKER POOL   ASSESSMENT   COMPLETION   STATUS
-worker        Degraded     39%          59 Total, 45 Available, 5 Progressing, 36 Outdated, 12 Draining, 0 Excluded, 7 Degraded
+worker        Degraded     37%          59 Total, 44 Available, 5 Progressing, 37 Outdated, 12 Draining, 0 Excluded, 7 Degraded
 
 Worker Pool Nodes: worker
-NAME                                      ASSESSMENT    PHASE      VERSION       EST    MESSAGE
-build0-gstfj-ci-prowjobs-worker-b-9lztv   Degraded      Draining   4.16.0-ec.2   ?      failed to drain node: <node> after 1 hour. Please see machine-config-controller logs for more information
-build0-gstfj-ci-prowjobs-worker-b-bg9f5   Degraded      Draining   4.16.0-ec.2   ?      failed to drain node: <node> after 1 hour. Please see machine-config-controller logs for more information
-build0-gstfj-ci-prowjobs-worker-b-mrxwn   Degraded      Draining   4.16.0-ec.2   ?      failed to drain node: <node> after 1 hour. Please see machine-config-controller logs for more information
-build0-gstfj-ci-tests-worker-b-4h7pn      Degraded      Draining   4.16.0-ec.2   ?      failed to drain node: <node> after 1 hour. Please see machine-config-controller logs for more information
-build0-gstfj-ci-tests-worker-b-jv5bg      Degraded      Draining   4.16.0-ec.2   ?      failed to drain node: <node> after 1 hour. Please see machine-config-controller logs for more information
-build0-gstfj-ci-tests-worker-b-kj6gk      Degraded      Draining   4.16.0-ec.2   ?      failed to drain node: <node> after 1 hour. Please see machine-config-controller logs for more information
-build0-gstfj-ci-tests-worker-c-dcz9p      Degraded      Draining   4.16.0-ec.2   ?      failed to drain node: <node> after 1 hour. Please see machine-config-controller logs for more information
-build0-gstfj-ci-prowjobs-worker-d-ddnxd   Unavailable   Pending    ?             ?      node's machine-config daemon state Done is neither Degraded nor Unreconcilable
-build0-gstfj-ci-tests-worker-c-jq5rk      Unavailable   Updated    4.16.0-ec.3   -      node is reporting Unschedulable
-build0-gstfj-ci-tests-worker-c-2kz4m      Progressing   Draining   4.16.0-ec.2   +10m   
+NAME                                      ASSESSMENT    PHASE      VERSION       EST   MESSAGE
+build0-gstfj-ci-prowjobs-worker-b-9lztv   Degraded      Draining   4.16.0-ec.2   ?     failed to drain node: <node> after 1 hour. Please see machine-config-controller logs for more information
+build0-gstfj-ci-prowjobs-worker-b-bg9f5   Degraded      Draining   4.16.0-ec.2   ?     failed to drain node: <node> after 1 hour. Please see machine-config-controller logs for more information
+build0-gstfj-ci-prowjobs-worker-b-mrxwn   Degraded      Draining   4.16.0-ec.2   ?     failed to drain node: <node> after 1 hour. Please see machine-config-controller logs for more information
+build0-gstfj-ci-tests-worker-b-4h7pn      Degraded      Draining   4.16.0-ec.2   ?     failed to drain node: <node> after 1 hour. Please see machine-config-controller logs for more information
+build0-gstfj-ci-tests-worker-b-jv5bg      Degraded      Draining   4.16.0-ec.2   ?     failed to drain node: <node> after 1 hour. Please see machine-config-controller logs for more information
+build0-gstfj-ci-tests-worker-b-kj6gk      Degraded      Draining   4.16.0-ec.2   ?     failed to drain node: <node> after 1 hour. Please see machine-config-controller logs for more information
+build0-gstfj-ci-tests-worker-c-dcz9p      Degraded      Draining   4.16.0-ec.2   ?     failed to drain node: <node> after 1 hour. Please see machine-config-controller logs for more information
+build0-gstfj-ci-prowjobs-worker-d-ddnxd   Unavailable   Pending    ?             ?     node's machine-config daemon state Done is neither Degraded nor Unreconcilable
+build0-gstfj-ci-tests-worker-b-d9vz2      Unavailable   Pending    ?             ?     node is reporting NotReady=False with message="kubelet is still setting up stuff"
+build0-gstfj-ci-tests-worker-c-jq5rk      Unavailable   Updated    4.16.0-ec.3   -     node is reporting Unschedulable
 ...
-Omitted additional 49 Total, 22 Completed, 45 Available, 4 Progressing, 27 Outdated, 4 Draining, 0 Excluded, and 0 Degraded nodes.
+Omitted additional 49 Total, 21 Completed, 44 Available, 5 Progressing, 28 Outdated, 5 Draining, 0 Excluded, and 0 Degraded nodes.
 Pass along --details=nodes to see all information.
 
 = Update Health =
@@ -43,6 +43,7 @@ SINCE   LEVEL     IMPACT           MESSAGE
 -       Error     Update Stalled   Node build0-gstfj-ci-tests-worker-c-dcz9p is degraded
 now     Warning   Update Stalled   Cluster Version version is failing to proceed with the update (ClusterOperatorDegraded)
 -       Warning   Update Speed     Node build0-gstfj-ci-prowjobs-worker-d-ddnxd is unavailable
+-       Warning   Update Speed     Node build0-gstfj-ci-tests-worker-b-d9vz2 is unavailable
 -       Warning   Update Speed     Node build0-gstfj-ci-tests-worker-c-jq5rk is unavailable
 
 Run with --details=health for additional description and links to related online documentation


### PR DESCRIPTION
We discovered our existing test was triggering "weird" paths in the assessment code, because the input node was missing a MCO annotation while the node was ready (and it was missing only one annotation). While this is a possible scenario, it would likely need to be created manually by someone messing with annotations or the like. It did not represent the common scenario otherwise.

The typical scenario for missing annotations is a freshly provisioned node, before MCO has a chance to reconcile it. Such node is typically also not ready yet.
