### PR TITLE
OTA-1292: upgrade-status: handle the OS image annotation better

### DIFF
--- a/pkg/cli/admin/upgrade/status/mco/layered_node_state.go
+++ b/pkg/cli/admin/upgrade/status/mco/layered_node_state.go
@@ -85,7 +85,10 @@ func (l *LayeredNodeState) isImageAnnotationEqualToPool(anno string, mcp *mcfgv1
 		if lps.GetOSImage() == val {
 			return true
 		}
-		l.ReasonOfUnavailability = fmt.Sprintf("the node annotation %s is %s, while the pool is trying to reconcile OS image %s", anno, lps.GetOSImage(), val)
+		// According to https://github.com/openshift/machine-config-operator/pull/4510#issuecomment-2271461847
+		// ExperimentalNewestLayeredImageEquivalentConfigAnnotationKey is not used any more and this case should never happen.
+		klog.V(5).Infof("Node annotation %s has value %s different from the OS image %s", anno, val, lps.GetOSImage())
+		l.ReasonOfUnavailability = fmt.Sprintf("Node has an unexpected annotation %s=%s", ExperimentalNewestLayeredImageEquivalentConfigAnnotationKey, lps.GetOSImage())
 		return false
 	}
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OTA-1292

Addressing the 3rd case from https://github.com/openshift/oc/pull/1838#pullrequestreview-2238631410

/cc @petr-muller @Davoska 