### PR TITLE
OCPBUGS-37344: Skip inspection of the daemonset pods running on data plane

### DIFF
--- a/pkg/cli/admin/inspect/inspect.go
+++ b/pkg/cli/admin/inspect/inspect.go
@@ -75,6 +75,7 @@ type InspectOptions struct {
 	rotatedPodLogs bool
 	sinceInt       int64
 	sinceTimestamp metav1.Time
+	nodeSelector   string
 
 	// directory where all gathered data will be stored
 	DestDir string
@@ -91,10 +92,11 @@ func NewInspectOptions(streams genericiooptions.IOStreams) *InspectOptions {
 		printFlags.JSONYamlPrintFlags.ShowManagedFields = true
 	}
 	return &InspectOptions{
-		printFlags:  printFlags,
-		configFlags: genericclioptions.NewConfigFlags(true),
-		overwrite:   true,
-		IOStreams:   streams,
+		printFlags:   printFlags,
+		configFlags:  genericclioptions.NewConfigFlags(true),
+		nodeSelector: "node-role.kubernetes.io/control-plane",
+		overwrite:    true,
+		IOStreams:    streams,
 	}
 }
 
@@ -117,6 +119,7 @@ func NewCmdInspect(streams genericiooptions.IOStreams) *cobra.Command {
 	cmd.Flags().BoolVarP(&o.allNamespaces, "all-namespaces", "A", o.allNamespaces, "If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
 	cmd.Flags().StringVar(&o.sinceTime, "since-time", o.sinceTime, "Only return logs after a specific date (RFC3339). Defaults to all logs. Only one of since-time / since may be used.")
 	cmd.Flags().DurationVar(&o.since, "since", o.since, "Only return logs newer than a relative duration like 5s, 2m, or 3h. Defaults to all logs. Only one of since-time / since may be used.")
+	cmd.Flags().StringVar(&o.nodeSelector, "node-selector", o.nodeSelector, "Set a specific node selector to use - only relevant for the daemonset pods. If the cluster's worker node count is less than or equal to 18, this flag will be ignored and every daemonset pod in all nodes will be collected.")
 	cmd.Flags().BoolVar(&o.rotatedPodLogs, "rotated-pod-logs", o.rotatedPodLogs, "Experimental: If present, retrieve rotated log files that are available for selected pods. This can significantly increase the collected logs size. since/since-time will be matched against the date in the log file name.")
 
 	// The rotated-pod-logs option should be removed once support for retrieving rotated logs is added to kubelet

--- a/pkg/cli/admin/inspect/namespace.go
+++ b/pkg/cli/admin/inspect/namespace.go
@@ -9,6 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/errors"
@@ -76,10 +77,26 @@ func (o *InspectOptions) gatherNamespaceData(baseDir, namespace string) error {
 	klog.V(1).Infof("    Gathering pod data for namespace %q...\n", namespace)
 	// gather specific pod data
 	if pods := resourcesToStore[corev1.SchemeGroupVersion.WithResource("pods")]; pods != nil {
+		nodeList, err := o.kubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			errs = append(errs, err)
+		}
+		var nodes []corev1.Node
+		if nodeList.Items != nil {
+			nodes = nodeList.Items
+		}
 		for _, pod := range pods.(*unstructured.UnstructuredList).Items {
-			klog.V(1).Infof("        Gathering data for pod %q\n", pod.GetName())
 			structuredPod := &corev1.Pod{}
 			runtime.DefaultUnstructuredConverter.FromUnstructured(pod.Object, structuredPod)
+			eligible, err := o.podEligibleForCollection(structuredPod, nodes)
+			if err != nil {
+				errs = append(errs, err)
+			}
+			if !eligible {
+				klog.V(1).Infof("        Skipping gathering data for pod %q\n", pod.GetName())
+				continue
+			}
+			klog.V(1).Infof("        Gathering data for pod %q\n", pod.GetName())
 			if err := o.gatherPodData(path.Join(destDir, "/pods/"+pod.GetName()), namespace, structuredPod); err != nil {
 				errs = append(errs, err)
 				continue
@@ -91,4 +108,57 @@ func (o *InspectOptions) gatherNamespaceData(baseDir, namespace string) error {
 		return fmt.Errorf("one or more errors occurred while gathering pod-specific data for namespace: %s\n\n    %v", namespace, errors.NewAggregate(errs))
 	}
 	return nil
+}
+
+// podEligibleForCollection aims to filter out the daemonset pods running on the
+// nodes whose mismatch with the given --node-selector, if data plane node count is greater than 18,
+// in order to save significant storage size and reduces the collection duration.
+func (o *InspectOptions) podEligibleForCollection(pod *corev1.Pod, nodes []corev1.Node) (bool, error) {
+	isDaemonSet := false
+	if len(pod.OwnerReferences) > 0 {
+		for _, OwnerRef := range pod.OwnerReferences {
+			if OwnerRef.Kind == "DaemonSet" {
+				isDaemonSet = true
+				break
+			}
+		}
+	}
+	if !isDaemonSet {
+		return true, nil
+	}
+
+	workerNodeCount := 0
+	for _, node := range nodes {
+		if _, ok := node.Labels["node-role.kubernetes.io/control-plane"]; ok {
+			continue
+		}
+		workerNodeCount++
+	}
+	const daemonsetCollectionMaxNodeSize = 18
+	if workerNodeCount <= daemonsetCollectionMaxNodeSize {
+		return true, nil
+	}
+
+	var podNode *corev1.Node
+	for _, node := range nodes {
+		if node.Name != pod.Spec.NodeName {
+			continue
+		}
+
+		podNode = &node
+		break
+	}
+
+	if podNode == nil {
+		return false, nil
+	}
+
+	nodeSelector, err := labels.Parse(o.nodeSelector)
+	if err != nil {
+		return true, err
+	}
+	if nodeSelector.Matches(labels.Set(podNode.Labels)) {
+		return true, nil
+	}
+	return false, nil
 }


### PR DESCRIPTION
Daemonset pods running on worker nodes generate high volume of log which increase storage size of must-gather output drastically in addition to the longer collection duration. On the other hand, our primary focus is to collect logs from control  plane rather than data plane. So that it looks reasonable to **not** collect daemonset pods running on data plane if the cluster's worker node count is greater than 18 (still collect logs of the pods whose are running on control plane of given daemonset).

This PR also introduces node-selector flag into the oc adm inspect command. This will work as a workaround, if someone want to collect logs of those skipped pods like this;

```
oc adm inspect namespace openshift-multus --node-selector='node-role.kubernetes.io/worker'
```