### PR TITLE
OTA-1273: pkg/cli/admin/upgrade/recommend: Add --version option for specific releases

### DIFF
--- a/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-not-recommended.output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-not-recommended.output
@@ -20,10 +20,10 @@ Updates to 4.13:
   Message: Exposure to ARODNSWrongBootSequence is unknown due to an evaluation failure: client-side throttling: only 8m30.897666224s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade https://access.redhat.com/solutions/7074686
 
-And 45 older 4.13 updates you can see with --show-outdated-releases
+And 45 older 4.13 updates you can see with '--show-outdated-releases' or '--version VERSION'.
 
 Updates to 4.12:
-  VERSION     IMAGE
-  4.12.64     quay.io/openshift-release-dev/ocp-release@sha256:669170342e3ae3456b2eb00dd0c45cd817d62af310e0aa2bf214f1da65fae9d0
-  4.12.63     quay.io/openshift-release-dev/ocp-release@sha256:5db6f8dd1db6b9d07dacfa74574a38a6e518145a3c0ab5d895e9c89e029a39e4
-And 43 older 4.12 updates you can see with --show-outdated-releases
+  VERSION     ISSUES
+  4.12.64     
+  4.12.63     
+And 43 older 4.12 updates you can see with '--show-outdated-releases' or '--version VERSION'.

--- a/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-not-recommended.show-outdated-releases-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-not-recommended.show-outdated-releases-output
@@ -7,635 +7,99 @@ Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: stable-4.13 (available channels: candidate-4.12, candidate-4.13, eus-4.12, eus-4.14, fast-4.12, fast-4.13, stable-4.12, stable-4.13)
 
 Updates to 4.13:
-
-  Version: 4.13.50
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:6afb11e1cac46fd26476ca134072937115256b9c6360f7a1cd1812992c065f02
-  Reason: EvaluationFailed
-  Message: Exposure to ARODNSWrongBootSequence is unknown due to an evaluation failure: client-side throttling: only 8m30.897651224s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade https://access.redhat.com/solutions/7074686
-
-  Version: 4.13.49
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:ab6f574665395d809511db9dc57764358278538eaae248c6d199208b3c30ab7d
-  Reason: EvaluationFailed
-  Message: Exposure to ARODNSWrongBootSequence is unknown due to an evaluation failure: client-side throttling: only 8m30.897666224s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade https://access.redhat.com/solutions/7074686
-
-  Version: 4.13.48
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:7235b8e139da4ba4c17c2b4b9864c05c93c5f55f7c2f561e7f9796c7e6589917
-  Reason: EvaluationFailed
-  Message: Exposure to ARODNSWrongBootSequence is unknown due to an evaluation failure: client-side throttling: only 8m30.897670324s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade https://access.redhat.com/solutions/7074686
-
-  Version: 4.13.46
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:de889d3c3837ff9111765d8e5a4855e8b763dc759cb465fa2ebfcf0395d3f6b9
-  Reason: EvaluationFailed
-  Message: Exposure to ARODNSWrongBootSequence is unknown due to an evaluation failure: client-side throttling: only 8m30.897673524s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade https://access.redhat.com/solutions/7074686
-  
-  Exposure to AROSystemDLooping is unknown due to an evaluation failure: client-side throttling: only 8m30.897679225s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  ARO clusters created on 4.12.z and below are experiencing a bug where systemd detects a dependency loop. Systemd deletes these dependencies causing kubelet and crio to never start on nodes. https://access.redhat.com/solutions/7082093
-  
-  Exposure to AzureSystemDLooping is unknown due to an evaluation failure: client-side throttling: only 8m30.897686225s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Azure clusters created on 4.(y<12) or 4.12.(z<54) are experiencing a bug where systemd detects a dependency loop. Systemd deletes these dependencies causing CRI-O and the kublet to never start on nodes. https://issues.redhat.com/browse/MCO-1257
-
-  Version: 4.13.45
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:c7e3658ca8f0f1fc8ce1512ecc36785a68b1388dfbfc39642bff8120bfa86a33
-  Reason: EvaluationFailed
-  Message: Exposure to ARODNSWrongBootSequence is unknown due to an evaluation failure: client-side throttling: only 8m30.897691125s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade https://access.redhat.com/solutions/7074686
-
-  Version: 4.13.44
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:e58807c46fab369428af73bdfec64ad4b509dcbdb4586694059013c69856e8a5
-  Reason: EvaluationFailed
-  Message: Exposure to ARODNSWrongBootSequence is unknown due to an evaluation failure: client-side throttling: only 8m30.897694625s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade https://access.redhat.com/solutions/7074686
-
-  Version: 4.13.43
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:d0da3d9b016e6d693a61c9425598921b6d0da99c52cb0f3404f6dbc126149e5d
-  Reason: EvaluationFailed
-  Message: Exposure to ARODNSWrongBootSequence is unknown due to an evaluation failure: client-side throttling: only 8m30.897697825s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade https://access.redhat.com/solutions/7074686
-
-  Version: 4.13.42
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:dcf5c3ad7384f8bee3c275da8f886b0bc9aea7611d166d695d0cf0fff40a0b55
-  Reason: EvaluationFailed
-  Message: Exposure to ARODNSWrongBootSequence is unknown due to an evaluation failure: client-side throttling: only 8m30.897701825s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade https://access.redhat.com/solutions/7074686
-
-  Version: 4.13.41
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:dbb8aa0cf53dc5ac663514e259ad2768d8c82fd1fe7181a4cfb484e3ffdbd3ba
-  Reason: EvaluationFailed
-  Message: Exposure to ARODNSWrongBootSequence is unknown due to an evaluation failure: client-side throttling: only 8m30.897704925s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade https://access.redhat.com/solutions/7074686
-  
-  Exposure to CephCapDropPanic is unknown due to an evaluation failure: executing PromQL query: Post "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091/api/v1/query": dial tcp: lookup thanos-querier.openshift-monitoring.svc.cluster.local: no such host
-  Nodes in clusters running workloads that mount Ceph volumes may experience kernel panics due to a CephFS client bug. https://issues.redhat.com/browse/COS-2781
-
-  Version: 4.13.40
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:c1f69e6137bc9cda2c6da56bafbc7ea969900acb5e5c349b1ebb2103b10b424f
-  Reason: EvaluationFailed
-  Message: Exposure to ARODNSWrongBootSequence is unknown due to an evaluation failure: client-side throttling: only 8m30.897714725s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade https://access.redhat.com/solutions/7074686
-  
-  Exposure to CephCapDropPanic is unknown due to an evaluation failure: executing PromQL query: Post "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091/api/v1/query": dial tcp: lookup thanos-querier.openshift-monitoring.svc.cluster.local: no such host
-  Nodes in clusters running workloads that mount Ceph volumes may experience kernel panics due to a CephFS client bug. https://issues.redhat.com/browse/COS-2781
-
-  Version: 4.13.39
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:dd58c982a2166dcac5ce8f390f8b26b36df27ac765c4e012a670a9c0bac909df
-  Reason: EvaluationFailed
-  Message: Exposure to ARODNSWrongBootSequence is unknown due to an evaluation failure: client-side throttling: only 8m30.897721025s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade https://access.redhat.com/solutions/7074686
-  
-  Exposure to AcceleratedNetworkingRace is unknown due to an evaluation failure: client-side throttling: only 8m30.897724225s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node may fail for clusters running on Azure with Accelerated Networking. https://issues.redhat.com/browse/OPNET-479
-  
-  Exposure to CephCapDropPanic is unknown due to an evaluation failure: executing PromQL query: Post "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091/api/v1/query": dial tcp: lookup thanos-querier.openshift-monitoring.svc.cluster.local: no such host
-  Nodes in clusters running workloads that mount Ceph volumes may experience kernel panics due to a CephFS client bug. https://issues.redhat.com/browse/COS-2781
-
-  Version: 4.13.38
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:db7a6fad1d56cf391159d252daabbb44178132081e077ae290317b91633fb1db
-  Reason: EvaluationFailed
-  Message: Exposure to ARODNSWrongBootSequence is unknown due to an evaluation failure: client-side throttling: only 8m30.897735625s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade https://access.redhat.com/solutions/7074686
-  
-  Exposure to AcceleratedNetworkingRace is unknown due to an evaluation failure: client-side throttling: only 8m30.897739125s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node may fail for clusters running on Azure with Accelerated Networking. https://issues.redhat.com/browse/OPNET-479
-  
-  Exposure to CephCapDropPanic is unknown due to an evaluation failure: executing PromQL query: Post "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091/api/v1/query": dial tcp: lookup thanos-querier.openshift-monitoring.svc.cluster.local: no such host
-  Nodes in clusters running workloads that mount Ceph volumes may experience kernel panics due to a CephFS client bug. https://issues.redhat.com/browse/COS-2781
-
-  Version: 4.13.37
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:0fb7bbb4e6771acc99e32c55d4d37edf58ad31901acb78f552ce77ff4ba1eb3c
-  Reason: EvaluationFailed
-  Message: Exposure to ARODNSWrongBootSequence is unknown due to an evaluation failure: client-side throttling: only 8m30.897745525s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade https://access.redhat.com/solutions/7074686
-  
-  Exposure to AcceleratedNetworkingRace is unknown due to an evaluation failure: client-side throttling: only 8m30.897748725s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node may fail for clusters running on Azure with Accelerated Networking. https://issues.redhat.com/browse/OPNET-479
-  
-  Exposure to CephCapDropPanic is unknown due to an evaluation failure: executing PromQL query: Post "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091/api/v1/query": dial tcp: lookup thanos-querier.openshift-monitoring.svc.cluster.local: no such host
-  Nodes in clusters running workloads that mount Ceph volumes may experience kernel panics due to a CephFS client bug. https://issues.redhat.com/browse/COS-2781
-
-  Version: 4.13.36
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:9ed18a88ce6242dceab887ee7dc92eecf9e0194a569e1e8c924cbf4b1da7816e
-  Reason: MultipleReasons
-  Message: Exposure to ARODNSWrongBootSequence is unknown due to an evaluation failure: client-side throttling: only 8m30.897756025s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade https://access.redhat.com/solutions/7074686
-  
-  Exposure to AcceleratedNetworkingRace is unknown due to an evaluation failure: client-side throttling: only 8m30.897759025s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node may fail for clusters running on Azure with Accelerated Networking. https://issues.redhat.com/browse/OPNET-479
-  
-  Exposure to CephCapDropPanic is unknown due to an evaluation failure: executing PromQL query: Post "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091/api/v1/query": dial tcp: lookup thanos-querier.openshift-monitoring.svc.cluster.local: no such host
-  Nodes in clusters running workloads that mount Ceph volumes may experience kernel panics due to a CephFS client bug. https://issues.redhat.com/browse/COS-2781
-  
-  An unintended reversion to the default kubelet nodeStatusReportFrequency can cause significant load on the control plane. https://issues.redhat.com/browse/MCO-1094
-
-  Version: 4.13.35
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:2399ee629b41bf4c4006478260dcffd40849912398c09cba77bfada2fc481247
-  Reason: MultipleReasons
-  Message: Exposure to ARODNSWrongBootSequence is unknown due to an evaluation failure: client-side throttling: only 8m30.897766926s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade https://access.redhat.com/solutions/7074686
-  
-  Exposure to AcceleratedNetworkingRace is unknown due to an evaluation failure: client-side throttling: only 8m30.897771726s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node may fail for clusters running on Azure with Accelerated Networking. https://issues.redhat.com/browse/OPNET-479
-  
-  An unintended reversion to the default kubelet nodeStatusReportFrequency can cause significant load on the control plane. https://issues.redhat.com/browse/MCO-1094
-
-  Version: 4.13.34
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:04081f0cdc3a98eb9b705aceb86d4a035f7e6ccf6d9d10621776d53134f81c33
-  Reason: MultipleReasons
-  Message: Exposure to ARODNSWrongBootSequence is unknown due to an evaluation failure: client-side throttling: only 8m30.897778326s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade https://access.redhat.com/solutions/7074686
-  
-  Exposure to AcceleratedNetworkingRace is unknown due to an evaluation failure: client-side throttling: only 8m30.897781026s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node may fail for clusters running on Azure with Accelerated Networking. https://issues.redhat.com/browse/OPNET-479
-  
-  An unintended reversion to the default kubelet nodeStatusReportFrequency can cause significant load on the control plane. https://issues.redhat.com/browse/MCO-1094
-
-  Version: 4.13.33
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:7083519fd75dc187b7405968ba3d3d764a9807529e955411fd0ca1142dd4b560
-  Reason: MultipleReasons
-  Message: Exposure to ARODNSWrongBootSequence is unknown due to an evaluation failure: client-side throttling: only 8m30.897786526s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade https://access.redhat.com/solutions/7074686
-  
-  Exposure to AcceleratedNetworkingRace is unknown due to an evaluation failure: client-side throttling: only 8m30.897790026s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node may fail for clusters running on Azure with Accelerated Networking. https://issues.redhat.com/browse/OPNET-479
-  
-  An unintended reversion to the default kubelet nodeStatusReportFrequency can cause significant load on the control plane. https://issues.redhat.com/browse/MCO-1094
-
-  Version: 4.13.32
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:c39085b26665ed9877e208c123ff147cf7939dde4eca79a4f00fda8ea5b13dc9
-  Reason: EvaluationFailed
-  Message: Exposure to ARODNSWrongBootSequence is unknown due to an evaluation failure: client-side throttling: only 8m30.897797626s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade https://access.redhat.com/solutions/7074686
-  
-  Exposure to AcceleratedNetworkingRace is unknown due to an evaluation failure: client-side throttling: only 8m30.897800626s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node may fail for clusters running on Azure with Accelerated Networking. https://issues.redhat.com/browse/OPNET-479
-
-  Version: 4.13.31
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:07cf79d6998a9b6a2d19b7fe168a3300ad682de33f190c9eb27bf61e67d3eeee
-  Reason: EvaluationFailed
-  Message: Exposure to ARODNSWrongBootSequence is unknown due to an evaluation failure: client-side throttling: only 8m30.897808326s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade https://access.redhat.com/solutions/7074686
-  
-  Exposure to AcceleratedNetworkingRace is unknown due to an evaluation failure: client-side throttling: only 8m30.897811326s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node may fail for clusters running on Azure with Accelerated Networking. https://issues.redhat.com/browse/OPNET-479
-
-  Version: 4.13.30
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:661be5aec551ee1b774a7176ced6f755d5ec0a5e8b957db234a89ebc8dd3c0f5
-  Reason: EvaluationFailed
-  Message: Exposure to ARODNSWrongBootSequence is unknown due to an evaluation failure: client-side throttling: only 8m30.897817926s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade https://access.redhat.com/solutions/7074686
-  
-  Exposure to AcceleratedNetworkingRace is unknown due to an evaluation failure: client-side throttling: only 8m30.897821326s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node may fail for clusters running on Azure with Accelerated Networking. https://issues.redhat.com/browse/OPNET-479
-
-  Version: 4.13.29
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:9c4a4471bb93ab11d255925535ff719742cafa8ae06d622b870133787a72abc3
-  Reason: EvaluationFailed
-  Message: Exposure to AROBrokenDNSMasq is unknown due to an evaluation failure: client-side throttling: only 8m30.897828126s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node will fail for clusters running on ARO. https://issues.redhat.com/browse/MCO-958
-  
-  Exposure to ARODNSWrongBootSequence is unknown due to an evaluation failure: client-side throttling: only 8m30.897831226s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade https://access.redhat.com/solutions/7074686
-  
-  Exposure to AcceleratedNetworkingRace is unknown due to an evaluation failure: client-side throttling: only 8m30.897834226s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node may fail for clusters running on Azure with Accelerated Networking. https://issues.redhat.com/browse/OPNET-479
-  
-  Exposure to OVNKubeMasterDSPrestop is unknown due to an evaluation failure: client-side throttling: only 8m30.897839426s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Upgrades can get stuck on OVN clusters that were installed as 4.10 or earlier. https://issues.redhat.com/browse/SDN-4196
-
-  Version: 4.13.28
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:1c834045db967d579aa2f1ef6f836dcb21db13d804bdffb972e8f4a7a4d59fc2
-  Reason: EvaluationFailed
-  Message: Exposure to AROBrokenDNSMasq is unknown due to an evaluation failure: client-side throttling: only 8m30.897843926s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node will fail for clusters running on ARO. https://issues.redhat.com/browse/MCO-958
-  
-  Exposure to ARODNSWrongBootSequence is unknown due to an evaluation failure: client-side throttling: only 8m30.897846626s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade https://access.redhat.com/solutions/7074686
-  
-  Exposure to AcceleratedNetworkingRace is unknown due to an evaluation failure: client-side throttling: only 8m30.897849327s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node may fail for clusters running on Azure with Accelerated Networking. https://issues.redhat.com/browse/OPNET-479
-  
-  Exposure to OVNKubeMasterDSPrestop is unknown due to an evaluation failure: client-side throttling: only 8m30.897853727s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Upgrades can get stuck on OVN clusters that were installed as 4.10 or earlier. https://issues.redhat.com/browse/SDN-4196
-
-  Version: 4.13.27
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:bc9006f9160663663c6d9a735c4c497f8f3300d94a7ec45cdafef1cebb15ebfe
-  Reason: EvaluationFailed
-  Message: Exposure to AROBrokenDNSMasq is unknown due to an evaluation failure: client-side throttling: only 8m30.897859627s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node will fail for clusters running on ARO. https://issues.redhat.com/browse/MCO-958
-  
-  Exposure to ARODNSWrongBootSequence is unknown due to an evaluation failure: client-side throttling: only 8m30.897862827s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade https://access.redhat.com/solutions/7074686
-  
-  Exposure to AcceleratedNetworkingRace is unknown due to an evaluation failure: client-side throttling: only 8m30.897865527s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node may fail for clusters running on Azure with Accelerated Networking. https://issues.redhat.com/browse/OPNET-479
-  
-  Exposure to OVNKubeMasterDSPrestop is unknown due to an evaluation failure: client-side throttling: only 8m30.897869427s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Upgrades can get stuck on OVN clusters that were installed as 4.10 or earlier. https://issues.redhat.com/browse/SDN-4196
-
-  Version: 4.13.26
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:dece136ed888653cae20c2832b9e94de7c7ab24e34cddf49d5d284f41d7b61b1
-  Reason: EvaluationFailed
-  Message: Exposure to AROBrokenDNSMasq is unknown due to an evaluation failure: client-side throttling: only 8m30.897873427s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node will fail for clusters running on ARO. https://issues.redhat.com/browse/MCO-958
-  
-  Exposure to ARODNSWrongBootSequence is unknown due to an evaluation failure: client-side throttling: only 8m30.897877127s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade https://access.redhat.com/solutions/7074686
-  
-  Exposure to AcceleratedNetworkingRace is unknown due to an evaluation failure: client-side throttling: only 8m30.897880527s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node may fail for clusters running on Azure with Accelerated Networking. https://issues.redhat.com/browse/OPNET-479
-  
-  Exposure to OVNKubeMasterDSPrestop is unknown due to an evaluation failure: client-side throttling: only 8m30.897884227s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Upgrades can get stuck on OVN clusters that were installed as 4.10 or earlier. https://issues.redhat.com/browse/SDN-4196
-
-  Version: 4.13.25
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:480f2026c07b0f2e19c3fc60a44e4a7147ab821474641952f077573d05747855
-  Reason: EvaluationFailed
-  Message: Exposure to AROBrokenDNSMasq is unknown due to an evaluation failure: client-side throttling: only 8m30.897889027s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node will fail for clusters running on ARO. https://issues.redhat.com/browse/MCO-958
-  
-  Exposure to ARODNSWrongBootSequence is unknown due to an evaluation failure: client-side throttling: only 8m30.897892927s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade https://access.redhat.com/solutions/7074686
-  
-  Exposure to AcceleratedNetworkingRace is unknown due to an evaluation failure: client-side throttling: only 8m30.897895427s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node may fail for clusters running on Azure with Accelerated Networking. https://issues.redhat.com/browse/OPNET-479
-  
-  Exposure to OVNKubeMasterDSPrestop is unknown due to an evaluation failure: client-side throttling: only 8m30.897899627s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Upgrades can get stuck on OVN clusters that were installed as 4.10 or earlier. https://issues.redhat.com/browse/SDN-4196
-
-  Version: 4.13.24
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:d6a7e20a8929a3ad985373f05472ea64bada8ff46f0beb89e1b6d04919affde3
-  Reason: EvaluationFailed
-  Message: Exposure to AcceleratedNetworkingRace is unknown due to an evaluation failure: client-side throttling: only 8m30.897904227s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node may fail for clusters running on Azure with Accelerated Networking. https://issues.redhat.com/browse/OPNET-479
-  
-  Exposure to OVNKubeMasterDSPrestop is unknown due to an evaluation failure: client-side throttling: only 8m30.897908927s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Upgrades can get stuck on OVN clusters that were installed as 4.10 or earlier. https://issues.redhat.com/browse/SDN-4196
-
-  Version: 4.13.23
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:ca556d3494d08765c90481f15dd965995371168ea7ee7a551000bed4481931c8
-  Reason: EvaluationFailed
-  Message: Exposure to AcceleratedNetworkingRace is unknown due to an evaluation failure: client-side throttling: only 8m30.897913427s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node may fail for clusters running on Azure with Accelerated Networking. https://issues.redhat.com/browse/OPNET-479
-  
-  Exposure to OVNKubeMasterDSPrestop is unknown due to an evaluation failure: client-side throttling: only 8m30.897917227s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Upgrades can get stuck on OVN clusters that were installed as 4.10 or earlier. https://issues.redhat.com/browse/SDN-4196
-
-  Version: 4.13.22
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:f323afe3e80d44da7d0caaed8c353fedef37e5fd5e7f765e8440be86f546cba0
-  Reason: EvaluationFailed
-  Message: Exposure to AcceleratedNetworkingRace is unknown due to an evaluation failure: client-side throttling: only 8m30.897921627s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node may fail for clusters running on Azure with Accelerated Networking. https://issues.redhat.com/browse/OPNET-479
-  
-  Exposure to OVNKubeMasterDSPrestop is unknown due to an evaluation failure: client-side throttling: only 8m30.897926627s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Upgrades can get stuck on OVN clusters that were installed as 4.10 or earlier. https://issues.redhat.com/browse/SDN-4196
-
-  Version: 4.13.21
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:562c214e9662e3684ac5b8c3d5d2759a83f544da8897a00ebe91a02fcad6d2d9
-  Reason: EvaluationFailed
-  Message: Exposure to AcceleratedNetworkingRace is unknown due to an evaluation failure: client-side throttling: only 8m30.897930027s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node may fail for clusters running on Azure with Accelerated Networking. https://issues.redhat.com/browse/OPNET-479
-  
-  Exposure to OVNKubeMasterDSPrestop is unknown due to an evaluation failure: client-side throttling: only 8m30.897933928s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Upgrades can get stuck on OVN clusters that were installed as 4.10 or earlier. https://issues.redhat.com/browse/SDN-4196
-
-  Version: 4.13.19
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:f8ba6f54eae419aba17926417d950ae18e06021beae9d7947a8b8243ad48353a
-  Reason: EvaluationFailed
-  Message: Exposure to AcceleratedNetworkingRace is unknown due to an evaluation failure: client-side throttling: only 8m30.897939028s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node may fail for clusters running on Azure with Accelerated Networking. https://issues.redhat.com/browse/OPNET-479
-  
-  Exposure to OVNKubeMasterDSPrestop is unknown due to an evaluation failure: client-side throttling: only 8m30.897943128s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Upgrades can get stuck on OVN clusters that were installed as 4.10 or earlier. https://issues.redhat.com/browse/SDN-4196
-
-  Version: 4.13.18
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:d0fd9d3ab8690605f816c879d74f4e6d6d9f72982f63a3e0ef3e027ecc512e1c
-  Reason: EvaluationFailed
-  Message: Exposure to AcceleratedNetworkingRace is unknown due to an evaluation failure: client-side throttling: only 8m30.897947628s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node may fail for clusters running on Azure with Accelerated Networking. https://issues.redhat.com/browse/OPNET-479
-  
-  Exposure to OVNKubeMasterDSPrestop is unknown due to an evaluation failure: client-side throttling: only 8m30.897952528s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Upgrades can get stuck on OVN clusters that were installed as 4.10 or earlier. https://issues.redhat.com/browse/SDN-4196
-
-  Version: 4.13.17
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:c1f2fa2170c02869484a4e049132128e216a363634d38abf292eef181e93b692
-  Reason: EvaluationFailed
-  Message: Exposure to AcceleratedNetworkingRace is unknown due to an evaluation failure: client-side throttling: only 8m30.897956028s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node may fail for clusters running on Azure with Accelerated Networking. https://issues.redhat.com/browse/OPNET-479
-  
-  Exposure to OVNKubeMasterDSPrestop is unknown due to an evaluation failure: client-side throttling: only 8m30.897959828s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Upgrades can get stuck on OVN clusters that were installed as 4.10 or earlier. https://issues.redhat.com/browse/SDN-4196
-
-  Version: 4.13.15
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:78f08839886fb2896857f95de0347b8f67ebcff16591b9d7aec87a20406b2897
-  Reason: EvaluationFailed
-  Message: Exposure to AcceleratedNetworkingRace is unknown due to an evaluation failure: client-side throttling: only 8m30.897963128s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node may fail for clusters running on Azure with Accelerated Networking. https://issues.redhat.com/browse/OPNET-479
-
-  Version: 4.13.14
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:406fcc160c097f61080412afcfa7fd65284ac8741ac7ad5b480e304aba73674b
-  Reason: EvaluationFailed
-  Message: Exposure to AcceleratedNetworkingRace is unknown due to an evaluation failure: client-side throttling: only 8m30.897966028s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node may fail for clusters running on Azure with Accelerated Networking. https://issues.redhat.com/browse/OPNET-479
-
-  Version: 4.13.13
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:d62495768e335c79a215ba56771ff5ae97e3cbb2bf49ed8fb3f6cefabcdc0f17
-  Reason: EvaluationFailed
-  Message: Exposure to AcceleratedNetworkingRace is unknown due to an evaluation failure: client-side throttling: only 8m30.897969128s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node may fail for clusters running on Azure with Accelerated Networking. https://issues.redhat.com/browse/OPNET-479
-
-  Version: 4.13.12
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:73946971c03b43a0dc6f7b0946b26a177c2f3c9d37105441315b4e3359373a55
-  Reason: EvaluationFailed
-  Message: Exposure to AcceleratedNetworkingRace is unknown due to an evaluation failure: client-side throttling: only 8m30.897972328s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node may fail for clusters running on Azure with Accelerated Networking. https://issues.redhat.com/browse/OPNET-479
-
-  Version: 4.13.11
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:e1c2377fdae1d063aaddc753b99acf25972b6997ab9a0b7e80cfef627b9ef3dd
-  Reason: EvaluationFailed
-  Message: Exposure to AcceleratedNetworkingRace is unknown due to an evaluation failure: client-side throttling: only 8m30.897975728s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node may fail for clusters running on Azure with Accelerated Networking. https://issues.redhat.com/browse/OPNET-479
-
-  Version: 4.13.10
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:28173b4b6efe4f67f8753566e5f3c9831e454609b7f1888e4b6687907f4b7f24
-  Reason: EvaluationFailed
-  Message: Exposure to AcceleratedNetworkingRace is unknown due to an evaluation failure: client-side throttling: only 8m30.897979428s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node may fail for clusters running on Azure with Accelerated Networking. https://issues.redhat.com/browse/OPNET-479
-
-  Version: 4.13.9
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:a266d3d65c433b460cdef7ab5d6531580f5391adbe85d9c475208a56452e4c0b
-  Reason: MultipleReasons
-  Message: Exposure to AcceleratedNetworkingRace is unknown due to an evaluation failure: client-side throttling: only 8m30.897982328s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node may fail for clusters running on Azure with Accelerated Networking. https://issues.redhat.com/browse/OPNET-479
-  
-  Pods scheduled to nodes running a RHCOS/kernel version with a known defect may fail to start with a CreateContainerError. https://issues.redhat.com/browse/COS-2437
-
-  Version: 4.13.8
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:a956488d295fe5a59c8663a4d9992b9b5d0950f510a7387dbbfb8d20fc5970ce
-  Reason: MultipleReasons
-  Message: Exposure to AcceleratedNetworkingRace is unknown due to an evaluation failure: client-side throttling: only 8m30.897987328s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node may fail for clusters running on Azure with Accelerated Networking. https://issues.redhat.com/browse/OPNET-479
-  
-  Pods scheduled to nodes running a RHCOS/kernel version with a known defect may fail to start with a CreateContainerError. https://issues.redhat.com/browse/COS-2437
-
-  Version: 4.13.6
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:3ca57045e070978b38c36d4c98e188795a6cb4b128130f9c8d7a08b47c133aba
-  Reason: MultipleReasons
-  Message: Exposure to AcceleratedNetworkingRace is unknown due to an evaluation failure: client-side throttling: only 8m30.897991228s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node may fail for clusters running on Azure with Accelerated Networking. https://issues.redhat.com/browse/OPNET-479
-  
-  Pods scheduled to nodes running a RHCOS/kernel version with a known defect may fail to start with a CreateContainerError. https://issues.redhat.com/browse/COS-2437
-
-  Version: 4.13.5
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:af19e94813478382e36ae1fa2ae7bbbff1f903dded6180f4eb0624afe6fc6cd4
-  Reason: MultipleReasons
-  Message: Exposure to AcceleratedNetworkingRace is unknown due to an evaluation failure: client-side throttling: only 8m30.897994928s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node may fail for clusters running on Azure with Accelerated Networking. https://issues.redhat.com/browse/OPNET-479
-  
-  Pods scheduled to nodes running a RHCOS/kernel version with a known defect may fail to start with a CreateContainerError. https://issues.redhat.com/browse/COS-2437
-
-  Version: 4.13.4
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:e3fb8ace9881ae5428ae7f0ac93a51e3daa71fa215b5299cd3209e134cadfc9c
-  Reason: MultipleReasons
-  Message: Exposure to AcceleratedNetworkingRace is unknown due to an evaluation failure: client-side throttling: only 8m30.897998428s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node may fail for clusters running on Azure with Accelerated Networking. https://issues.redhat.com/browse/OPNET-479
-  
-  Exposure to MultiNetworkAttachmentsWhereaboutsVersion is unknown due to an evaluation failure: client-side throttling: only 8m30.898001028s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Upgrade can get stuck on clusters that have multiple network attachments. https://access.redhat.com/solutions/7024726
-  
-  Exposure to PerformanceProfilesCPUQuota is unknown due to an evaluation failure: client-side throttling: only 8m30.898004028s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Pods may not execute properly because of CPU quota issues on clusters using PerformanceProfiles. https://issues.redhat.com/browse/OCPNODE-1705
-  
-  Pods scheduled to nodes running a RHCOS/kernel version with a known defect may fail to start with a CreateContainerError. https://issues.redhat.com/browse/COS-2437
-
-  Version: 4.13.3
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:bc9835804046aa844c874d2cc37387ec95fe7e87d8ce96129fba78d465c932fa
-  Reason: MultipleReasons
-  Message: Exposure to AcceleratedNetworkingRace is unknown due to an evaluation failure: client-side throttling: only 8m30.898009228s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node may fail for clusters running on Azure with Accelerated Networking. https://issues.redhat.com/browse/OPNET-479
-  
-  Exposure to MultiNetworkAttachmentsWhereaboutsVersion is unknown due to an evaluation failure: client-side throttling: only 8m30.898011828s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Upgrade can get stuck on clusters that have multiple network attachments. https://access.redhat.com/solutions/7024726
-  
-  Exposure to PerformanceProfilesCPUQuota is unknown due to an evaluation failure: client-side throttling: only 8m30.898014828s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Pods may not execute properly because of CPU quota issues on clusters using PerformanceProfiles. https://issues.redhat.com/browse/OCPNODE-1705
-  
-  New PersistentVolumes are created bound to an invalid symlink instead of the correct one and thus fail once updated to 4.13.4 or later as the invalid symlink dispears. https://issues.redhat.com/browse/COS-2349
-  
-  Pods scheduled to nodes running a RHCOS/kernel version with a known defect may fail to start with a CreateContainerError. https://issues.redhat.com/browse/COS-2437
-
-  Version: 4.13.2
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:6ef3cf4bed1970d547dce08a6e334b675d361b212427c4493151dcad6e093d27
-  Reason: MultipleReasons
-  Message: Exposure to AcceleratedNetworkingRace is unknown due to an evaluation failure: client-side throttling: only 8m30.898019529s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node may fail for clusters running on Azure with Accelerated Networking. https://issues.redhat.com/browse/OPNET-479
-  
-  Exposure to MultiNetworkAttachmentsWhereaboutsVersion is unknown due to an evaluation failure: client-side throttling: only 8m30.898022029s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Upgrade can get stuck on clusters that have multiple network attachments. https://access.redhat.com/solutions/7024726
-  
-  Exposure to PerformanceProfilesCPUQuota is unknown due to an evaluation failure: client-side throttling: only 8m30.898025429s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Pods may not execute properly because of CPU quota issues on clusters using PerformanceProfiles. https://issues.redhat.com/browse/OCPNODE-1705
-  
-  New PersistentVolumes are created bound to an invalid symlink instead of the correct one and thus fail once updated to 4.13.4 or later as the invalid symlink dispears. https://issues.redhat.com/browse/COS-2349
-  
-  Pods scheduled to nodes running a RHCOS/kernel version with a known defect may fail to start with a CreateContainerError. https://issues.redhat.com/browse/COS-2437
-
-  Version: 4.13.1
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:9c92b5ec203ee7f81626cc4e9f02086484056a76548961e5895916f136302b1f
-  Reason: MultipleReasons
-  Message: Exposure to AcceleratedNetworkingRace is unknown due to an evaluation failure: client-side throttling: only 8m30.898031629s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node may fail for clusters running on Azure with Accelerated Networking. https://issues.redhat.com/browse/OPNET-479
-  
-  Exposure to MultiNetworkAttachmentsWhereaboutsVersion is unknown due to an evaluation failure: client-side throttling: only 8m30.898034429s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Upgrade can get stuck on clusters that have multiple network attachments. https://access.redhat.com/solutions/7024726
-  
-  Exposure to PerformanceProfilesCPUQuota is unknown due to an evaluation failure: client-side throttling: only 8m30.898037329s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Pods may not execute properly because of CPU quota issues on clusters using PerformanceProfiles. https://issues.redhat.com/browse/OCPNODE-1705
-  
-  New PersistentVolumes are created bound to an invalid symlink instead of the correct one and thus fail once updated to 4.13.4 or later as the invalid symlink dispears. https://issues.redhat.com/browse/COS-2349
-  
-  Pods scheduled to nodes running a RHCOS/kernel version with a known defect may fail to start with a CreateContainerError. https://issues.redhat.com/browse/COS-2437
-
-  Version: 4.13.0
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:74b23ed4bbb593195a721373ed6693687a9b444c97065ce8ac653ba464375711
-  Reason: MultipleReasons
-  Message: Exposure to AcceleratedNetworkingRace is unknown due to an evaluation failure: client-side throttling: only 8m30.898043529s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Adding a new worker node may fail for clusters running on Azure with Accelerated Networking. https://issues.redhat.com/browse/OPNET-479
-  
-  Exposure to MultiNetworkAttachmentsWhereaboutsVersion is unknown due to an evaluation failure: client-side throttling: only 8m30.898047129s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Upgrade can get stuck on clusters that have multiple network attachments. https://access.redhat.com/solutions/7024726
-  
-  Exposure to PerformanceProfilesCPUQuota is unknown due to an evaluation failure: client-side throttling: only 8m30.898050029s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Pods may not execute properly because of CPU quota issues on clusters using PerformanceProfiles. https://issues.redhat.com/browse/OCPNODE-1705
-  
-  New PersistentVolumes are created bound to an invalid symlink instead of the correct one and thus fail once updated to 4.13.4 or later as the invalid symlink dispears. https://issues.redhat.com/browse/COS-2349
-  
-  Pods scheduled to nodes running a RHCOS/kernel version with a known defect may fail to start with a CreateContainerError. https://issues.redhat.com/browse/COS-2437
+  VERSION     ISSUES
+  4.13.50     EvaluationFailed
+  4.13.49     EvaluationFailed
+  4.13.48     EvaluationFailed
+  4.13.46     EvaluationFailed
+  4.13.45     EvaluationFailed
+  4.13.44     EvaluationFailed
+  4.13.43     EvaluationFailed
+  4.13.42     EvaluationFailed
+  4.13.41     EvaluationFailed
+  4.13.40     EvaluationFailed
+  4.13.39     EvaluationFailed
+  4.13.38     EvaluationFailed
+  4.13.37     EvaluationFailed
+  4.13.36     MultipleReasons
+  4.13.35     MultipleReasons
+  4.13.34     MultipleReasons
+  4.13.33     MultipleReasons
+  4.13.32     EvaluationFailed
+  4.13.31     EvaluationFailed
+  4.13.30     EvaluationFailed
+  4.13.29     EvaluationFailed
+  4.13.28     EvaluationFailed
+  4.13.27     EvaluationFailed
+  4.13.26     EvaluationFailed
+  4.13.25     EvaluationFailed
+  4.13.24     EvaluationFailed
+  4.13.23     EvaluationFailed
+  4.13.22     EvaluationFailed
+  4.13.21     EvaluationFailed
+  4.13.19     EvaluationFailed
+  4.13.18     EvaluationFailed
+  4.13.17     EvaluationFailed
+  4.13.15     EvaluationFailed
+  4.13.14     EvaluationFailed
+  4.13.13     EvaluationFailed
+  4.13.12     EvaluationFailed
+  4.13.11     EvaluationFailed
+  4.13.10     EvaluationFailed
+  4.13.9      MultipleReasons
+  4.13.8      MultipleReasons
+  4.13.6      MultipleReasons
+  4.13.5      MultipleReasons
+  4.13.4      MultipleReasons
+  4.13.3      MultipleReasons
+  4.13.2      MultipleReasons
+  4.13.1      MultipleReasons
+  4.13.0      MultipleReasons
 
 Updates to 4.12:
-  VERSION     IMAGE
-  4.12.64     quay.io/openshift-release-dev/ocp-release@sha256:669170342e3ae3456b2eb00dd0c45cd817d62af310e0aa2bf214f1da65fae9d0
-  4.12.63     quay.io/openshift-release-dev/ocp-release@sha256:5db6f8dd1db6b9d07dacfa74574a38a6e518145a3c0ab5d895e9c89e029a39e4
-  4.12.61     quay.io/openshift-release-dev/ocp-release@sha256:faa201ea7790bb101de7b9b6f01543136e8c589463b8437a10678da0cdd0197a
-  4.12.60     quay.io/openshift-release-dev/ocp-release@sha256:22174072f8aaef46f80bded25d5a2bdfa6fd8bb01fc5242a07e550f132cafc5a
-  4.12.59     quay.io/openshift-release-dev/ocp-release@sha256:8908e5a46f106e7520faa5f5ee679033c4c2f0026f1b8a339e6b3ea4becdd969
-  4.12.58     quay.io/openshift-release-dev/ocp-release@sha256:b622d947ade4a13754e9d9f6803107f1b321eecd925c897f3c12de1aafccbdc5
-  4.12.57     quay.io/openshift-release-dev/ocp-release@sha256:ebd20cd66e0bbb5bcd7d16559ff4856918b7172e29d6a7bd34d8cc49a556b8f7
-
-  Version: 4.12.56
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:7446b0c3cc24c6d35c0d0fc968ef27f52da92c60f41951c0e646041db108169a
-  Reason: EvaluationFailed
-  Message: Exposure to CephCapDropPanic is unknown due to an evaluation failure: executing PromQL query: Post "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091/api/v1/query": dial tcp: lookup thanos-querier.openshift-monitoring.svc.cluster.local: no such host
-  Nodes in clusters running workloads that mount Ceph volumes may experience kernel panics due to a CephFS client bug. https://issues.redhat.com/browse/COS-2781
-
-  Version: 4.12.55
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:ecf790d11e32ec8c88c4224660eb1a107db5fdf54b0712eededb9d9bf0ab1a6d
-  Reason: EvaluationFailed
-  Message: Exposure to CephCapDropPanic is unknown due to an evaluation failure: executing PromQL query: Post "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091/api/v1/query": dial tcp: lookup thanos-querier.openshift-monitoring.svc.cluster.local: no such host
-  Nodes in clusters running workloads that mount Ceph volumes may experience kernel panics due to a CephFS client bug. https://issues.redhat.com/browse/COS-2781
-
-  Version: 4.12.54
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:5bbeeae3698249a41d6bd9987aac42cecbe862e1dd3710ab16ff4da651fc66a8
-  Reason: EvaluationFailed
-  Message: Exposure to CephCapDropPanic is unknown due to an evaluation failure: executing PromQL query: Post "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091/api/v1/query": dial tcp: lookup thanos-querier.openshift-monitoring.svc.cluster.local: no such host
-  Nodes in clusters running workloads that mount Ceph volumes may experience kernel panics due to a CephFS client bug. https://issues.redhat.com/browse/COS-2781
-
-  VERSION     IMAGE
-  4.12.53     quay.io/openshift-release-dev/ocp-release@sha256:b584f5458fb946115b0cf0f1793dc9224c5e6a4567e74018f0590805a03eb523
-
-  Version: 4.12.51
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:158ced797e49f6caf7862acccef58484be63b642fdd2f66e6416295fa7958ab0
-  Reason: MultipleReasons
-  Message: An unintended reversion to the default kubelet nodeStatusReportFrequency can cause significant load on the control plane. https://issues.redhat.com/browse/MCO-1094
-  
-  After rebooting into kernel-4.18.0-372.88.1.el8_6 or later, kernel nodes experience high load average and io_wait times. The nodes might fail to start or stop pods and probes may fail. Workload and host processes may become unresponsive and workload may be disrupted. https://issues.redhat.com/browse/COS-2705
-
-  Version: 4.12.50
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:a9d7e4938d224a6a8f9c7a5c05ca2b4d6e92292812b14c4a3e0d9e938e8dc3bf
-  Reason: RHELKernelHighLoadIOWait
-  Message: After rebooting into kernel-4.18.0-372.88.1.el8_6 or later, kernel nodes experience high load average and io_wait times. The nodes might fail to start or stop pods and probes may fail. Workload and host processes may become unresponsive and workload may be disrupted. https://issues.redhat.com/browse/COS-2705
-
-  Version: 4.12.49
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:c93133ca1ccb35ea8552065ed7a74dccf5c7ee133e581f5211e465f1914c62d7
-  Reason: RHELKernelHighLoadIOWait
-  Message: After rebooting into kernel-4.18.0-372.88.1.el8_6 or later, kernel nodes experience high load average and io_wait times. The nodes might fail to start or stop pods and probes may fail. Workload and host processes may become unresponsive and workload may be disrupted. https://issues.redhat.com/browse/COS-2705
-
-  VERSION     IMAGE
-  4.12.48     quay.io/openshift-release-dev/ocp-release@sha256:c31b9b63b8c21d4327201fd0e78a4b6b0af7f1f8162acd29e4cde1cd65a56d19
-
-  Version: 4.12.47
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:fcc9920ba10ebb02c69bdd9cd597273260eeec1b22e9ef9986a47f4874a21253
-  Reason: EvaluationFailed
-  Message: Exposure to OVNKubeMasterDSPrestop is unknown due to an evaluation failure: client-side throttling: only 8m30.898085029s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Upgrades can get stuck on OVN clusters that were installed as 4.10 or earlier. https://issues.redhat.com/browse/SDN-4196
-
-  Version: 4.12.46
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:2dda17736b7b747b463b040cb3b7abba9c4174b0922e2fd84127e3887f6d69c5
-  Reason: EvaluationFailed
-  Message: Exposure to OVNKubeMasterDSPrestop is unknown due to an evaluation failure: client-side throttling: only 8m30.898090729s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Upgrades can get stuck on OVN clusters that were installed as 4.10 or earlier. https://issues.redhat.com/browse/SDN-4196
-
-  Version: 4.12.45
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:faf0aebc0abce8890e046eecfa392c24bc24f6c49146c45447fb0977e692db6e
-  Reason: EvaluationFailed
-  Message: Exposure to OVNKubeMasterDSPrestop is unknown due to an evaluation failure: client-side throttling: only 8m30.898096329s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Upgrades can get stuck on OVN clusters that were installed as 4.10 or earlier. https://issues.redhat.com/browse/SDN-4196
-
-  Version: 4.12.44
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:304f37f9d7aa290252951751c5bf03a97085f77b4bcde0ed8a2fa455e9600e68
-  Reason: EvaluationFailed
-  Message: Exposure to OVNKubeMasterDSPrestop is unknown due to an evaluation failure: client-side throttling: only 8m30.898100329s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Upgrades can get stuck on OVN clusters that were installed as 4.10 or earlier. https://issues.redhat.com/browse/SDN-4196
-
-  Version: 4.12.43
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:10221b3f8f23fe625f3aab8f1e3297eaa340efc64fb5eff8d46cc8461888804e
-  Reason: EvaluationFailed
-  Message: Exposure to OVNKubeMasterDSPrestop is unknown due to an evaluation failure: client-side throttling: only 8m30.89810603s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Upgrades can get stuck on OVN clusters that were installed as 4.10 or earlier. https://issues.redhat.com/browse/SDN-4196
-
-  Version: 4.12.42
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:a52419c56d84f2953ddaa121e89a3d806902af4538503d8cf229b1e8a14f8902
-  Reason: EvaluationFailed
-  Message: Exposure to OVNKubeMasterDSPrestop is unknown due to an evaluation failure: client-side throttling: only 8m30.89811093s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Upgrades can get stuck on OVN clusters that were installed as 4.10 or earlier. https://issues.redhat.com/browse/SDN-4196
-
-  Version: 4.12.41
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:59c93fdfff4ecca2ca6d6bb0ec722bca2bb08152252ae10ce486a9fc80c82dcf
-  Reason: EvaluationFailed
-  Message: Exposure to OVNKubeMasterDSPrestop is unknown due to an evaluation failure: client-side throttling: only 8m30.89811573s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Upgrades can get stuck on OVN clusters that were installed as 4.10 or earlier. https://issues.redhat.com/browse/SDN-4196
-
-  VERSION     IMAGE
-  4.12.40     quay.io/openshift-release-dev/ocp-release@sha256:b0b1aac82f9083d20e7e4269b05dd3679299d277d122fa9d29b772f38d2cacff
-  4.12.39     quay.io/openshift-release-dev/ocp-release@sha256:75687feb6344caeb0edb6b1513b53fd07b90b481079415b6545d860fe74059eb
-  4.12.37     quay.io/openshift-release-dev/ocp-release@sha256:ba7544a126dfd1028cfa9e9afde9ae9d2eb21bad26f8da56eb7aebc0fb132c84
-  4.12.36     quay.io/openshift-release-dev/ocp-release@sha256:38ccab25d5895a216a465a9f297541fbbebe7aa115fdaa9f2015c8d5a5d036eb
-  4.12.35     quay.io/openshift-release-dev/ocp-release@sha256:ef892e96305d4f401860304732b06ca4eac5dbcce287ebaa98c48edd6fb91023
-  4.12.34     quay.io/openshift-release-dev/ocp-release@sha256:b411b7157e124ccb5c9cd1c72499759a2cb0d784e5107c03dc73a7c83359bb1b
-  4.12.33     quay.io/openshift-release-dev/ocp-release@sha256:ab18794370bfbb469d7f37fef8ca17b7d3ef3976b7ad3e28b137398c9154ea86
-  4.12.32     quay.io/openshift-release-dev/ocp-release@sha256:008c933f9d2b49721d6729c1e558f3f0c91e8368201d33469dcd5bda5cf7d333
-  4.12.31     quay.io/openshift-release-dev/ocp-release@sha256:4e0e74e9fdfbaec726654fa883b2018beb548e12ad9db2ffbeb7cf2d6862f7e8
-  4.12.30     quay.io/openshift-release-dev/ocp-release@sha256:86ee723d4dc2a83f836232d1d03f8b4193940c50a2636ee86924acb5d14b0b64
-  4.12.29     quay.io/openshift-release-dev/ocp-release@sha256:dac46152be54e0669694e0ae56d66d8fb3c34dc26ec0d3704eef29d6099846c4
-  4.12.28     quay.io/openshift-release-dev/ocp-release@sha256:f3910eae62029cf1108aadc9f9c649625e49a998d3e5547cb8849d0db9c54843
-  4.12.27     quay.io/openshift-release-dev/ocp-release@sha256:e15e52f22247b833d1db59b1507fa67d920e39b75297bc3a74f3f15e560d6d02
-  4.12.26     quay.io/openshift-release-dev/ocp-release@sha256:8d72f29227418d2ae12ee52e25cce9edef7cd645bdaea02410a89fe8a0ec6a47
-
-  Version: 4.12.25
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:5a4fb052cda1d14d1e306ce87e6b0ded84edddaa76f1cf401bcded99cef2ad84
-  Reason: EvaluationFailed
-  Message: Exposure to MultiNetworkAttachmentsWhereaboutsVersion is unknown due to an evaluation failure: client-side throttling: only 8m30.89811903s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Upgrade can get stuck on clusters that have multiple network attachments. https://access.redhat.com/solutions/7024726
-
-  Version: 4.12.24
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:b0b11eedf91175459b5d7aefcf3936d0cabf00f01ced756677483f5f26227328
-  Reason: EvaluationFailed
-  Message: Exposure to MultiNetworkAttachmentsWhereaboutsVersion is unknown due to an evaluation failure: client-side throttling: only 8m30.89812213s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Upgrade can get stuck on clusters that have multiple network attachments. https://access.redhat.com/solutions/7024726
-
-  Version: 4.12.23
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:2309578b68c5666dad62aed696f1f9d778ae1a089ee461060ba7b9514b7ca417
-  Reason: EvaluationFailed
-  Message: Exposure to MultiNetworkAttachmentsWhereaboutsVersion is unknown due to an evaluation failure: client-side throttling: only 8m30.89812513s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Upgrade can get stuck on clusters that have multiple network attachments. https://access.redhat.com/solutions/7024726
-
-  Version: 4.12.22
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:ba7956f5c2aae61c8ff3ab1ab2ee7e625db9b1c8964a65339764db79c148e4e6
-  Reason: EvaluationFailed
-  Message: Exposure to MultiNetworkAttachmentsWhereaboutsVersion is unknown due to an evaluation failure: client-side throttling: only 8m30.89812813s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Upgrade can get stuck on clusters that have multiple network attachments. https://access.redhat.com/solutions/7024726
-
-  Version: 4.12.21
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:71e158c6173ad6aa6e356c119a87459196bbe70e89c0db1e35c1f63a87d90676
-  Reason: EvaluationFailed
-  Message: Exposure to MultiNetworkAttachmentsWhereaboutsVersion is unknown due to an evaluation failure: client-side throttling: only 8m30.89813093s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Upgrade can get stuck on clusters that have multiple network attachments. https://access.redhat.com/solutions/7024726
-
-  Version: 4.12.20
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:5c504578e34e8cf6eb70fad7a9bee92896b6d38d09b6d81891f730ee4f9d268b
-  Reason: MultipleReasons
-  Message: Upgrade can get stuck on clusters that use multiple networks together with dual stack. https://issues.redhat.com/browse/SDN-3996
-  
-  Exposure to MultiNetworkAttachmentsWhereaboutsVersion is unknown due to an evaluation failure: client-side throttling: only 8m30.89813453s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Upgrade can get stuck on clusters that have multiple network attachments. https://access.redhat.com/solutions/7024726
-
-  Version: 4.12.19
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:41fd42cc8b9f86fc86cc8763dcf27e976299ff632a336d393b8e643bd8a5f967
-  Reason: MultipleReasons
-  Message: Upgrade can get stuck on clusters that use multiple networks together with dual stack. https://issues.redhat.com/browse/SDN-3996
-  
-  Exposure to MultiNetworkAttachmentsWhereaboutsVersion is unknown due to an evaluation failure: client-side throttling: only 8m30.89813823s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Upgrade can get stuck on clusters that have multiple network attachments. https://access.redhat.com/solutions/7024726
-
-  Version: 4.12.18
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:8465e416a403cec2e6887c8aebe783b976f46f81d513890f17037b652b143de5
-  Reason: MultipleReasons
-  Message: Upgrade can get stuck on clusters that use multiple networks together with dual stack. https://issues.redhat.com/browse/SDN-3996
-  
-  Exposure to MultiNetworkAttachmentsWhereaboutsVersion is unknown due to an evaluation failure: client-side throttling: only 8m30.89814223s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
-  Upgrade can get stuck on clusters that have multiple network attachments. https://access.redhat.com/solutions/7024726
-
-  VERSION     IMAGE
-  4.12.17     quay.io/openshift-release-dev/ocp-release@sha256:7ca5f8aa44bbc537c5a985a523d87365eab3f6e72abc50b7be4caae741e093f4
+  VERSION     ISSUES
+  4.12.64     
+  4.12.63     
+  4.12.61     
+  4.12.60     
+  4.12.59     
+  4.12.58     
+  4.12.57     
+  4.12.56     EvaluationFailed
+  4.12.55     EvaluationFailed
+  4.12.54     EvaluationFailed
+  4.12.53     
+  4.12.51     MultipleReasons
+  4.12.50     RHELKernelHighLoadIOWait
+  4.12.49     RHELKernelHighLoadIOWait
+  4.12.48     
+  4.12.47     EvaluationFailed
+  4.12.46     EvaluationFailed
+  4.12.45     EvaluationFailed
+  4.12.44     EvaluationFailed
+  4.12.43     EvaluationFailed
+  4.12.42     EvaluationFailed
+  4.12.41     EvaluationFailed
+  4.12.40     
+  4.12.39     
+  4.12.37     
+  4.12.36     
+  4.12.35     
+  4.12.34     
+  4.12.33     
+  4.12.32     
+  4.12.31     
+  4.12.30     
+  4.12.29     
+  4.12.28     
+  4.12.27     
+  4.12.26     
+  4.12.25     EvaluationFailed
+  4.12.24     EvaluationFailed
+  4.12.23     EvaluationFailed
+  4.12.22     EvaluationFailed
+  4.12.21     EvaluationFailed
+  4.12.20     MultipleReasons
+  4.12.19     MultipleReasons
+  4.12.18     MultipleReasons
+  4.12.17     

--- a/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-not-recommended.version-4.12.51-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-not-recommended.version-4.12.51-output
@@ -1,0 +1,15 @@
+Upgradeable=False
+
+  Reason: AdminAckRequired
+  Message: Kubernetes 1.26 and therefore OpenShift 4.13 remove several APIs which require admin consideration. Please see the knowledge article https://access.redhat.com/articles/6958394 for details and instructions.
+
+Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
+Channel: stable-4.13 (available channels: candidate-4.12, candidate-4.13, eus-4.12, eus-4.14, fast-4.12, fast-4.13, stable-4.12, stable-4.13)
+
+Update to 4.12.51 Recommended=False:
+Image: quay.io/openshift-release-dev/ocp-release@sha256:158ced797e49f6caf7862acccef58484be63b642fdd2f66e6416295fa7958ab0
+URL: https://access.redhat.com/errata/RHSA-2024:1052
+Reason: MultipleReasons
+Message: An unintended reversion to the default kubelet nodeStatusReportFrequency can cause significant load on the control plane. https://issues.redhat.com/browse/MCO-1094
+  
+  After rebooting into kernel-4.18.0-372.88.1.el8_6 or later, kernel nodes experience high load average and io_wait times. The nodes might fail to start or stop pods and probes may fail. Workload and host processes may become unresponsive and workload may be disrupted. https://issues.redhat.com/browse/COS-2705

--- a/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-recommended.output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-recommended.output
@@ -7,13 +7,13 @@ Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: stable-4.13 (available channels: candidate-4.12, candidate-4.13, eus-4.12, eus-4.14, fast-4.12, fast-4.13, stable-4.12, stable-4.13)
 
 Updates to 4.13:
-  VERSION     IMAGE
-  4.13.50     quay.io/openshift-release-dev/ocp-release@sha256:6afb11e1cac46fd26476ca134072937115256b9c6360f7a1cd1812992c065f02
-  4.13.49     quay.io/openshift-release-dev/ocp-release@sha256:ab6f574665395d809511db9dc57764358278538eaae248c6d199208b3c30ab7d
-And 45 older 4.13 updates you can see with --show-outdated-releases
+  VERSION     ISSUES
+  4.13.50     
+  4.13.49     
+And 45 older 4.13 updates you can see with '--show-outdated-releases' or '--version VERSION'.
 
 Updates to 4.12:
-  VERSION     IMAGE
-  4.12.64     quay.io/openshift-release-dev/ocp-release@sha256:669170342e3ae3456b2eb00dd0c45cd817d62af310e0aa2bf214f1da65fae9d0
-  4.12.63     quay.io/openshift-release-dev/ocp-release@sha256:5db6f8dd1db6b9d07dacfa74574a38a6e518145a3c0ab5d895e9c89e029a39e4
-And 43 older 4.12 updates you can see with --show-outdated-releases
+  VERSION     ISSUES
+  4.12.64     
+  4.12.63     
+And 43 older 4.12 updates you can see with '--show-outdated-releases' or '--version VERSION'.

--- a/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-recommended.show-outdated-releases-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-recommended.show-outdated-releases-output
@@ -7,197 +7,99 @@ Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: stable-4.13 (available channels: candidate-4.12, candidate-4.13, eus-4.12, eus-4.14, fast-4.12, fast-4.13, stable-4.12, stable-4.13)
 
 Updates to 4.13:
-  VERSION     IMAGE
-  4.13.50     quay.io/openshift-release-dev/ocp-release@sha256:6afb11e1cac46fd26476ca134072937115256b9c6360f7a1cd1812992c065f02
-  4.13.49     quay.io/openshift-release-dev/ocp-release@sha256:ab6f574665395d809511db9dc57764358278538eaae248c6d199208b3c30ab7d
-  4.13.48     quay.io/openshift-release-dev/ocp-release@sha256:7235b8e139da4ba4c17c2b4b9864c05c93c5f55f7c2f561e7f9796c7e6589917
-
-  Version: 4.13.46
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:de889d3c3837ff9111765d8e5a4855e8b763dc759cb465fa2ebfcf0395d3f6b9
-  Reason: AzureSystemDLooping
-  Message: Azure clusters created on 4.(y<12) or 4.12.(z<54) are experiencing a bug where systemd detects a dependency loop. Systemd deletes these dependencies causing CRI-O and the kublet to never start on nodes. https://issues.redhat.com/browse/MCO-1257
-
-  VERSION     IMAGE
-  4.13.45     quay.io/openshift-release-dev/ocp-release@sha256:c7e3658ca8f0f1fc8ce1512ecc36785a68b1388dfbfc39642bff8120bfa86a33
-  4.13.44     quay.io/openshift-release-dev/ocp-release@sha256:e58807c46fab369428af73bdfec64ad4b509dcbdb4586694059013c69856e8a5
-  4.13.43     quay.io/openshift-release-dev/ocp-release@sha256:d0da3d9b016e6d693a61c9425598921b6d0da99c52cb0f3404f6dbc126149e5d
-  4.13.42     quay.io/openshift-release-dev/ocp-release@sha256:dcf5c3ad7384f8bee3c275da8f886b0bc9aea7611d166d695d0cf0fff40a0b55
-  4.13.41     quay.io/openshift-release-dev/ocp-release@sha256:dbb8aa0cf53dc5ac663514e259ad2768d8c82fd1fe7181a4cfb484e3ffdbd3ba
-  4.13.40     quay.io/openshift-release-dev/ocp-release@sha256:c1f69e6137bc9cda2c6da56bafbc7ea969900acb5e5c349b1ebb2103b10b424f
-  4.13.39     quay.io/openshift-release-dev/ocp-release@sha256:dd58c982a2166dcac5ce8f390f8b26b36df27ac765c4e012a670a9c0bac909df
-  4.13.38     quay.io/openshift-release-dev/ocp-release@sha256:db7a6fad1d56cf391159d252daabbb44178132081e077ae290317b91633fb1db
-  4.13.37     quay.io/openshift-release-dev/ocp-release@sha256:0fb7bbb4e6771acc99e32c55d4d37edf58ad31901acb78f552ce77ff4ba1eb3c
-
-  Version: 4.13.36
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:9ed18a88ce6242dceab887ee7dc92eecf9e0194a569e1e8c924cbf4b1da7816e
-  Reason: HighNodeStatusReportFrequency
-  Message: An unintended reversion to the default kubelet nodeStatusReportFrequency can cause significant load on the control plane. https://issues.redhat.com/browse/MCO-1094
-
-  Version: 4.13.35
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:2399ee629b41bf4c4006478260dcffd40849912398c09cba77bfada2fc481247
-  Reason: HighNodeStatusReportFrequency
-  Message: An unintended reversion to the default kubelet nodeStatusReportFrequency can cause significant load on the control plane. https://issues.redhat.com/browse/MCO-1094
-
-  Version: 4.13.34
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:04081f0cdc3a98eb9b705aceb86d4a035f7e6ccf6d9d10621776d53134f81c33
-  Reason: HighNodeStatusReportFrequency
-  Message: An unintended reversion to the default kubelet nodeStatusReportFrequency can cause significant load on the control plane. https://issues.redhat.com/browse/MCO-1094
-
-  Version: 4.13.33
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:7083519fd75dc187b7405968ba3d3d764a9807529e955411fd0ca1142dd4b560
-  Reason: HighNodeStatusReportFrequency
-  Message: An unintended reversion to the default kubelet nodeStatusReportFrequency can cause significant load on the control plane. https://issues.redhat.com/browse/MCO-1094
-
-  VERSION     IMAGE
-  4.13.32     quay.io/openshift-release-dev/ocp-release@sha256:c39085b26665ed9877e208c123ff147cf7939dde4eca79a4f00fda8ea5b13dc9
-  4.13.31     quay.io/openshift-release-dev/ocp-release@sha256:07cf79d6998a9b6a2d19b7fe168a3300ad682de33f190c9eb27bf61e67d3eeee
-  4.13.30     quay.io/openshift-release-dev/ocp-release@sha256:661be5aec551ee1b774a7176ced6f755d5ec0a5e8b957db234a89ebc8dd3c0f5
-  4.13.29     quay.io/openshift-release-dev/ocp-release@sha256:9c4a4471bb93ab11d255925535ff719742cafa8ae06d622b870133787a72abc3
-  4.13.28     quay.io/openshift-release-dev/ocp-release@sha256:1c834045db967d579aa2f1ef6f836dcb21db13d804bdffb972e8f4a7a4d59fc2
-  4.13.27     quay.io/openshift-release-dev/ocp-release@sha256:bc9006f9160663663c6d9a735c4c497f8f3300d94a7ec45cdafef1cebb15ebfe
-  4.13.26     quay.io/openshift-release-dev/ocp-release@sha256:dece136ed888653cae20c2832b9e94de7c7ab24e34cddf49d5d284f41d7b61b1
-  4.13.25     quay.io/openshift-release-dev/ocp-release@sha256:480f2026c07b0f2e19c3fc60a44e4a7147ab821474641952f077573d05747855
-  4.13.24     quay.io/openshift-release-dev/ocp-release@sha256:d6a7e20a8929a3ad985373f05472ea64bada8ff46f0beb89e1b6d04919affde3
-  4.13.23     quay.io/openshift-release-dev/ocp-release@sha256:ca556d3494d08765c90481f15dd965995371168ea7ee7a551000bed4481931c8
-  4.13.22     quay.io/openshift-release-dev/ocp-release@sha256:f323afe3e80d44da7d0caaed8c353fedef37e5fd5e7f765e8440be86f546cba0
-  4.13.21     quay.io/openshift-release-dev/ocp-release@sha256:562c214e9662e3684ac5b8c3d5d2759a83f544da8897a00ebe91a02fcad6d2d9
-  4.13.19     quay.io/openshift-release-dev/ocp-release@sha256:f8ba6f54eae419aba17926417d950ae18e06021beae9d7947a8b8243ad48353a
-  4.13.18     quay.io/openshift-release-dev/ocp-release@sha256:d0fd9d3ab8690605f816c879d74f4e6d6d9f72982f63a3e0ef3e027ecc512e1c
-  4.13.17     quay.io/openshift-release-dev/ocp-release@sha256:c1f2fa2170c02869484a4e049132128e216a363634d38abf292eef181e93b692
-  4.13.15     quay.io/openshift-release-dev/ocp-release@sha256:78f08839886fb2896857f95de0347b8f67ebcff16591b9d7aec87a20406b2897
-  4.13.14     quay.io/openshift-release-dev/ocp-release@sha256:406fcc160c097f61080412afcfa7fd65284ac8741ac7ad5b480e304aba73674b
-  4.13.13     quay.io/openshift-release-dev/ocp-release@sha256:d62495768e335c79a215ba56771ff5ae97e3cbb2bf49ed8fb3f6cefabcdc0f17
-  4.13.12     quay.io/openshift-release-dev/ocp-release@sha256:73946971c03b43a0dc6f7b0946b26a177c2f3c9d37105441315b4e3359373a55
-  4.13.11     quay.io/openshift-release-dev/ocp-release@sha256:e1c2377fdae1d063aaddc753b99acf25972b6997ab9a0b7e80cfef627b9ef3dd
-  4.13.10     quay.io/openshift-release-dev/ocp-release@sha256:28173b4b6efe4f67f8753566e5f3c9831e454609b7f1888e4b6687907f4b7f24
-
-  Version: 4.13.9
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:a266d3d65c433b460cdef7ab5d6531580f5391adbe85d9c475208a56452e4c0b
-  Reason: SeccompFilterErrno524
-  Message: Pods scheduled to nodes running a RHCOS/kernel version with a known defect may fail to start with a CreateContainerError. https://issues.redhat.com/browse/COS-2437
-
-  Version: 4.13.8
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:a956488d295fe5a59c8663a4d9992b9b5d0950f510a7387dbbfb8d20fc5970ce
-  Reason: SeccompFilterErrno524
-  Message: Pods scheduled to nodes running a RHCOS/kernel version with a known defect may fail to start with a CreateContainerError. https://issues.redhat.com/browse/COS-2437
-
-  Version: 4.13.6
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:3ca57045e070978b38c36d4c98e188795a6cb4b128130f9c8d7a08b47c133aba
-  Reason: SeccompFilterErrno524
-  Message: Pods scheduled to nodes running a RHCOS/kernel version with a known defect may fail to start with a CreateContainerError. https://issues.redhat.com/browse/COS-2437
-
-  Version: 4.13.5
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:af19e94813478382e36ae1fa2ae7bbbff1f903dded6180f4eb0624afe6fc6cd4
-  Reason: SeccompFilterErrno524
-  Message: Pods scheduled to nodes running a RHCOS/kernel version with a known defect may fail to start with a CreateContainerError. https://issues.redhat.com/browse/COS-2437
-
-  Version: 4.13.4
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:e3fb8ace9881ae5428ae7f0ac93a51e3daa71fa215b5299cd3209e134cadfc9c
-  Reason: SeccompFilterErrno524
-  Message: Pods scheduled to nodes running a RHCOS/kernel version with a known defect may fail to start with a CreateContainerError. https://issues.redhat.com/browse/COS-2437
-
-  Version: 4.13.3
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:bc9835804046aa844c874d2cc37387ec95fe7e87d8ce96129fba78d465c932fa
-  Reason: MultipleReasons
-  Message: New PersistentVolumes are created bound to an invalid symlink instead of the correct one and thus fail once updated to 4.13.4 or later as the invalid symlink dispears. https://issues.redhat.com/browse/COS-2349
-  
-  Pods scheduled to nodes running a RHCOS/kernel version with a known defect may fail to start with a CreateContainerError. https://issues.redhat.com/browse/COS-2437
-
-  Version: 4.13.2
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:6ef3cf4bed1970d547dce08a6e334b675d361b212427c4493151dcad6e093d27
-  Reason: MultipleReasons
-  Message: New PersistentVolumes are created bound to an invalid symlink instead of the correct one and thus fail once updated to 4.13.4 or later as the invalid symlink dispears. https://issues.redhat.com/browse/COS-2349
-  
-  Pods scheduled to nodes running a RHCOS/kernel version with a known defect may fail to start with a CreateContainerError. https://issues.redhat.com/browse/COS-2437
-
-  Version: 4.13.1
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:9c92b5ec203ee7f81626cc4e9f02086484056a76548961e5895916f136302b1f
-  Reason: MultipleReasons
-  Message: New PersistentVolumes are created bound to an invalid symlink instead of the correct one and thus fail once updated to 4.13.4 or later as the invalid symlink dispears. https://issues.redhat.com/browse/COS-2349
-  
-  Pods scheduled to nodes running a RHCOS/kernel version with a known defect may fail to start with a CreateContainerError. https://issues.redhat.com/browse/COS-2437
-
-  Version: 4.13.0
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:74b23ed4bbb593195a721373ed6693687a9b444c97065ce8ac653ba464375711
-  Reason: MultipleReasons
-  Message: New PersistentVolumes are created bound to an invalid symlink instead of the correct one and thus fail once updated to 4.13.4 or later as the invalid symlink dispears. https://issues.redhat.com/browse/COS-2349
-  
-  Pods scheduled to nodes running a RHCOS/kernel version with a known defect may fail to start with a CreateContainerError. https://issues.redhat.com/browse/COS-2437
+  VERSION     ISSUES
+  4.13.50     
+  4.13.49     
+  4.13.48     
+  4.13.46     AzureSystemDLooping
+  4.13.45     
+  4.13.44     
+  4.13.43     
+  4.13.42     
+  4.13.41     
+  4.13.40     
+  4.13.39     
+  4.13.38     
+  4.13.37     
+  4.13.36     HighNodeStatusReportFrequency
+  4.13.35     HighNodeStatusReportFrequency
+  4.13.34     HighNodeStatusReportFrequency
+  4.13.33     HighNodeStatusReportFrequency
+  4.13.32     
+  4.13.31     
+  4.13.30     
+  4.13.29     
+  4.13.28     
+  4.13.27     
+  4.13.26     
+  4.13.25     
+  4.13.24     
+  4.13.23     
+  4.13.22     
+  4.13.21     
+  4.13.19     
+  4.13.18     
+  4.13.17     
+  4.13.15     
+  4.13.14     
+  4.13.13     
+  4.13.12     
+  4.13.11     
+  4.13.10     
+  4.13.9      SeccompFilterErrno524
+  4.13.8      SeccompFilterErrno524
+  4.13.6      SeccompFilterErrno524
+  4.13.5      SeccompFilterErrno524
+  4.13.4      SeccompFilterErrno524
+  4.13.3      MultipleReasons
+  4.13.2      MultipleReasons
+  4.13.1      MultipleReasons
+  4.13.0      MultipleReasons
 
 Updates to 4.12:
-  VERSION     IMAGE
-  4.12.64     quay.io/openshift-release-dev/ocp-release@sha256:669170342e3ae3456b2eb00dd0c45cd817d62af310e0aa2bf214f1da65fae9d0
-  4.12.63     quay.io/openshift-release-dev/ocp-release@sha256:5db6f8dd1db6b9d07dacfa74574a38a6e518145a3c0ab5d895e9c89e029a39e4
-  4.12.61     quay.io/openshift-release-dev/ocp-release@sha256:faa201ea7790bb101de7b9b6f01543136e8c589463b8437a10678da0cdd0197a
-  4.12.60     quay.io/openshift-release-dev/ocp-release@sha256:22174072f8aaef46f80bded25d5a2bdfa6fd8bb01fc5242a07e550f132cafc5a
-  4.12.59     quay.io/openshift-release-dev/ocp-release@sha256:8908e5a46f106e7520faa5f5ee679033c4c2f0026f1b8a339e6b3ea4becdd969
-  4.12.58     quay.io/openshift-release-dev/ocp-release@sha256:b622d947ade4a13754e9d9f6803107f1b321eecd925c897f3c12de1aafccbdc5
-  4.12.57     quay.io/openshift-release-dev/ocp-release@sha256:ebd20cd66e0bbb5bcd7d16559ff4856918b7172e29d6a7bd34d8cc49a556b8f7
-  4.12.56     quay.io/openshift-release-dev/ocp-release@sha256:7446b0c3cc24c6d35c0d0fc968ef27f52da92c60f41951c0e646041db108169a
-  4.12.55     quay.io/openshift-release-dev/ocp-release@sha256:ecf790d11e32ec8c88c4224660eb1a107db5fdf54b0712eededb9d9bf0ab1a6d
-  4.12.54     quay.io/openshift-release-dev/ocp-release@sha256:5bbeeae3698249a41d6bd9987aac42cecbe862e1dd3710ab16ff4da651fc66a8
-  4.12.53     quay.io/openshift-release-dev/ocp-release@sha256:b584f5458fb946115b0cf0f1793dc9224c5e6a4567e74018f0590805a03eb523
-
-  Version: 4.12.51
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:158ced797e49f6caf7862acccef58484be63b642fdd2f66e6416295fa7958ab0
-  Reason: MultipleReasons
-  Message: An unintended reversion to the default kubelet nodeStatusReportFrequency can cause significant load on the control plane. https://issues.redhat.com/browse/MCO-1094
-  
-  After rebooting into kernel-4.18.0-372.88.1.el8_6 or later, kernel nodes experience high load average and io_wait times. The nodes might fail to start or stop pods and probes may fail. Workload and host processes may become unresponsive and workload may be disrupted. https://issues.redhat.com/browse/COS-2705
-
-  Version: 4.12.50
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:a9d7e4938d224a6a8f9c7a5c05ca2b4d6e92292812b14c4a3e0d9e938e8dc3bf
-  Reason: RHELKernelHighLoadIOWait
-  Message: After rebooting into kernel-4.18.0-372.88.1.el8_6 or later, kernel nodes experience high load average and io_wait times. The nodes might fail to start or stop pods and probes may fail. Workload and host processes may become unresponsive and workload may be disrupted. https://issues.redhat.com/browse/COS-2705
-
-  Version: 4.12.49
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:c93133ca1ccb35ea8552065ed7a74dccf5c7ee133e581f5211e465f1914c62d7
-  Reason: RHELKernelHighLoadIOWait
-  Message: After rebooting into kernel-4.18.0-372.88.1.el8_6 or later, kernel nodes experience high load average and io_wait times. The nodes might fail to start or stop pods and probes may fail. Workload and host processes may become unresponsive and workload may be disrupted. https://issues.redhat.com/browse/COS-2705
-
-  VERSION     IMAGE
-  4.12.48     quay.io/openshift-release-dev/ocp-release@sha256:c31b9b63b8c21d4327201fd0e78a4b6b0af7f1f8162acd29e4cde1cd65a56d19
-  4.12.47     quay.io/openshift-release-dev/ocp-release@sha256:fcc9920ba10ebb02c69bdd9cd597273260eeec1b22e9ef9986a47f4874a21253
-  4.12.46     quay.io/openshift-release-dev/ocp-release@sha256:2dda17736b7b747b463b040cb3b7abba9c4174b0922e2fd84127e3887f6d69c5
-  4.12.45     quay.io/openshift-release-dev/ocp-release@sha256:faf0aebc0abce8890e046eecfa392c24bc24f6c49146c45447fb0977e692db6e
-  4.12.44     quay.io/openshift-release-dev/ocp-release@sha256:304f37f9d7aa290252951751c5bf03a97085f77b4bcde0ed8a2fa455e9600e68
-  4.12.43     quay.io/openshift-release-dev/ocp-release@sha256:10221b3f8f23fe625f3aab8f1e3297eaa340efc64fb5eff8d46cc8461888804e
-  4.12.42     quay.io/openshift-release-dev/ocp-release@sha256:a52419c56d84f2953ddaa121e89a3d806902af4538503d8cf229b1e8a14f8902
-  4.12.41     quay.io/openshift-release-dev/ocp-release@sha256:59c93fdfff4ecca2ca6d6bb0ec722bca2bb08152252ae10ce486a9fc80c82dcf
-  4.12.40     quay.io/openshift-release-dev/ocp-release@sha256:b0b1aac82f9083d20e7e4269b05dd3679299d277d122fa9d29b772f38d2cacff
-  4.12.39     quay.io/openshift-release-dev/ocp-release@sha256:75687feb6344caeb0edb6b1513b53fd07b90b481079415b6545d860fe74059eb
-  4.12.37     quay.io/openshift-release-dev/ocp-release@sha256:ba7544a126dfd1028cfa9e9afde9ae9d2eb21bad26f8da56eb7aebc0fb132c84
-  4.12.36     quay.io/openshift-release-dev/ocp-release@sha256:38ccab25d5895a216a465a9f297541fbbebe7aa115fdaa9f2015c8d5a5d036eb
-  4.12.35     quay.io/openshift-release-dev/ocp-release@sha256:ef892e96305d4f401860304732b06ca4eac5dbcce287ebaa98c48edd6fb91023
-  4.12.34     quay.io/openshift-release-dev/ocp-release@sha256:b411b7157e124ccb5c9cd1c72499759a2cb0d784e5107c03dc73a7c83359bb1b
-  4.12.33     quay.io/openshift-release-dev/ocp-release@sha256:ab18794370bfbb469d7f37fef8ca17b7d3ef3976b7ad3e28b137398c9154ea86
-  4.12.32     quay.io/openshift-release-dev/ocp-release@sha256:008c933f9d2b49721d6729c1e558f3f0c91e8368201d33469dcd5bda5cf7d333
-  4.12.31     quay.io/openshift-release-dev/ocp-release@sha256:4e0e74e9fdfbaec726654fa883b2018beb548e12ad9db2ffbeb7cf2d6862f7e8
-  4.12.30     quay.io/openshift-release-dev/ocp-release@sha256:86ee723d4dc2a83f836232d1d03f8b4193940c50a2636ee86924acb5d14b0b64
-  4.12.29     quay.io/openshift-release-dev/ocp-release@sha256:dac46152be54e0669694e0ae56d66d8fb3c34dc26ec0d3704eef29d6099846c4
-  4.12.28     quay.io/openshift-release-dev/ocp-release@sha256:f3910eae62029cf1108aadc9f9c649625e49a998d3e5547cb8849d0db9c54843
-  4.12.27     quay.io/openshift-release-dev/ocp-release@sha256:e15e52f22247b833d1db59b1507fa67d920e39b75297bc3a74f3f15e560d6d02
-  4.12.26     quay.io/openshift-release-dev/ocp-release@sha256:8d72f29227418d2ae12ee52e25cce9edef7cd645bdaea02410a89fe8a0ec6a47
-  4.12.25     quay.io/openshift-release-dev/ocp-release@sha256:5a4fb052cda1d14d1e306ce87e6b0ded84edddaa76f1cf401bcded99cef2ad84
-  4.12.24     quay.io/openshift-release-dev/ocp-release@sha256:b0b11eedf91175459b5d7aefcf3936d0cabf00f01ced756677483f5f26227328
-  4.12.23     quay.io/openshift-release-dev/ocp-release@sha256:2309578b68c5666dad62aed696f1f9d778ae1a089ee461060ba7b9514b7ca417
-  4.12.22     quay.io/openshift-release-dev/ocp-release@sha256:ba7956f5c2aae61c8ff3ab1ab2ee7e625db9b1c8964a65339764db79c148e4e6
-  4.12.21     quay.io/openshift-release-dev/ocp-release@sha256:71e158c6173ad6aa6e356c119a87459196bbe70e89c0db1e35c1f63a87d90676
-
-  Version: 4.12.20
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:5c504578e34e8cf6eb70fad7a9bee92896b6d38d09b6d81891f730ee4f9d268b
-  Reason: DualStackNeedsController
-  Message: Upgrade can get stuck on clusters that use multiple networks together with dual stack. https://issues.redhat.com/browse/SDN-3996
-
-  Version: 4.12.19
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:41fd42cc8b9f86fc86cc8763dcf27e976299ff632a336d393b8e643bd8a5f967
-  Reason: DualStackNeedsController
-  Message: Upgrade can get stuck on clusters that use multiple networks together with dual stack. https://issues.redhat.com/browse/SDN-3996
-
-  Version: 4.12.18
-  Image: quay.io/openshift-release-dev/ocp-release@sha256:8465e416a403cec2e6887c8aebe783b976f46f81d513890f17037b652b143de5
-  Reason: DualStackNeedsController
-  Message: Upgrade can get stuck on clusters that use multiple networks together with dual stack. https://issues.redhat.com/browse/SDN-3996
-
-  VERSION     IMAGE
-  4.12.17     quay.io/openshift-release-dev/ocp-release@sha256:7ca5f8aa44bbc537c5a985a523d87365eab3f6e72abc50b7be4caae741e093f4
+  VERSION     ISSUES
+  4.12.64     
+  4.12.63     
+  4.12.61     
+  4.12.60     
+  4.12.59     
+  4.12.58     
+  4.12.57     
+  4.12.56     
+  4.12.55     
+  4.12.54     
+  4.12.53     
+  4.12.51     MultipleReasons
+  4.12.50     RHELKernelHighLoadIOWait
+  4.12.49     RHELKernelHighLoadIOWait
+  4.12.48     
+  4.12.47     
+  4.12.46     
+  4.12.45     
+  4.12.44     
+  4.12.43     
+  4.12.42     
+  4.12.41     
+  4.12.40     
+  4.12.39     
+  4.12.37     
+  4.12.36     
+  4.12.35     
+  4.12.34     
+  4.12.33     
+  4.12.32     
+  4.12.31     
+  4.12.30     
+  4.12.29     
+  4.12.28     
+  4.12.27     
+  4.12.26     
+  4.12.25     
+  4.12.24     
+  4.12.23     
+  4.12.22     
+  4.12.21     
+  4.12.20     DualStackNeedsController
+  4.12.19     DualStackNeedsController
+  4.12.18     DualStackNeedsController
+  4.12.17     

--- a/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-recommended.version-4.12.51-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-recommended.version-4.12.51-output
@@ -1,0 +1,15 @@
+Upgradeable=False
+
+  Reason: AdminAckRequired
+  Message: Kubernetes 1.26 and therefore OpenShift 4.13 remove several APIs which require admin consideration. Please see the knowledge article https://access.redhat.com/articles/6958394 for details and instructions.
+
+Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
+Channel: stable-4.13 (available channels: candidate-4.12, candidate-4.13, eus-4.12, eus-4.14, fast-4.12, fast-4.13, stable-4.12, stable-4.13)
+
+Update to 4.12.51 Recommended=False:
+Image: quay.io/openshift-release-dev/ocp-release@sha256:158ced797e49f6caf7862acccef58484be63b642fdd2f66e6416295fa7958ab0
+URL: https://access.redhat.com/errata/RHSA-2024:1052
+Reason: MultipleReasons
+Message: An unintended reversion to the default kubelet nodeStatusReportFrequency can cause significant load on the control plane. https://issues.redhat.com/browse/MCO-1094
+  
+  After rebooting into kernel-4.18.0-372.88.1.el8_6 or later, kernel nodes experience high load average and io_wait times. The nodes might fail to start or stop pods and probes may fail. Workload and host processes may become unresponsive and workload may be disrupted. https://issues.redhat.com/browse/COS-2705

--- a/pkg/cli/admin/upgrade/recommend/examples/4.14.1-all-recommended.show-outdated-releases-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.14.1-all-recommended.show-outdated-releases-output
@@ -4,14 +4,14 @@ Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: candidate-4.14 (available channels: candidate-4.14, candidate-4.15, eus-4.14, fast-4.14, stable-4.14)
 
 Updates to 4.14:
-  VERSION     IMAGE
-  4.14.11     quay.io/openshift-release-dev/ocp-release@sha256:36783a8b066c96dd6258e818ce51b5a763438adbf56221ea5c4b62ae4f345886
-  4.14.10     quay.io/openshift-release-dev/ocp-release@sha256:03cc63c0c48b2416889e9ee53f2efc2c940323c15f08384b439c00de8e66e8aa
-  4.14.9      quay.io/openshift-release-dev/ocp-release@sha256:f5eaf0248779a0478cfd83f055d56dc7d755937800a68ad55f6047c503977c44
-  4.14.8      quay.io/openshift-release-dev/ocp-release@sha256:073a4e46289be25e2a05f5264c8f1d697410db66b960c9ceeddebd1c61e58717
-  4.14.7      quay.io/openshift-release-dev/ocp-release@sha256:a346fc0c84644e64c726013a98bef0f75e58f246fce1faa83fb6bbbc6d4050aa
-  4.14.6      quay.io/openshift-release-dev/ocp-release@sha256:e5128c3b0ab225e0abf9344dae504e08b82dda4885bbd047e2dbc13cc3d9879b
-  4.14.5      quay.io/openshift-release-dev/ocp-release@sha256:0ec9d715c717b2a592d07dd83860013613529fae69bc9eecb4b2d4ace679f6f3
-  4.14.4      quay.io/openshift-release-dev/ocp-release@sha256:e6e1d90b492d50438034e6edb46bdafa6c86ae3b80ef3328685912d89681fdee
-  4.14.3      quay.io/openshift-release-dev/ocp-release@sha256:e73ab4b33a9c3ff00c9f800a38d69853ca0c4dfa5a88e3df331f66df8f18ec55
-  4.14.2      quay.io/openshift-release-dev/ocp-release@sha256:45a396b169974dcbd8aae481c647bf55bcf9f0f8f6222483d407d7cec450928d
+  VERSION     ISSUES
+  4.14.11     
+  4.14.10     
+  4.14.9      
+  4.14.8      
+  4.14.7      
+  4.14.6      
+  4.14.5      
+  4.14.4      
+  4.14.3      
+  4.14.2      

--- a/pkg/cli/admin/upgrade/recommend/examples/4.14.1-all-recommended.version-4.12.51-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.14.1-all-recommended.version-4.12.51-output
@@ -3,8 +3,4 @@ info: An update is in progress.  You may wish to let this update complete before
 Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: candidate-4.14 (available channels: candidate-4.14, candidate-4.15, eus-4.14, fast-4.14, stable-4.14)
 
-Updates to 4.14:
-  VERSION     ISSUES
-  4.14.11     
-  4.14.10     
-And 8 older 4.14 updates you can see with '--show-outdated-releases' or '--version VERSION'.
+error: no updates to 4.12 available, so cannot display context for the requested release 4.12.51

--- a/pkg/cli/admin/upgrade/recommend/examples_test.go
+++ b/pkg/cli/admin/upgrade/recommend/examples_test.go
@@ -46,6 +46,7 @@ func TestExamples(t *testing.T) {
 	variants := []struct {
 		name                 string
 		showOutdatedReleases bool
+		version              string
 		outputSuffix         string
 	}{
 		{
@@ -58,6 +59,11 @@ func TestExamples(t *testing.T) {
 			showOutdatedReleases: true,
 			outputSuffix:         ".show-outdated-releases-output",
 		},
+		{
+			name:         "specific version",
+			version:      "4.12.51",
+			outputSuffix: ".version-4.12.51-output",
+		},
 	}
 
 	for _, cv := range cvs {
@@ -69,6 +75,7 @@ func TestExamples(t *testing.T) {
 				opts := &options{
 					mockData:             mockData{cvPath: cv},
 					showOutdatedReleases: variant.showOutdatedReleases,
+					rawVersion:           variant.version,
 				}
 				if err := opts.Complete(nil, nil, nil); err != nil {
 					t.Fatalf("Error when completing options: %v", err)
@@ -79,10 +86,10 @@ func TestExamples(t *testing.T) {
 				opts.ErrOut = &stderr
 
 				if err := opts.Run(context.Background()); err != nil {
-					t.Fatalf("Error when running: %v", err)
+					compareWithFixture(t, bytes.Join([][]byte{stdout.Bytes(), []byte("\nerror: "), []byte(err.Error()), []byte("\n")}, []byte{}), cv, variant.outputSuffix)
+				} else {
+					compareWithFixture(t, stdout.Bytes(), cv, variant.outputSuffix)
 				}
-
-				compareWithFixture(t, stdout.Bytes(), cv, variant.outputSuffix)
 			})
 		}
 	}

--- a/pkg/cli/admin/upgrade/recommend/recommend.go
+++ b/pkg/cli/admin/upgrade/recommend/recommend.go
@@ -3,6 +3,7 @@ package recommend
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -44,6 +45,11 @@ func New(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command 
 
 			This subcommand is read-only and does not affect the state of the cluster.
 			To request an update, use the 'oc adm upgrade' subcommand.
+
+			By default, this command displays recent potential target releases.  Use
+			'--version VERSION' to display context for a particular target release.  Use
+			'--show-outdated-releases' to display all known targets, including older
+			releases.
 		`),
 		Run: func(cmd *cobra.Command, args []string) {
 			kcmdutil.CheckErr(o.Complete(f, cmd, args))
@@ -52,6 +58,7 @@ func New(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command 
 	}
 	flags := cmd.Flags()
 	flags.BoolVar(&o.showOutdatedReleases, "show-outdated-releases", o.showOutdatedReleases, "Display additional older releases.  These releases may be exposed to known issues which have been fixed in more recent releases.  But all updates will contain fixes not present in your current release.")
+	flags.StringVar(&o.rawVersion, "version", o.rawVersion, "Select a particular target release to display by version.")
 
 	// TODO: We can remove this flag once the idea about `oc adm upgrade recommend` stabilizes and the command
 	//       is promoted out of the OC_ENABLE_CMD_UPGRADE_RECOMMEND feature gate
@@ -65,6 +72,12 @@ type options struct {
 
 	mockData             mockData
 	showOutdatedReleases bool
+
+	// rawVersion is parsed into version by options.Complete.  Do not consume it directly outside of that early option handling.
+	rawVersion string
+
+	// version is the parsed form of rawVersion.  Consumers after options.Complete should prefer this property.
+	version *semver.Version
 
 	Client configv1client.Interface
 }
@@ -86,6 +99,18 @@ func (o *options) Complete(f kcmdutil.Factory, cmd *cobra.Command, args []string
 		err := o.mockData.load()
 		if err != nil {
 			return err
+		}
+	}
+
+	if o.rawVersion != "" {
+		if o.showOutdatedReleases {
+			return errors.New("when --version is set, --show-outdated-releases is unnecessary")
+		}
+
+		if version, err := semver.Parse(o.rawVersion); err != nil {
+			return fmt.Errorf("cannot parse SemVer target %q: %v", o.rawVersion, err)
+		} else {
+			o.version = &version
 		}
 	}
 
@@ -181,6 +206,31 @@ func (o *options) Run(ctx context.Context) error {
 		})
 	}
 
+	if o.version != nil {
+		if len(majorMinorBuckets) == 0 {
+			return fmt.Errorf("no updates available, so cannot display context for the requested release %s", o.version)
+		}
+
+		if major, ok := majorMinorBuckets[o.version.Major]; !ok {
+			return fmt.Errorf("no updates to %d available, so cannot display context for the requested release %s", o.version.Major, o.version)
+		} else if minor, ok := major[o.version.Minor]; !ok {
+			return fmt.Errorf("no updates to %d.%d available, so cannot display context for the requested release %s", o.version.Major, o.version.Minor, o.version)
+		} else {
+			for _, update := range minor {
+				if update.Release.Version == o.version.String() {
+					fmt.Fprintln(o.Out)
+					if c := notRecommendedCondition(update); c == nil {
+						fmt.Fprintf(o.Out, "Update to %s has no known issues relevant to this cluster.\nImage: %s\nURL: %s\n", update.Release.Version, update.Release.Image, update.Release.URL)
+					} else {
+						fmt.Fprintf(o.Out, "Update to %s %s=%s:\nImage: %s\nURL: %s\nReason: %s\nMessage: %s\n", update.Release.Version, c.Type, c.Status, update.Release.Image, update.Release.URL, c.Reason, strings.ReplaceAll(c.Message, "\n", "\n  "))
+					}
+					return nil
+				}
+			}
+			return fmt.Errorf("no updates to %d.%d available, so cannot display context for the requested release %s", o.version.Major, o.version.Minor, o.version)
+		}
+	}
+
 	if len(majorMinorBuckets) == 0 {
 		fmt.Fprintf(o.Out, "No updates available. You may still upgrade to a specific release image with --to-image or wait for new updates to be available.\n")
 		return nil
@@ -208,35 +258,42 @@ func (o *options) Run(ctx context.Context) error {
 			headerQueued := true
 
 			// set the minimal cell width to 14 to have a larger space between the columns for shorter versions
-			w := tabwriter.NewWriter(o.Out, 14, 2, 1, ' ', 0)
-			fmt.Fprintf(w, "  VERSION\tIMAGE\n")
+			w := tabwriter.NewWriter(o.Out, 14, 2, 1, ' ', tabwriter.DiscardEmptyColumns)
+			fmt.Fprintf(w, "  VERSION\tISSUES\n")
 			// TODO: add metadata about version
 
 			sortConditionalUpdatesBySemanticVersions(majorMinorBuckets[major][minor])
 			for i, update := range majorMinorBuckets[major][minor] {
 				c := notRecommendedCondition(update)
-				if lastWasLong || c != nil {
+				if lastWasLong || (c != nil && !o.showOutdatedReleases) {
 					fmt.Fprintln(o.Out)
 					if c == nil && !headerQueued {
-						fmt.Fprintf(w, "  VERSION\tIMAGE\n")
+						fmt.Fprintf(w, "  VERSION\tISSUES\n")
 						headerQueued = true
 					}
 					lastWasLong = false
 				}
 				if i == 2 && !o.showOutdatedReleases {
-					fmt.Fprintf(o.Out, "And %d older %d.%d updates you can see with --show-outdated-releases\n", len(majorMinorBuckets[major][minor])-2, major, minor)
+					fmt.Fprintf(o.Out, "And %d older %d.%d updates you can see with '--show-outdated-releases' or '--version VERSION'.\n", len(majorMinorBuckets[major][minor])-2, major, minor)
 					lastWasLong = true
 					break
 				}
 				if c == nil {
-					fmt.Fprintf(w, "  %s\t%s\n", update.Release.Version, update.Release.Image)
-					w.Flush()
-					headerQueued = false
+					fmt.Fprintf(w, "  %s\t\n", update.Release.Version)
+					if !o.showOutdatedReleases {
+						headerQueued = false
+						w.Flush()
+					}
+				} else if o.showOutdatedReleases {
+					fmt.Fprintf(w, "  %s\t%s\n", update.Release.Version, c.Reason)
 				} else {
 					fmt.Fprintf(o.Out, "  Version: %s\n  Image: %s\n", update.Release.Version, update.Release.Image)
 					fmt.Fprintf(o.Out, "  Reason: %s\n  Message: %s\n", c.Reason, strings.ReplaceAll(strings.TrimSpace(c.Message), "\n", "\n  "))
 					lastWasLong = true
 				}
+			}
+			if o.showOutdatedReleases {
+				w.Flush()
 			}
 		}
 	}


### PR DESCRIPTION
This allows us to drop the detailed, multi-line entries from the long `--show-outdated-releases` output.  Now that form just gives us an overview of releases with `reason` slugs for any updates with assessed issues.  Cluster administrators who see something in that overview that they are interested in can make a subsequent call with `--version VERSION` to get the long-form details on that particular target.

I'm keeping the long-form output for release-exposed risks in the default rendering though, because part of the motivation behind d8cac253ac (#1889) is to surface those longest-hop risk messages for cluster administrators, in case the issue is something like `EvaluationFailed`, which says more about the current cluster state than it does about the health of the update.

Because the `--version 4.12.51` runs fail for some of our ClusterVersion example fixtures, I've adjusted `examples_test.go` to catch and compare output when `opts.Run` fails.