### PR TITLE
OCPBUGS-38450:  Fix copy artifacts for all CPU architectures

### DIFF
--- a/pkg/cli/admin/nodeimage/create.go
+++ b/pkg/cli/admin/nodeimage/create.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"path"
 	"regexp"
 	"strconv"
 	"strings"
@@ -331,15 +330,17 @@ func (o *CreateOptions) copyArtifactsFromNodeJoinerPod() error {
 	klog.V(2).Infof("Copying artifacts from %s", o.nodeJoinerPod.GetName())
 	rsyncOptions := &rsync.RsyncOptions{
 		Namespace:     o.nodeJoinerNamespace.GetName(),
-		Source:        &rsync.PathSpec{PodName: o.nodeJoinerPod.GetName(), Path: path.Join("/assets", "node.x86_64.iso")},
+		Source:        &rsync.PathSpec{PodName: o.nodeJoinerPod.GetName(), Path: "/assets/"},
 		ContainerName: nodeJoinerContainer,
-		Destination:   &rsync.PathSpec{PodName: "", Path: path.Join(o.AssetsDir, o.OutputName)},
+		Destination:   &rsync.PathSpec{PodName: "", Path: o.AssetsDir},
 		Client:        o.Client,
 		Config:        o.Config,
 		Compress:      true,
 		RshCmd:        fmt.Sprintf("%s --namespace=%s -c %s", o.rsyncRshCmd, o.nodeJoinerNamespace.GetName(), nodeJoinerContainer),
 		IOStreams:     o.IOStreams,
 		Quiet:         true,
+		RsyncInclude:  []string{"*.iso"},
+		RsyncExclude:  []string{"*"},
 	}
 	rsyncOptions.Strategy = o.copyStrategy(rsyncOptions)
 	return rsyncOptions.RunRsync()

--- a/pkg/cli/admin/nodeimage/create_test.go
+++ b/pkg/cli/admin/nodeimage/create_test.go
@@ -130,27 +130,18 @@ func TestRun(t *testing.T) {
 		name        string
 		nodesConfig string
 		assetsDir   string
-		outputName  string
 
 		objects          func(string, string) []runtime.Object
 		remoteExecOutput string
 
-		expectedOutputImage string
-		expectedError       string
-		expectedPod         func(t *testing.T, pod *corev1.Pod)
+		expectedError string
+		expectedPod   func(t *testing.T, pod *corev1.Pod)
 	}{
 		{
 			name:        "default",
 			nodesConfig: defaultNodesConfigYaml,
 			objects:     defaultClusterVersionObjectFn,
-		},
-		{
-			name:                "command with options",
-			nodesConfig:         defaultNodesConfigYaml,
-			objects:             defaultClusterVersionObjectFn,
-			assetsDir:           "/my-working-dir",
-			outputName:          "node.iso",
-			expectedOutputImage: "/my-working-dir/node.iso",
+			assetsDir:   "/my-working-dir",
 		},
 		{
 			name:             "node-joiner tool failure",
@@ -253,8 +244,7 @@ func TestRun(t *testing.T) {
 					return fakeCp
 				},
 
-				AssetsDir:  tc.assetsDir,
-				OutputName: tc.outputName,
+				AssetsDir: tc.assetsDir,
 			}
 			// Since the fake registry creates a self-signed cert, let's configure
 			// the command options accordingly
@@ -270,8 +260,8 @@ func TestRun(t *testing.T) {
 			}
 
 			if tc.expectedError == "" {
-				if fakeCp.options.Destination.Path != tc.expectedOutputImage {
-					t.Errorf("expected %v, actual %v", tc.expectedOutputImage, fakeCp.options.Destination.Path)
+				if fakeCp.options.Destination.Path != tc.assetsDir {
+					t.Errorf("expected %v, actual %v", fakeCp.options.Destination.Path, tc.assetsDir)
 				}
 			}
 		})


### PR DESCRIPTION
The "oc adm node-image create" command currently expects the filename to be node.x86_64.iso which doesn't work for non x86_64 architectures. Updated RsyncOptions to copy any iso file to include files for any CPU architecture.

Authored by @andfasano 