### PR TITLE
OTA-1271: Create the `oc adm upgrade recommend` subcommand

### DIFF
--- a/pkg/cli/admin/upgrade/recommend/recommend.go
+++ b/pkg/cli/admin/upgrade/recommend/recommend.go
@@ -1,0 +1,243 @@
+// Package recommend displays recommended update information.
+package recommend
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/blang/semver"
+	"github.com/spf13/cobra"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/templates"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configv1client "github.com/openshift/client-go/config/clientset/versioned"
+)
+
+const (
+	// clusterStatusFailing is set on the ClusterVersion status when a cluster
+	// cannot reach the desired state. It is considered more serious than Degraded
+	// and indicates the cluster is not healthy.
+	clusterStatusFailing = configv1.ClusterStatusConditionType("Failing")
+)
+
+func newOptions(streams genericiooptions.IOStreams) *options {
+	return &options{
+		IOStreams: streams,
+	}
+}
+
+func New(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
+	o := newOptions(streams)
+	cmd := &cobra.Command{
+		Use:   "recommend",
+		Short: "Displays cluster update recommendations.",
+		Long: templates.LongDesc(`
+			Displays cluster update recommendations.
+
+			This subcommand is read-only and does not affect the state of the cluster.
+			To request an update, use the 'oc adm upgrade' subcommand.
+		`),
+		Run: func(cmd *cobra.Command, args []string) {
+			kcmdutil.CheckErr(o.Complete(f, cmd, args))
+			kcmdutil.CheckErr(o.Run(cmd.Context()))
+		},
+	}
+	flags := cmd.Flags()
+	flags.BoolVar(&o.IncludeNotRecommended, "include-not-recommended", o.IncludeNotRecommended, "Display additional updates which are not recommended based on your cluster configuration.")
+
+	return cmd
+}
+
+type options struct {
+	genericiooptions.IOStreams
+
+	IncludeNotRecommended bool
+
+	Client configv1client.Interface
+}
+
+func (o *options) Complete(f kcmdutil.Factory, cmd *cobra.Command, args []string) error {
+	kcmdutil.RequireNoArguments(cmd, args)
+
+	cfg, err := f.ToRESTConfig()
+	if err != nil {
+		return err
+	}
+	client, err := configv1client.NewForConfig(cfg)
+	if err != nil {
+		return err
+	}
+	o.Client = client
+	return nil
+}
+
+func (o *options) Run(ctx context.Context) error {
+	cv, err := o.Client.ConfigV1().ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("No cluster version information available - you must be connected to an OpenShift version 4 server to fetch the current version")
+		}
+		return err
+	}
+
+	if c := findClusterOperatorStatusCondition(cv.Status.Conditions, clusterStatusFailing); c != nil {
+		if c.Status != configv1.ConditionFalse {
+			fmt.Fprintf(o.Out, "%s=%s:\n\n  Reason: %s\n  Message: %s\n\n", c.Type, c.Status, c.Reason, strings.ReplaceAll(c.Message, "\n", "\n  "))
+		}
+	} else {
+		fmt.Fprintf(o.ErrOut, "warning: No current %s info, see `oc describe clusterversion` for more details.\n", clusterStatusFailing)
+	}
+
+	if c := findClusterOperatorStatusCondition(cv.Status.Conditions, configv1.OperatorProgressing); c != nil && len(c.Message) > 0 {
+		if c.Status == configv1.ConditionTrue {
+			fmt.Fprintf(o.Out, "info: An upgrade is in progress. %s\n", c.Message)
+		} else {
+			fmt.Fprintln(o.Out, c.Message)
+		}
+	} else {
+		fmt.Fprintf(o.ErrOut, "warning: No current %s info, see `oc describe clusterversion` for more details.\n", configv1.OperatorProgressing)
+	}
+	fmt.Fprintln(o.Out)
+
+	if c := findClusterOperatorStatusCondition(cv.Status.Conditions, configv1.OperatorUpgradeable); c != nil && c.Status == configv1.ConditionFalse {
+		fmt.Fprintf(o.Out, "%s=%s\n\n  Reason: %s\n  Message: %s\n\n", c.Type, c.Status, c.Reason, strings.ReplaceAll(c.Message, "\n", "\n  "))
+	}
+
+	if c := findClusterOperatorStatusCondition(cv.Status.Conditions, "ReleaseAccepted"); c != nil && c.Status != configv1.ConditionTrue {
+		fmt.Fprintf(o.Out, "ReleaseAccepted=%s\n\n  Reason: %s\n  Message: %s\n\n", c.Status, c.Reason, strings.ReplaceAll(c.Message, "\n", "\n  "))
+	}
+
+	if cv.Spec.Channel != "" {
+		if cv.Spec.Upstream == "" {
+			fmt.Fprint(o.Out, "Upstream is unset, so the cluster will use an appropriate default.\n")
+		} else {
+			fmt.Fprintf(o.Out, "Upstream: %s\n", cv.Spec.Upstream)
+		}
+		if len(cv.Status.Desired.Channels) > 0 {
+			fmt.Fprintf(o.Out, "Channel: %s (available channels: %s)\n", cv.Spec.Channel, strings.Join(cv.Status.Desired.Channels, ", "))
+		} else {
+			fmt.Fprintf(o.Out, "Channel: %s\n", cv.Spec.Channel)
+		}
+	}
+
+	if len(cv.Status.AvailableUpdates) > 0 {
+		fmt.Fprintf(o.Out, "\nRecommended updates:\n\n")
+		// set the minimal cell width to 14 to have a larger space between the columns for shorter versions
+		w := tabwriter.NewWriter(o.Out, 14, 2, 1, ' ', 0)
+		fmt.Fprintf(w, "  VERSION\tIMAGE\n")
+		// TODO: add metadata about version
+		sortReleasesBySemanticVersions(cv.Status.AvailableUpdates)
+		for _, update := range cv.Status.AvailableUpdates {
+			fmt.Fprintf(w, "  %s\t%s\n", update.Version, update.Image)
+		}
+		w.Flush()
+		if c := findClusterOperatorStatusCondition(cv.Status.Conditions, configv1.RetrievedUpdates); c != nil && c.Status == configv1.ConditionFalse {
+			fmt.Fprintf(o.ErrOut, "warning: Cannot refresh available updates:\n  Reason: %s\n  Message: %s\n\n", c.Reason, strings.ReplaceAll(c.Message, "\n", "\n  "))
+		}
+	} else {
+		if c := findClusterOperatorStatusCondition(cv.Status.Conditions, configv1.RetrievedUpdates); c != nil && c.Status == configv1.ConditionFalse {
+			fmt.Fprintf(o.ErrOut, "warning: Cannot display available updates:\n  Reason: %s\n  Message: %s\n\n", c.Reason, strings.ReplaceAll(c.Message, "\n", "\n  "))
+		} else {
+			fmt.Fprintf(o.Out, "No updates available. You may still upgrade to a specific release image with --to-image or wait for new updates to be available.\n")
+		}
+	}
+
+	if o.IncludeNotRecommended {
+		if containsNotRecommendedUpdate(cv.Status.ConditionalUpdates) {
+			sortConditionalUpdatesBySemanticVersions(cv.Status.ConditionalUpdates)
+			fmt.Fprintf(o.Out, "\nUpdates with known issues:\n")
+			for _, update := range cv.Status.ConditionalUpdates {
+				if c := findCondition(update.Conditions, "Recommended"); c != nil && c.Status != metav1.ConditionTrue {
+					fmt.Fprintf(o.Out, "\n  Version: %s\n  Image: %s\n", update.Release.Version, update.Release.Image)
+					fmt.Fprintf(o.Out, "  Reason: %s\n  Message: %s\n", c.Reason, strings.ReplaceAll(strings.TrimSpace(c.Message), "\n", "\n  "))
+				}
+			}
+		} else {
+			fmt.Fprintf(o.Out, "\nNo updates which are not recommended based on your cluster configuration are available.\n")
+		}
+	} else if containsNotRecommendedUpdate(cv.Status.ConditionalUpdates) {
+		qualifier := ""
+		for _, upgrade := range cv.Status.ConditionalUpdates {
+			if c := findCondition(upgrade.Conditions, "Recommended"); c != nil && c.Status != metav1.ConditionTrue && c.Status != metav1.ConditionFalse {
+				qualifier = fmt.Sprintf(", or where the recommended status is %q,", c.Status)
+				break
+			}
+		}
+		fmt.Fprintf(o.Out, "\nAdditional updates which are not recommended%s for your cluster configuration are available, to view those re-run the command with --include-not-recommended.\n", qualifier)
+	}
+
+	// TODO: print previous versions
+
+	return nil
+}
+
+func containsNotRecommendedUpdate(updates []configv1.ConditionalUpdate) bool {
+	for _, update := range updates {
+		if c := findCondition(update.Conditions, "Recommended"); c != nil && c.Status != metav1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+// sortReleasesBySemanticVersions sorts the input slice in decreasing order.
+func sortReleasesBySemanticVersions(versions []configv1.Release) {
+	sort.Slice(versions, func(i, j int) bool {
+		a, errA := semver.Parse(versions[i].Version)
+		b, errB := semver.Parse(versions[j].Version)
+		if errA == nil && errB != nil {
+			return true
+		}
+		if errB == nil && errA != nil {
+			return false
+		}
+		if errA != nil && errB != nil {
+			return versions[i].Version > versions[j].Version
+		}
+		return a.GT(b)
+	})
+}
+
+// sortConditionalUpdatesBySemanticVersions sorts the input slice in decreasing order.
+func sortConditionalUpdatesBySemanticVersions(updates []configv1.ConditionalUpdate) {
+	sort.Slice(updates, func(i, j int) bool {
+		a, errA := semver.Parse(updates[i].Release.Version)
+		b, errB := semver.Parse(updates[j].Release.Version)
+		if errA == nil && errB != nil {
+			return true
+		}
+		if errB == nil && errA != nil {
+			return false
+		}
+		if errA != nil && errB != nil {
+			return updates[i].Release.Version > updates[j].Release.Version
+		}
+		return a.GT(b)
+	})
+}
+
+func findCondition(conditions []metav1.Condition, name string) *metav1.Condition {
+	for i := range conditions {
+		if conditions[i].Type == name {
+			return &conditions[i]
+		}
+	}
+	return nil
+}
+
+func findClusterOperatorStatusCondition(conditions []configv1.ClusterOperatorStatusCondition, name configv1.ClusterStatusConditionType) *configv1.ClusterOperatorStatusCondition {
+	for i := range conditions {
+		if conditions[i].Type == name {
+			return &conditions[i]
+		}
+	}
+	return nil
+}

--- a/pkg/cli/admin/upgrade/recommend/recommend_test.go
+++ b/pkg/cli/admin/upgrade/recommend/recommend_test.go
@@ -1,0 +1,31 @@
+package recommend
+
+import (
+	"math/rand"
+	"reflect"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+func TestSortReleasesBySemanticVersions(t *testing.T) {
+	expected := []configv1.Release{
+		{Version: "10.0.0"},
+		{Version: "2.0.10"},
+		{Version: "2.0.5"},
+		{Version: "2.0.1"},
+		{Version: "2.0.0"},
+		{Version: "not-sem-ver-2"},
+		{Version: "not-sem-ver-1"},
+	}
+
+	actual := make([]configv1.Release, len(expected))
+	for i, j := range rand.Perm(len(expected)) {
+		actual[i] = expected[j]
+	}
+
+	sortReleasesBySemanticVersions(actual)
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("%v != %v", actual, expected)
+	}
+}

--- a/pkg/cli/admin/upgrade/upgrade.go
+++ b/pkg/cli/admin/upgrade/upgrade.go
@@ -26,6 +26,7 @@ import (
 	imagereference "github.com/openshift/library-go/pkg/image/reference"
 
 	"github.com/openshift/oc/pkg/cli/admin/upgrade/channel"
+	"github.com/openshift/oc/pkg/cli/admin/upgrade/recommend"
 	"github.com/openshift/oc/pkg/cli/admin/upgrade/rollback"
 	"github.com/openshift/oc/pkg/cli/admin/upgrade/status"
 )
@@ -113,14 +114,16 @@ func New(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command 
 	flags.BoolVar(&o.IncludeNotRecommended, "include-not-recommended", o.IncludeNotRecommended, "Display additional updates which are not recommended based on your cluster configuration.")
 	flags.BoolVar(&o.AllowNotRecommended, "allow-not-recommended", o.AllowNotRecommended, "Allows upgrade to a version when it is supported but not recommended for updates.")
 
+	cmd.AddCommand(channel.New(f, streams))
+
 	if kcmdutil.FeatureGate("OC_ENABLE_CMD_UPGRADE_STATUS").IsEnabled() {
 		cmd.AddCommand(status.New(f, streams))
 	}
-
-	cmd.AddCommand(channel.New(f, streams))
-
 	if kcmdutil.FeatureGate("OC_ENABLE_CMD_UPGRADE_ROLLBACK").IsEnabled() {
 		cmd.AddCommand(rollback.New(f, streams))
+	}
+	if kcmdutil.FeatureGate("OC_ENABLE_CMD_UPGRADE_RECOMMEND").IsEnabled() {
+		cmd.AddCommand(recommend.New(f, streams))
 	}
 
 	return cmd


### PR DESCRIPTION
This PR will add the backbones for the new `oc adm upgrade recommend` subcommand.

The logic is copied over from an existing `github.com/openshift/oc/pkg/cli/admin/upgrade` package. The logic is to be changed over the upcoming iterations of development.

For the initial commit, the new `recommend` package contains the logic from the `github.com/openshift/oc/pkg/cli/admin/upgrade` package as of the 93286c9260285c104259f0c50704c4b880c4fec3 commit. Only the logic regarding the default output of the `oc adm upgrade` command and outputs regarding available or available but not recommended updates was copied over.

This logic was placed behind a feature gate environment variable named `OC_ENABLE_CMD_UPGRADE_RECOMMEND`. The new subcommand can be tested by running:

```
$ OC_ENABLE_CMD_UPGRADE_RECOMMEND=true ./oc adm upgrade recommend
```

As most of the internal functions are not exported, the existing tests were copied over as well for the existing used functions in the new package `recommend`.

This pull request references https://issues.redhat.com/browse/OTA-1271