### PR TITLE
OCPBUGS-42143: Check cast result in adm prune deployments to prevent panic

### DIFF
--- a/pkg/cli/admin/prune/deployments/data.go
+++ b/pkg/cli/admin/prune/deployments/data.go
@@ -196,7 +196,11 @@ func (d *dataSet) GetDeployment(replica metav1.Object) (metav1.Object, bool, err
 		key := &kappsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: v.Namespace}}
 		item, exists, err := d.deploymentStore.Get(key)
 		if exists {
-			deployment = item.(*kappsv1.Deployment)
+			deploy, ok := item.(*kappsv1.Deployment)
+			if !ok {
+				return nil, false, nil
+			}
+			deployment = deploy
 		}
 		return deployment, exists, err
 	default:
@@ -258,7 +262,11 @@ func (d *dataSet) ListReplicasByDeployment(deployment metav1.Object) ([]metav1.O
 		}
 
 		for _, item := range items {
-			results = append(results, item.(*corev1.ReplicationController))
+			rc, ok := item.(*corev1.ReplicationController)
+			if !ok {
+				continue
+			}
+			results = append(results, rc)
 		}
 	case *kappsv1.Deployment:
 		key := &kappsv1.ReplicaSet{
@@ -280,7 +288,11 @@ func (d *dataSet) ListReplicasByDeployment(deployment metav1.Object) ([]metav1.O
 		}
 
 		for _, item := range items {
-			results = append(results, item.(*kappsv1.ReplicaSet))
+			rs, ok := item.(*kappsv1.ReplicaSet)
+			if !ok {
+				continue
+			}
+			results = append(results, rs)
 		}
 	default:
 		return nil, fmt.Errorf("unknown type: %T", deployment)


### PR DESCRIPTION
This PR covers the other places missed in https://github.com/openshift/oc/pull/1797