### PR TITLE
OCPBUGS-41519: Add HOST env var in oc debug for sos report collects more

### DIFF
--- a/pkg/cli/debug/debug.go
+++ b/pkg/cli/debug/debug.go
@@ -1091,6 +1091,11 @@ func (o *DebugOptions) approximatePodTemplateForObject(object runtime.Object) (*
 								Name:  "TMOUT",
 								Value: "900",
 							},
+							{
+								//  to collect more sos report requires this env var is set
+								Name:  "HOST",
+								Value: "/host",
+							},
 						},
 					},
 				},


### PR DESCRIPTION
Without the `HOST` environment variable, I ran `sos report` on a node and it printed out (please see the `Size`);
```sh
Your sosreport has been generated and saved in:
	/var/tmp/sosreport-node.tar.xz

 Size	4.66MiB
```
After manually setting `HOST=/host` (please see the change of `Size`);
```sh
Your sosreport has been generated and saved in:
	/host/var/tmp/sosreport-node.tar.xz

 Size	12.35MiB
```

It looks like this unlocks some more reports. 

Users can manually export this environment variable and it works. However, it requires having this knowledge beforehand and most will move forward with the small size sos report. 

Alternatively we can update our oc debug document by mentioning this behavior and recommend them to run `export HOST=/host`. This still puts in a risk of moving forward with small size sos report. So that, this PR adds this environment variable in the node debug pod.