### PR TITLE
OCPBUGS-43309: The "oc adm ocp-certificates regenerate-machine-config-server-serving-cert" command is failing

### DIFF
--- a/pkg/cli/admin/ocpcertificates/regeneratemco/OWNERS
+++ b/pkg/cli/admin/ocpcertificates/regeneratemco/OWNERS
@@ -1,0 +1,20 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+  - djoshy
+  - dkhater-redhat
+  - yuqi-zhang
+  - cheesesashimi
+  - umohnani8
+  - LorbusChris
+  - RishabhSaini
+reviewers:
+  - djoshy
+  - dkhater-redhat
+  - yuqi-zhang
+  - cheesesashimi
+  - umohnani8
+  - LorbusChris
+  - RishabhSaini
+
+component: "Machine Config Operator"


### PR DESCRIPTION
Closes: [OCPBUGS-43309](https://issues.redhat.com/browse/OCPBUGS-43309)

This ensures that the machine-config-server-tls secret is of the `kubernetes.io/tls` type before attempting to rotate them. 

This is only an issue in 4.18+, as the vendored cert controller package was updated during the 1.31.1 rebase. (https://github.com/openshift/oc/pull/1877, [diff](https://github.com/openshift/oc/pull/1877/commits/eac0d7de9cdc8a5e0c085415ea45577f14c32821#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R39)) 

In the current master of library-go, the cert controller only permits secrets of the type `kubernetes.io/tls` to be rotated, and therefore this "preflight check" is necessary before running the controller sync.