### PR TITLE
OCPBUGS-43513: Show node-joiner container logs when error occurs

### DIFF
--- a/pkg/cli/admin/nodeimage/create_test.go
+++ b/pkg/cli/admin/nodeimage/create_test.go
@@ -136,7 +136,7 @@ func TestRun(t *testing.T) {
 			nodesConfig:      defaultNodesConfigYaml,
 			objects:          defaultClusterVersionObjectFn,
 			remoteExecOutput: "1",
-			expectedError:    `image generation error (exit code: 1)`,
+			expectedError:    `image generation error: <nil> (exit code: 1)`,
 		},
 		{
 			name:             "node-joiner unsupported prior to 4.17",


### PR DESCRIPTION
Currently only a message saying an error has occurred is displayed which doesn't provide any information indicating the cause.

The container logs may indicate why image generation did not succeed.