### PR TITLE
OCPBUGS-8259: pkg/cli/admin/upgrade: Propagate --force for --to-multi-arch

### DIFF
--- a/pkg/cli/admin/upgrade/upgrade.go
+++ b/pkg/cli/admin/upgrade/upgrade.go
@@ -240,8 +240,17 @@ func (o *Options) Run() error {
 			fmt.Fprintf(o.ErrOut, "warning: --allow-upgrade-with-warnings is bypassing: %s\n", err)
 		}
 
-		if err := patchDesiredUpdate(ctx, &configv1.Update{Architecture: configv1.ClusterVersionArchitectureMulti,
-			Version: cv.Status.Desired.Version}, o.Client, cv.Name); err != nil {
+		update := &configv1.Update{
+			Architecture: configv1.ClusterVersionArchitectureMulti,
+			Version:      cv.Status.Desired.Version,
+		}
+
+		if o.Force {
+			update.Force = true
+			fmt.Fprintln(o.ErrOut, "warning: --force overrides cluster verification of your supplied release image and waives any update precondition failures.")
+		}
+
+		if err := patchDesiredUpdate(ctx, update, o.Client, cv.Name); err != nil {
 
 			return err
 		}

--- a/pkg/cli/admin/upgrade/upgrade.go
+++ b/pkg/cli/admin/upgrade/upgrade.go
@@ -153,8 +153,8 @@ func (o *Options) Complete(f kcmdutil.Factory, cmd *cobra.Command, args []string
 	if o.Clear && (len(o.ToImage) > 0 || len(o.To) > 0 || o.ToLatestAvailable || o.ToMultiArch) {
 		return fmt.Errorf("--clear may not be specified with any other flags")
 	}
-	if o.ToMultiArch && (len(o.To) > 0 || len(o.ToImage) > 0) {
-		return fmt.Errorf("--to-multi-arch may not be used with --to or --to-image")
+	if o.ToMultiArch && (len(o.To) > 0 || len(o.ToImage) > 0 || o.ToLatestAvailable) {
+		return fmt.Errorf("--to-multi-arch may not be used with --to, --to-image, or --to-latest")
 	}
 	if len(o.To) > 0 && len(o.ToImage) > 0 {
 		return fmt.Errorf("only one of --to or --to-image may be provided")


### PR DESCRIPTION
Folks might want to break through cluster-version-operator-side guards to test `--to-multi-arch` updates as well.

Also error on `--to-multi-arch` with `--to-latest`.   `--to-multi-arch` is about transitioning from single-arch to multi-arch without changing the version, so all of the "pick a new target version/release" options are incompatible.