### PR TITLE
make the idle command's scale update unconditional

### DIFF
--- a/pkg/cli/idle/idle.go
+++ b/pkg/cli/idle/idle.go
@@ -643,6 +643,11 @@ func (o *IdleOptions) RunIdle() error {
 			hadError = true
 			continue
 		}
+		// this CLI command is "do the thing" and doesn't provide a sensible input object for a starting ResourceVersion
+		// the command is an imperative, "do this now" without a precondition, so the desired behavior is deconflicting.
+		// we can do this by having an unconditional scale instance for writing.
+		scale.ResourceVersion = ""
+
 		replicas[scaleRef] = scale.Spec.Replicas
 		toScale[scaleRef] = scaleInfo{scale: scale, obj: obj, namespace: svcName.Namespace}
 	}


### PR DESCRIPTION
Check https://search.dptools.openshift.org/?search=unable+to+scale+.*+but+still+listed+as+target+for+unidling%3A+Operation+cannot+be+fulfilled+on+.*%3A+the+object+has+been+modified%3B+please+apply+your+changes+to+the+latest+version+and+try+again&maxAge=48h&context=1&type=junit&name=4.18&excludeName=multi&maxMatches=5&maxBytes=20971520&groupBy=job 

and

 https://sippy.dptools.openshift.org/sippy-ng/tests/4.18/analysis?test=%5Bsig-network-edge%5D%5BFeature%3AIdling%5D%20Unidling%20with%20Deployments%20%5Bapigroup%3Aroute.openshift.io%5D%20should%20work%20with%20TCP%20(when%20fully%20idled)%20%5BSuite%3Aopenshift%2Fconformance%2Fparallel%5D&filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Bsig-network-edge%5D%5BFeature%3AIdling%5D%20Unidling%20with%20Deployments%20%5Bapigroup%3Aroute.openshift.io%5D%20should%20work%20with%20TCP%20(when%20fully%20idled)%20%5BSuite%3Aopenshift%2Fconformance%2Fparallel%5D%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22not%22%3Atrue%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22never-stable%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22not%22%3Atrue%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22aggregated%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D&view=Passing to determine if it's fixed.