### PR TITLE
OTA-902: pkg/cli/admin/upgrade/recommend: Treat Upgradeable=False as a conditional update risk

### DIFF
--- a/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-not-recommended.output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-not-recommended.output
@@ -1,8 +1,3 @@
-Upgradeable=False
-
-  Reason: AdminAckRequired
-  Message: Kubernetes 1.26 and therefore OpenShift 4.13 remove several APIs which require admin consideration. Please see the knowledge article https://access.redhat.com/articles/6958394 for details and instructions.
-
 Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: stable-4.13 (available channels: candidate-4.12, candidate-4.13, eus-4.12, eus-4.14, fast-4.12, fast-4.13, stable-4.12, stable-4.13)
 
@@ -10,14 +5,18 @@ Updates to 4.13:
 
   Version: 4.13.50
   Image: quay.io/openshift-release-dev/ocp-release@sha256:6afb11e1cac46fd26476ca134072937115256b9c6360f7a1cd1812992c065f02
-  Reason: EvaluationFailed
-  Message: Exposure to ARODNSWrongBootSequence is unknown due to an evaluation failure: client-side throttling: only 8m30.897651224s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
+  Reason: MultipleReasons
+  Message: Kubernetes 1.26 and therefore OpenShift 4.13 remove several APIs which require admin consideration. Please see the knowledge article https://access.redhat.com/articles/6958394 for details and instructions.
+  
+  Exposure to ARODNSWrongBootSequence is unknown due to an evaluation failure: client-side throttling: only 8m30.897651224s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade https://access.redhat.com/solutions/7074686
 
   Version: 4.13.49
   Image: quay.io/openshift-release-dev/ocp-release@sha256:ab6f574665395d809511db9dc57764358278538eaae248c6d199208b3c30ab7d
-  Reason: EvaluationFailed
-  Message: Exposure to ARODNSWrongBootSequence is unknown due to an evaluation failure: client-side throttling: only 8m30.897666224s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
+  Reason: MultipleReasons
+  Message: Kubernetes 1.26 and therefore OpenShift 4.13 remove several APIs which require admin consideration. Please see the knowledge article https://access.redhat.com/articles/6958394 for details and instructions.
+  
+  Exposure to ARODNSWrongBootSequence is unknown due to an evaluation failure: client-side throttling: only 8m30.897666224s has elapsed since the last match call completed for this cluster condition backend; this cached cluster condition request has been queued for later execution
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade https://access.redhat.com/solutions/7074686
 
 And 45 older 4.13 updates you can see with '--show-outdated-releases' or '--version VERSION'.

--- a/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-not-recommended.show-outdated-releases-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-not-recommended.show-outdated-releases-output
@@ -1,51 +1,46 @@
-Upgradeable=False
-
-  Reason: AdminAckRequired
-  Message: Kubernetes 1.26 and therefore OpenShift 4.13 remove several APIs which require admin consideration. Please see the knowledge article https://access.redhat.com/articles/6958394 for details and instructions.
-
 Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: stable-4.13 (available channels: candidate-4.12, candidate-4.13, eus-4.12, eus-4.14, fast-4.12, fast-4.13, stable-4.12, stable-4.13)
 
 Updates to 4.13:
   VERSION     ISSUES
-  4.13.50     EvaluationFailed
-  4.13.49     EvaluationFailed
-  4.13.48     EvaluationFailed
-  4.13.46     EvaluationFailed
-  4.13.45     EvaluationFailed
-  4.13.44     EvaluationFailed
-  4.13.43     EvaluationFailed
-  4.13.42     EvaluationFailed
-  4.13.41     EvaluationFailed
-  4.13.40     EvaluationFailed
-  4.13.39     EvaluationFailed
-  4.13.38     EvaluationFailed
-  4.13.37     EvaluationFailed
+  4.13.50     MultipleReasons
+  4.13.49     MultipleReasons
+  4.13.48     MultipleReasons
+  4.13.46     MultipleReasons
+  4.13.45     MultipleReasons
+  4.13.44     MultipleReasons
+  4.13.43     MultipleReasons
+  4.13.42     MultipleReasons
+  4.13.41     MultipleReasons
+  4.13.40     MultipleReasons
+  4.13.39     MultipleReasons
+  4.13.38     MultipleReasons
+  4.13.37     MultipleReasons
   4.13.36     MultipleReasons
   4.13.35     MultipleReasons
   4.13.34     MultipleReasons
   4.13.33     MultipleReasons
-  4.13.32     EvaluationFailed
-  4.13.31     EvaluationFailed
-  4.13.30     EvaluationFailed
-  4.13.29     EvaluationFailed
-  4.13.28     EvaluationFailed
-  4.13.27     EvaluationFailed
-  4.13.26     EvaluationFailed
-  4.13.25     EvaluationFailed
-  4.13.24     EvaluationFailed
-  4.13.23     EvaluationFailed
-  4.13.22     EvaluationFailed
-  4.13.21     EvaluationFailed
-  4.13.19     EvaluationFailed
-  4.13.18     EvaluationFailed
-  4.13.17     EvaluationFailed
-  4.13.15     EvaluationFailed
-  4.13.14     EvaluationFailed
-  4.13.13     EvaluationFailed
-  4.13.12     EvaluationFailed
-  4.13.11     EvaluationFailed
-  4.13.10     EvaluationFailed
+  4.13.32     MultipleReasons
+  4.13.31     MultipleReasons
+  4.13.30     MultipleReasons
+  4.13.29     MultipleReasons
+  4.13.28     MultipleReasons
+  4.13.27     MultipleReasons
+  4.13.26     MultipleReasons
+  4.13.25     MultipleReasons
+  4.13.24     MultipleReasons
+  4.13.23     MultipleReasons
+  4.13.22     MultipleReasons
+  4.13.21     MultipleReasons
+  4.13.19     MultipleReasons
+  4.13.18     MultipleReasons
+  4.13.17     MultipleReasons
+  4.13.15     MultipleReasons
+  4.13.14     MultipleReasons
+  4.13.13     MultipleReasons
+  4.13.12     MultipleReasons
+  4.13.11     MultipleReasons
+  4.13.10     MultipleReasons
   4.13.9      MultipleReasons
   4.13.8      MultipleReasons
   4.13.6      MultipleReasons

--- a/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-not-recommended.version-4.12.51-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-not-recommended.version-4.12.51-output
@@ -1,8 +1,3 @@
-Upgradeable=False
-
-  Reason: AdminAckRequired
-  Message: Kubernetes 1.26 and therefore OpenShift 4.13 remove several APIs which require admin consideration. Please see the knowledge article https://access.redhat.com/articles/6958394 for details and instructions.
-
 Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: stable-4.13 (available channels: candidate-4.12, candidate-4.13, eus-4.12, eus-4.14, fast-4.12, fast-4.13, stable-4.12, stable-4.13)
 

--- a/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-recommended.output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-recommended.output
@@ -1,15 +1,18 @@
-Upgradeable=False
-
-  Reason: AdminAckRequired
-  Message: Kubernetes 1.26 and therefore OpenShift 4.13 remove several APIs which require admin consideration. Please see the knowledge article https://access.redhat.com/articles/6958394 for details and instructions.
-
 Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: stable-4.13 (available channels: candidate-4.12, candidate-4.13, eus-4.12, eus-4.14, fast-4.12, fast-4.13, stable-4.12, stable-4.13)
 
 Updates to 4.13:
-  VERSION     ISSUES
-  4.13.50     
-  4.13.49     
+
+  Version: 4.13.50
+  Image: quay.io/openshift-release-dev/ocp-release@sha256:6afb11e1cac46fd26476ca134072937115256b9c6360f7a1cd1812992c065f02
+  Reason: AdminAckRequired
+  Message: Kubernetes 1.26 and therefore OpenShift 4.13 remove several APIs which require admin consideration. Please see the knowledge article https://access.redhat.com/articles/6958394 for details and instructions.
+
+  Version: 4.13.49
+  Image: quay.io/openshift-release-dev/ocp-release@sha256:ab6f574665395d809511db9dc57764358278538eaae248c6d199208b3c30ab7d
+  Reason: AdminAckRequired
+  Message: Kubernetes 1.26 and therefore OpenShift 4.13 remove several APIs which require admin consideration. Please see the knowledge article https://access.redhat.com/articles/6958394 for details and instructions.
+
 And 45 older 4.13 updates you can see with '--show-outdated-releases' or '--version VERSION'.
 
 Updates to 4.12:

--- a/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-recommended.show-outdated-releases-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-recommended.show-outdated-releases-output
@@ -1,56 +1,51 @@
-Upgradeable=False
-
-  Reason: AdminAckRequired
-  Message: Kubernetes 1.26 and therefore OpenShift 4.13 remove several APIs which require admin consideration. Please see the knowledge article https://access.redhat.com/articles/6958394 for details and instructions.
-
 Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: stable-4.13 (available channels: candidate-4.12, candidate-4.13, eus-4.12, eus-4.14, fast-4.12, fast-4.13, stable-4.12, stable-4.13)
 
 Updates to 4.13:
   VERSION     ISSUES
-  4.13.50     
-  4.13.49     
-  4.13.48     
-  4.13.46     AzureSystemDLooping
-  4.13.45     
-  4.13.44     
-  4.13.43     
-  4.13.42     
-  4.13.41     
-  4.13.40     
-  4.13.39     
-  4.13.38     
-  4.13.37     
-  4.13.36     HighNodeStatusReportFrequency
-  4.13.35     HighNodeStatusReportFrequency
-  4.13.34     HighNodeStatusReportFrequency
-  4.13.33     HighNodeStatusReportFrequency
-  4.13.32     
-  4.13.31     
-  4.13.30     
-  4.13.29     
-  4.13.28     
-  4.13.27     
-  4.13.26     
-  4.13.25     
-  4.13.24     
-  4.13.23     
-  4.13.22     
-  4.13.21     
-  4.13.19     
-  4.13.18     
-  4.13.17     
-  4.13.15     
-  4.13.14     
-  4.13.13     
-  4.13.12     
-  4.13.11     
-  4.13.10     
-  4.13.9      SeccompFilterErrno524
-  4.13.8      SeccompFilterErrno524
-  4.13.6      SeccompFilterErrno524
-  4.13.5      SeccompFilterErrno524
-  4.13.4      SeccompFilterErrno524
+  4.13.50     AdminAckRequired
+  4.13.49     AdminAckRequired
+  4.13.48     AdminAckRequired
+  4.13.46     MultipleReasons
+  4.13.45     AdminAckRequired
+  4.13.44     AdminAckRequired
+  4.13.43     AdminAckRequired
+  4.13.42     AdminAckRequired
+  4.13.41     AdminAckRequired
+  4.13.40     AdminAckRequired
+  4.13.39     AdminAckRequired
+  4.13.38     AdminAckRequired
+  4.13.37     AdminAckRequired
+  4.13.36     MultipleReasons
+  4.13.35     MultipleReasons
+  4.13.34     MultipleReasons
+  4.13.33     MultipleReasons
+  4.13.32     AdminAckRequired
+  4.13.31     AdminAckRequired
+  4.13.30     AdminAckRequired
+  4.13.29     AdminAckRequired
+  4.13.28     AdminAckRequired
+  4.13.27     AdminAckRequired
+  4.13.26     AdminAckRequired
+  4.13.25     AdminAckRequired
+  4.13.24     AdminAckRequired
+  4.13.23     AdminAckRequired
+  4.13.22     AdminAckRequired
+  4.13.21     AdminAckRequired
+  4.13.19     AdminAckRequired
+  4.13.18     AdminAckRequired
+  4.13.17     AdminAckRequired
+  4.13.15     AdminAckRequired
+  4.13.14     AdminAckRequired
+  4.13.13     AdminAckRequired
+  4.13.12     AdminAckRequired
+  4.13.11     AdminAckRequired
+  4.13.10     AdminAckRequired
+  4.13.9      MultipleReasons
+  4.13.8      MultipleReasons
+  4.13.6      MultipleReasons
+  4.13.5      MultipleReasons
+  4.13.4      MultipleReasons
   4.13.3      MultipleReasons
   4.13.2      MultipleReasons
   4.13.1      MultipleReasons

--- a/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-recommended.version-4.12.51-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-recommended.version-4.12.51-output
@@ -1,8 +1,3 @@
-Upgradeable=False
-
-  Reason: AdminAckRequired
-  Message: Kubernetes 1.26 and therefore OpenShift 4.13 remove several APIs which require admin consideration. Please see the knowledge article https://access.redhat.com/articles/6958394 for details and instructions.
-
 Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: stable-4.13 (available channels: candidate-4.12, candidate-4.13, eus-4.12, eus-4.14, fast-4.12, fast-4.13, stable-4.12, stable-4.13)
 


### PR DESCRIPTION
We've [had `Upgradeable` since 2019][1], but it is a confusing condition, because [the "between minor versions" wording][2] in the `message` isn't obvious to users who have not yet internalized [SemVer's `MAJOR.MINOR.PATCH` terminology][3].  [Conditional update risks landed in 2021][4] and give us a clear API for declaring exactly which update targets have the exposure.  This commit adds client-side code to the tech-preview `recommend` subcommand, so folks can get a feel for that user experience.  If it goes over well, we can shift the logic to the cluster-version operator so all clients can benefit.  The `alreadyHasUpgradeableRisk` check ensures we don't double up if the CVO eventually picks up this pivot.

[1]: https://github.com/openshift/api/pull/206
[2]: https://github.com/openshift/cluster-version-operator/blob/c4b8362d8acd08d63a600b4d53c33e8737ed7a53/pkg/cvo/upgradeable.go#L218-L228
[3]: https://semver.org/spec/v2.0.0.html#summary
[4]: https://github.com/openshift/api/pull/1011