### PR TITLE
OCPBUGS-42528: fix outputname flag for node-image create command

### DIFF
--- a/pkg/cli/admin/nodeimage/create.go
+++ b/pkg/cli/admin/nodeimage/create.go
@@ -161,7 +161,7 @@ func (o *CreateOptions) AddFlags(cmd *cobra.Command) {
 	flags := o.addBaseFlags(cmd)
 
 	flags.StringVar(&o.AssetsDir, "dir", o.AssetsDir, "The path containing the configuration file, used also to store the generated artifacts.")
-	flags.StringVarP(&o.OutputName, "output-name", "o", "node.iso", "The name of the output image.")
+	flags.StringVarP(&o.OutputName, "output-name", "o", "", "The name of the output image.")
 
 	flags.StringP(snFlagMacAddress, "m", "", "Single node flag. MAC address used to identify the host to apply the configuration. If specified, the nodes-config.yaml config file will not be used.")
 	usageFmt := "Single node flag. %s. Valid only when `mac-address` is defined."
@@ -242,10 +242,6 @@ func (o *CreateOptions) Validate() error {
 		if err != nil {
 			return err
 		}
-	}
-
-	if o.OutputName == "" {
-		return fmt.Errorf("--output-name cannot be empty")
 	}
 
 	return nil

--- a/pkg/cli/admin/nodeimage/create_test.go
+++ b/pkg/cli/admin/nodeimage/create_test.go
@@ -48,7 +48,6 @@ var (
   interfaces:
   - name: eth0
     macAddress: 00:b9:9b:c8:ac:f4`
-	defaultOutputName = "node.iso"
 )
 
 func TestValidate(t *testing.T) {
@@ -61,7 +60,6 @@ func TestValidate(t *testing.T) {
 		{
 			name:        "default",
 			nodesConfig: &defaultNodesConfigYaml,
-			outputName:  &defaultOutputName,
 		},
 		{
 			name:          "missing configuration file",
@@ -70,14 +68,7 @@ func TestValidate(t *testing.T) {
 		{
 			name:          "invalid configuration file",
 			nodesConfig:   strPtr("invalid: yaml\n\tfile"),
-			outputName:    &defaultOutputName,
 			expectedError: "config file nodes-config.yaml is not valid",
-		},
-		{
-			name:          "invalid output name",
-			nodesConfig:   &defaultNodesConfigYaml,
-			outputName:    strPtr(""),
-			expectedError: "--output-name cannot be empty",
 		},
 	}
 	for _, tc := range testCases {
@@ -90,9 +81,6 @@ func TestValidate(t *testing.T) {
 			}
 			o := &CreateOptions{
 				FSys: fakeFileSystem,
-			}
-			if tc.outputName != nil {
-				o.OutputName = *tc.outputName
 			}
 
 			err := o.Validate()


### PR DESCRIPTION
By default the name of the output image is the one naturally provided by the node-joiner - since it includes also the target architecture prefix. The renaming must be applied only if specified by the user.