### PR TITLE
OCPBUGS-39375: Update push targets of digest with new appended tags

### DIFF
--- a/pkg/cli/image/mirror/mappings.go
+++ b/pkg/cli/image/mirror/mappings.go
@@ -164,6 +164,7 @@ func (d *destinations) mergeIntoDigests(srcDigest digest.Digest, target pushTarg
 			continue
 		}
 		existing.tags = append(existing.tags, dst.tags...)
+		current[repo] = existing
 	}
 }
 


### PR DESCRIPTION
Code actually has an ability to handle different tags with same layers. However, it is forgotten to update the tag list with the new list. This PR fixes this.