### PR TITLE
add proxy-url flag to login cmd

### DIFF
--- a/pkg/cli/login/login.go
+++ b/pkg/cli/login/login.go
@@ -90,6 +90,8 @@ func NewCmdLogin(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.
 	cmds.Flags().StringVarP(&o.Username, "username", "u", o.Username, "Username for server")
 	cmds.Flags().StringVarP(&o.Password, "password", "p", o.Password, "Password for server")
 
+	cmds.Flags().StringVarP(&o.ProxyURL, "proxy-url", "x", o.ProxyURL, "Proxy URL to use for connection to the server")
+
 	cmds.Flags().BoolVarP(&o.WebLogin, "web", "w", o.WebLogin, "Login with web browser. Starts a local HTTP callback server to perform the OAuth2 Authorization Code Grant flow. Use with caution on multi-user systems, as the server's port will be open to all users.")
 	cmds.Flags().Int32VarP(&o.CallbackPort, "callback-port", "c", o.CallbackPort, "Port for the callback server when using --web. Defaults to a random open port")
 

--- a/pkg/cli/login/loginoptions.go
+++ b/pkg/cli/login/loginoptions.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -70,6 +71,7 @@ type LoginOptions struct {
 	Project      string
 	WebLogin     bool
 	CallbackPort int32
+	ProxyURL     string
 
 	// infra
 	StartingKubeConfig *kclientcmdapi.Config
@@ -167,6 +169,14 @@ func (o *LoginOptions) getClientConfig() (*restclient.Config, error) {
 			clientConfig.CAFile = caFile
 			clientConfig.CAData = caData
 		}
+	}
+
+	if len(o.ProxyURL) > 0 {
+		url, err := url.Parse(o.ProxyURL)
+		if err != nil {
+			return nil, err
+		}
+		clientConfig.Proxy = http.ProxyURL(url)
 	}
 
 	// try to TCP connect to the server to make sure it's reachable, and discover


### PR DESCRIPTION
Allow setting a proxy for connecting to the cluster at login.

Setting a proxy globally works but we need to use a specific proxy only for connection to our clusters.

With this change, the given proxy will be used set and used during the cluster config creation (ie first login):

```
$ ./oc login -x https://proxy.example.com https://cluster.example.com:6443 --web
Opening login URL in the default browser: ...
Login successful.

You have access to 298 projects, the list has been suppressed. You can list all projects with 'oc projects'

Using project "default".

$ head ~/.kube/config
apiVersion: v1
clusters:
- cluster:
    proxy-url: https://proxy.example.com
    server: https://cluster.example.com:6443
  name: cluster-example-com:6443
...

```