### PR TITLE
NO-JIRA: Fix newapp unit test failure by using different image

### DIFF
--- a/pkg/helpers/newapp/newapptest/newapp_test.go
+++ b/pkg/helpers/newapp/newapptest/newapp_test.go
@@ -1015,14 +1015,14 @@ func TestNewAppRunBuilds(t *testing.T) {
 			name: "successful build from dockerfile",
 			config: &cmd.AppConfig{
 				GenerationInputs: cmd.GenerationInputs{
-					Dockerfile: "FROM openshift/origin:v1.0.6\nUSER foo",
+					Dockerfile: "FROM centos:centos8\nUSER foo",
 				},
 			},
 			expected: map[string][]string{
-				"buildConfig": {"origin"},
+				"buildConfig": {"centos"},
 				// There's a single image stream, but different tags: input from
 				// openshift/origin:v1.0.6, output to openshift/origin:latest.
-				"imageStream": {"origin"},
+				"imageStream": {"centos"},
 			},
 		},
 		{


### PR DESCRIPTION
It seems that `openshift/origin` does not exist in quay anymore, so that a unit test in oc is perma-failing. This PR switches to existing image to unblock the CI.