### PR TITLE
NO-JIRA: adm release: cleanups

### DIFF
--- a/pkg/cli/admin/release/image_mapper.go
+++ b/pkg/cli/admin/release/image_mapper.go
@@ -335,7 +335,7 @@ func ComponentReferencesForImageStream(is *imageapi.ImageStream) (func(string) i
 	}, nil
 }
 
-var componentVersionRe = regexp.MustCompile(`([\W]|^)0\.0\.1-snapshot([a-z0-9\-]*)`)
+var componentVersionRe = regexp.MustCompile(`(\W|^)0\.0\.1-snapshot([a-z0-9\-]*)`)
 
 // NewComponentVersionsMapper substitutes strings of the form 0.0.1-snapshot with releaseName and strings
 // of the form 0.0.1-snapshot-[component] with the version value located in versions, or returns an error.
@@ -408,7 +408,7 @@ var (
 	// reAllowedVersionKey limits the allowed component name to a strict subset
 	reAllowedVersionKey = regexp.MustCompile(`^[a-z0-9]+[\-a-z0-9]*[a-z0-9]+$`)
 	// reAllowedDisplayNameKey limits the allowed component name to a strict subset
-	reAllowedDisplayNameKey = regexp.MustCompile(`^[a-zA-Z0-9\-\:\s\(\)]+$`)
+	reAllowedDisplayNameKey = regexp.MustCompile(`^[a-zA-Z0-9\-:\s()]+$`)
 )
 
 // ComponentVersion includes the version and optional display name.

--- a/pkg/cli/admin/release/image_mapper.go
+++ b/pkg/cli/admin/release/image_mapper.go
@@ -275,7 +275,7 @@ func NewImageMapper(images map[string]ImageReference) (ManifestMapper, error) {
 			ref := images[name]
 
 			suffix := parts[3]
-			klog.V(2).Infof("found repository %q with locator %q in the input, switching to %q (from pattern %s)", string(repository), string(suffix), ref.TargetPullSpec, pattern)
+			klog.V(2).Infof("found repository %q with locator %q in the input, switching to %q (from pattern %s)", repository, string(suffix), ref.TargetPullSpec, pattern)
 			switch {
 			case len(suffix) == 0:
 				// we found a repository, but no tag or digest (implied latest), or we got an exact match
@@ -434,7 +434,7 @@ func (v ComponentVersion) String() string {
 // labels removed, but prerelease segments are preserved.
 type ComponentVersions map[string]ComponentVersion
 
-// OrderedKeys returns the keys in this map in lexigraphic order.
+// OrderedKeys returns the keys in this map in lexicographic order.
 func (v ComponentVersions) OrderedKeys() []string {
 	keys := make([]string, 0, len(v))
 	for k := range v {

--- a/pkg/cli/admin/release/image_mapper.go
+++ b/pkg/cli/admin/release/image_mapper.go
@@ -66,7 +66,7 @@ func (p *Payload) Rewrite(allowTags bool, fn func(component string) imagereferen
 			continue
 		}
 		path := filepath.Join(p.path, file.Name())
-		data, err := ioutil.ReadFile(path)
+		data, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}
@@ -78,7 +78,7 @@ func (p *Payload) Rewrite(allowTags bool, fn func(component string) imagereferen
 			continue
 		}
 		klog.V(6).Infof("Rewrote\n%s\n\nto\n\n%s\n", string(data), string(out))
-		if err := ioutil.WriteFile(path, out, file.Mode()); err != nil {
+		if err := os.WriteFile(path, out, file.Mode()); err != nil {
 			return err
 		}
 	}
@@ -99,7 +99,7 @@ func (p *Payload) References() (*imageapi.ImageStream, error) {
 }
 
 func parseImageStream(path string) (*imageapi.ImageStream, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
 		return nil, err
 	}

--- a/pkg/cli/admin/release/image_mapper_test.go
+++ b/pkg/cli/admin/release/image_mapper_test.go
@@ -5,11 +5,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 
 	imageapi "github.com/openshift/api/image/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/diff"
 )
 
 func TestNewImageMapper(t *testing.T) {
@@ -696,18 +696,18 @@ func Test_loadImageStreamTransforms(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ioStream := genericiooptions.NewTestIOStreamsDiscard()
-			got, got1, got2, err := loadImageStreamTransforms(tt.input, tt.local, tt.allowMissingImages, tt.src, ioStream.ErrOut)
+			got, gotTags, gotRefs, err := loadImageStreamTransforms(tt.input, tt.local, tt.allowMissingImages, tt.src, ioStream.ErrOut)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("loadImageStreamTransforms() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("%s", diff.ObjectReflectDiff(got, tt.want))
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("versions differ (-want +got):\n%s", diff)
 			}
-			if !reflect.DeepEqual(got1, tt.wantTags) {
-				t.Errorf("%s", diff.ObjectReflectDiff(got1, tt.wantTags))
+			if diff := cmp.Diff(tt.wantTags, gotTags); diff != "" {
+				t.Errorf("tags differ (-want +got):\n%s", diff)
 			}
-			if !reflect.DeepEqual(got2, tt.wantRefs) {
-				t.Errorf("%s", diff.ObjectReflectDiff(got2, tt.wantRefs))
+			if diff := cmp.Diff(tt.wantRefs, gotRefs); diff != "" {
+				t.Errorf("refs differ (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/cli/admin/release/image_mapper_test.go
+++ b/pkg/cli/admin/release/image_mapper_test.go
@@ -265,8 +265,6 @@ func TestNewExactMapper(t *testing.T) {
 }
 
 func TestNewComponentVersionsMapper(t *testing.T) {
-	type args struct {
-	}
 	tests := []struct {
 		name        string
 		releaseName string
@@ -372,8 +370,6 @@ func TestNewComponentVersionsMapper(t *testing.T) {
 }
 
 func Test_parseComponentVersionsLabel(t *testing.T) {
-	type args struct {
-	}
 	tests := []struct {
 		name         string
 		label        string

--- a/pkg/cli/admin/release/new.go
+++ b/pkg/cli/admin/release/new.go
@@ -346,10 +346,7 @@ func (o *NewOptions) Run(ctx context.Context) error {
 		o.AlwaysInclude = append(o.AlwaysInclude, o.ToImageBaseTag)
 	}
 
-	exclude := sets.NewString()
-	for _, s := range o.Exclude {
-		exclude.Insert(s)
-	}
+	exclude := sets.New[string](o.Exclude...)
 
 	metadata := make(map[string]imageData)
 	var ordered []string
@@ -795,7 +792,7 @@ func (o *NewOptions) Run(ctx context.Context) error {
 	return nil
 }
 
-func resolveImageStreamTagsToReferenceMode(inputIS, is *imageapi.ImageStream, referenceMode string, exclude sets.String) error {
+func resolveImageStreamTagsToReferenceMode(inputIS, is *imageapi.ImageStream, referenceMode string, exclude sets.Set[string]) error {
 	switch referenceMode {
 	case "public", "", "source":
 		forceExternal := referenceMode == "public" || referenceMode == ""

--- a/pkg/cli/admin/release/new.go
+++ b/pkg/cli/admin/release/new.go
@@ -217,7 +217,7 @@ type NewOptions struct {
 	cleanupFns []func()
 }
 
-func (o *NewOptions) Complete(f kcmdutil.Factory, cmd *cobra.Command, args []string) error {
+func (o *NewOptions) Complete(f kcmdutil.Factory, _ *cobra.Command, args []string) error {
 	overlap := make(map[string]string)
 	var mappings []Mapping
 	for _, filename := range o.MappingFilenames {
@@ -1495,26 +1495,6 @@ func hasTag(tags []imageapi.TagReference, tag string) *imageapi.TagReference {
 		}
 	}
 	return nil
-}
-
-func pruneEmptyDirectories(dir string) error {
-	return filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if !info.IsDir() {
-			return nil
-		}
-		names, err := os.ReadDir(path)
-		if err != nil {
-			return err
-		}
-		if len(names) > 0 {
-			return nil
-		}
-		klog.V(4).Infof("Component %s does not have any manifests", path)
-		return os.Remove(path)
-	})
 }
 
 type Mapping struct {


### PR DESCRIPTION
While working towards fixing [OCPBUGS-19824](https://issues.redhat.com/browse/OCPBUGS-19824) and [OCPBUGS-30080](https://issues.redhat.com/browse/OCPBUGS-30080) I needed to familiarize myself with this code. Taking opportunities for small improvements as I go.

Separating commits for easy review (and to allow easy removing some changes if not desired for any reason), but I think we can squash-merge them:

- **adm release: remove unused code**
- **adm release: port deprecated functions**
- **adm release: minor cleanups**
- **adm release: compile regex just once**
- **adm release: simplify regexes**
