### PR TITLE
Fixing -o flag in command example

### DIFF
--- a/pkg/cli/admin/nodeimage/create.go
+++ b/pkg/cli/admin/nodeimage/create.go
@@ -71,11 +71,11 @@ var (
 		cluster release.
 
 		A nodes-config.yaml config file must be created to provide the required
-		initial configuration for the selected nodes. 
+		initial configuration for the selected nodes.
 		Alternatively, to support simpler configurations for adding just a single
 		node, it's also possible to use a set of flags to configure the host. In
 		such case the '--mac-address' is the only mandatory flag - while all the
-		others will be optional (note: any eventual configuration file present 
+		others will be optional (note: any eventual configuration file present
 		will be ignored).
 	`)
 
@@ -87,7 +87,7 @@ var (
 		  oc adm node-image create --dir=/tmp/assets
 
 		# Specify a custom image name
-		  oc adm node-image create --o=my-node.iso
+		  oc adm node-image create -o=my-node.iso
 
 		# Create an ISO to add a single node without using the configuration file
 		  oc adm node-image create --mac-address=00:d8:e7:c7:4b:bb

--- a/pkg/cli/admin/nodeimage/nodeimage.go
+++ b/pkg/cli/admin/nodeimage/nodeimage.go
@@ -12,7 +12,7 @@ import (
 func NewCmdNodeImage(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "node-image",
-		Short: "Add nodes to an existing cluster.",
+		Short: "Add nodes to an existing cluster",
 		Long: templates.LongDesc(`
 			The subcommands allow you to create an ISO image to be used for adding the desired
 			nodes to an OpenShift cluster, and also to monitor the process.


### PR DESCRIPTION
And also removing punctuation (short descriptions use no ending period).

No jira.