### PR TITLE
Documentation fix: add missing whitespace character

### DIFF
--- a/pkg/cli/set/data.go
+++ b/pkg/cli/set/data.go
@@ -116,7 +116,7 @@ func NewCmdData(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.C
 		&o.FileSources,
 		"from-file",
 		[]string{},
-		"Specify a file using its file path, in which case the file basename will be used as the key"+
+		"Specify a file using its file path, in which case the file basename will be used as the key "+
 			"or optionally with a key and file path, in which case the given key will be used.  Specifying a "+
 			"directory will iterate each named file in the directory whose basename is a valid secret key.")
 	cmd.Flags().StringArrayVar(


### PR DESCRIPTION
This change adds a missing whitespace character in the help description for the 'oc set data --from-file' parameter.