### PR TITLE
AGENT-1000: improve oc adm node-image output

### DIFF
--- a/pkg/cli/admin/nodeimage/basenodeimagecommand.go
+++ b/pkg/cli/admin/nodeimage/basenodeimagecommand.go
@@ -1,0 +1,404 @@
+package nodeimage
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"regexp"
+	"time"
+
+	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
+	"k8s.io/klog/v2"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	kapierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/kubectl/pkg/cmd/exec"
+
+	ocpv1 "github.com/openshift/api/config/v1"
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
+	"github.com/openshift/library-go/pkg/operator/resource/retry"
+	ocrelease "github.com/openshift/oc/pkg/cli/admin/release"
+	imagemanifest "github.com/openshift/oc/pkg/cli/image/manifest"
+)
+
+type BaseNodeImageCommand struct {
+	genericiooptions.IOStreams
+	SecurityOptions imagemanifest.SecurityOptions
+	LogOut          io.Writer
+
+	Config                   *rest.Config
+	remoteExecutor           exec.RemoteExecutor
+	ConfigClient             configclient.Interface
+	Client                   kubernetes.Interface
+	nodeJoinerImage          string
+	nodeJoinerNamespace      *corev1.Namespace
+	nodeJoinerServiceAccount *corev1.ServiceAccount
+	nodeJoinerRole           *rbacv1.ClusterRole
+	RESTClientGetter         genericclioptions.RESTClientGetter
+	nodeJoinerPod            *corev1.Pod
+	command                  string
+}
+
+func newBaseNodeImageCommand(streams genericiooptions.IOStreams, command, prefix string) *BaseNodeImageCommand {
+	cmd := &BaseNodeImageCommand{
+		IOStreams: streams,
+		command:   command,
+	}
+	cmd.LogOut = cmd.newPrefixWriter(streams.Out, prefix)
+	return cmd
+}
+
+func (c *BaseNodeImageCommand) newPrefixWriter(out io.Writer, prefix string) io.Writer {
+	reader, writer := io.Pipe()
+	scanner := bufio.NewScanner(reader)
+	go func() {
+		for scanner.Scan() {
+			text := scanner.Text()
+			ts := time.Now().UTC().Format(time.RFC3339)
+			fmt.Fprintf(out, "%s [node-image %s] %s\n", ts, prefix, text)
+		}
+	}()
+	return writer
+}
+
+func (c *BaseNodeImageCommand) log(format string, a ...interface{}) {
+	fmt.Fprintf(c.LogOut, format+"\n", a...)
+}
+
+func (c *BaseNodeImageCommand) getNodeJoinerPullSpec(ctx context.Context) error {
+	// Get the current cluster release version.
+	releaseImage, err := c.fetchClusterReleaseImage(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Extract the baremetal-installer image pullspec, since it
+	// provide the node-joiner tool.
+	opts := ocrelease.NewInfoOptions(c.IOStreams)
+	opts.SecurityOptions = c.SecurityOptions
+	release, err := opts.LoadReleaseInfo(releaseImage, false)
+	if err != nil {
+		return err
+	}
+
+	tagName := "baremetal-installer"
+	for _, tag := range release.References.Spec.Tags {
+		if tag.Name == tagName {
+			c.nodeJoinerImage = tag.From.Name
+			return nil
+		}
+	}
+
+	return fmt.Errorf("no image tag %q exists in the release image %s", tagName, releaseImage)
+}
+
+func (c *BaseNodeImageCommand) fetchClusterReleaseImage(ctx context.Context) (string, error) {
+	cv, err := c.getCurrentClusterVersion(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	image := cv.Status.Desired.Image
+	if len(image) == 0 && cv.Spec.DesiredUpdate != nil {
+		image = cv.Spec.DesiredUpdate.Image
+	}
+	if len(image) == 0 {
+		return "", fmt.Errorf("the server is not reporting a release image at this time")
+	}
+
+	return image, nil
+}
+
+func (c *BaseNodeImageCommand) getCurrentClusterVersion(ctx context.Context) (*ocpv1.ClusterVersion, error) {
+	cv, err := c.ConfigClient.ConfigV1().ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
+	if err != nil {
+		if kapierrors.IsNotFound(err) || kapierrors.ReasonForError(err) == metav1.StatusReasonUnknown {
+			klog.V(2).Infof("Unable to find cluster version object from cluster: %v", err)
+			return nil, fmt.Errorf("command expects a connection to an OpenShift 4.x server")
+		}
+	}
+	return cv, nil
+}
+
+func (c *BaseNodeImageCommand) isClusterVersionLessThan(ctx context.Context, version string) (bool, error) {
+	cv, err := c.getCurrentClusterVersion(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	currentVersion := cv.Status.Desired.Version
+	matches := regexp.MustCompile(`^(\d+[.]\d+)[.].*`).FindStringSubmatch(currentVersion)
+	if len(matches) < 2 {
+		return false, fmt.Errorf("failed to parse major.minor version from ClusterVersion status.desired.version %q", currentVersion)
+	}
+	return matches[1] < version, nil
+}
+
+// Adds a guardrail for node-image commands which is supported only for Openshift version 4.17 and later
+func (c *BaseNodeImageCommand) checkMinSupportedVersion(ctx context.Context) error {
+	notSupported, err := c.isClusterVersionLessThan(ctx, nodeJoinerMinimumSupportedVersion)
+	if err != nil {
+		return err
+	}
+	if notSupported {
+		return fmt.Errorf("the 'oc adm node-image' command is only available for OpenShift versions %s and later", nodeJoinerMinimumSupportedVersion)
+	}
+	return nil
+}
+
+func (c *BaseNodeImageCommand) createNamespace(ctx context.Context) error {
+	nsNodeJoiner := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "openshift-node-joiner-",
+			Annotations: map[string]string{
+				"oc.openshift.io/command":    c.command,
+				"openshift.io/node-selector": "",
+			},
+		},
+	}
+
+	ns, err := c.Client.CoreV1().Namespaces().Create(ctx, nsNodeJoiner, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("cannot create namespace: %w", err)
+	}
+
+	c.nodeJoinerNamespace = ns
+	return nil
+}
+
+func (c *BaseNodeImageCommand) cleanup(ctx context.Context) {
+	if c.nodeJoinerNamespace == nil {
+		return
+	}
+
+	err := c.Client.CoreV1().Namespaces().Delete(ctx, c.nodeJoinerNamespace.GetName(), metav1.DeleteOptions{})
+	if err != nil {
+		klog.Errorf("cannot delete namespace %s: %v\n", c.nodeJoinerNamespace.GetName(), err)
+	}
+}
+
+func (c *BaseNodeImageCommand) createServiceAccount(ctx context.Context) error {
+	nodeJoinerServiceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "node-joiner-",
+			Annotations: map[string]string{
+				"oc.openshift.io/command": c.command,
+			},
+			Namespace: c.nodeJoinerNamespace.GetName(),
+		},
+	}
+
+	sa, err := c.Client.CoreV1().ServiceAccounts(c.nodeJoinerNamespace.GetName()).Create(ctx, nodeJoinerServiceAccount, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("cannot create service account: %w", err)
+	}
+
+	c.nodeJoinerServiceAccount = sa
+	return nil
+}
+
+func (c *BaseNodeImageCommand) clusterRoleBindings() *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "node-joiner-monitor-",
+			Annotations: map[string]string{
+				"oc.openshift.io/command": c.command,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "v1",
+					Kind:       "Namespace",
+					Name:       c.nodeJoinerNamespace.GetName(),
+					UID:        c.nodeJoinerNamespace.GetUID(),
+				},
+			},
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      c.nodeJoinerServiceAccount.GetName(),
+				Namespace: c.nodeJoinerNamespace.GetName(),
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     c.nodeJoinerRole.GetName(),
+		},
+	}
+}
+
+func (c *BaseNodeImageCommand) waitForRunningPod(ctx context.Context) error {
+	// Wait for the node-joiner pod to come up
+	return wait.PollUntilContextTimeout(
+		ctx,
+		time.Second*5,
+		time.Minute*15,
+		true,
+		func(ctx context.Context) (done bool, err error) {
+			pod, err := c.Client.CoreV1().Pods(c.nodeJoinerNamespace.GetName()).Get(context.TODO(), c.nodeJoinerPod.GetName(), metav1.GetOptions{})
+			if err == nil {
+				if len(pod.Status.ContainerStatuses) == 0 {
+					return false, nil
+				}
+				state := pod.Status.ContainerStatuses[0].State
+				if state.Waiting != nil {
+					switch state.Waiting.Reason {
+					case "InvalidImageName":
+						return true, fmt.Errorf("unable to pull image: %v: %v", state.Waiting.Reason, state.Waiting.Message)
+					case "ErrImagePull", "ImagePullBackOff":
+						klog.V(1).Infof("Unable to pull image (%s), retrying", state.Waiting.Reason)
+						return false, nil
+					}
+				}
+				return state.Running != nil || state.Terminated != nil, nil
+			}
+			if retry.IsHTTPClientError(err) {
+				return false, nil
+			}
+			return false, err
+		})
+}
+
+func (c *BaseNodeImageCommand) createRolesAndBindings(ctx context.Context) error {
+	nodeJoinerRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "node-joiner-",
+			Annotations: map[string]string{
+				"oc.openshift.io/command": c.command,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "v1",
+					Kind:       "Namespace",
+					Name:       c.nodeJoinerNamespace.GetName(),
+					UID:        c.nodeJoinerNamespace.GetUID(),
+				},
+			},
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{
+					"config.openshift.io",
+				},
+				Resources: []string{
+					"clusterversions",
+					"infrastructures",
+					"proxies",
+					"imagedigestmirrorsets",
+					"imagecontentpolicies",
+				},
+				Verbs: []string{
+					"get",
+					"list",
+				},
+			},
+			{
+				APIGroups: []string{
+					"machineconfiguration.openshift.io",
+				},
+				Resources: []string{
+					"machineconfigs",
+				},
+				Verbs: []string{
+					"get",
+					"list",
+				},
+			},
+			{
+				APIGroups: []string{
+					"certificates.k8s.io",
+				},
+				Resources: []string{
+					"certificatesigningrequests",
+				},
+				Verbs: []string{
+					"get",
+					"list",
+				},
+			},
+			{
+				APIGroups: []string{
+					"",
+				},
+				Resources: []string{
+					"configmaps",
+					"nodes",
+					"pods",
+					"nodes",
+				},
+				Verbs: []string{
+					"get",
+					"list",
+				},
+			},
+			{
+				APIGroups: []string{
+					"",
+				},
+				Resources: []string{
+					"secrets",
+				},
+				Verbs: []string{
+					"get",
+					"list",
+					"create",
+					"update",
+				},
+			},
+		},
+	}
+	cr, err := c.Client.RbacV1().ClusterRoles().Create(ctx, nodeJoinerRole, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("cannot create role: %w", err)
+	}
+	c.nodeJoinerRole = cr
+
+	_, err = c.Client.RbacV1().ClusterRoleBindings().Create(ctx, c.clusterRoleBindings(), metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("cannot create role binding: %w", err)
+	}
+
+	return nil
+}
+
+func (c *BaseNodeImageCommand) baseComplete(f genericclioptions.RESTClientGetter) error {
+	c.RESTClientGetter = f
+
+	var err error
+	if c.Config, err = f.ToRESTConfig(); err != nil {
+		return err
+	}
+	if c.Client, err = kubernetes.NewForConfig(c.Config); err != nil {
+		return err
+	}
+	if c.ConfigClient, err = configclient.NewForConfig(c.Config); err != nil {
+		return err
+	}
+	c.remoteExecutor = &exec.DefaultRemoteExecutor{}
+	return nil
+}
+
+func (c *BaseNodeImageCommand) addBaseFlags(cmd *cobra.Command) *flag.FlagSet {
+	f := cmd.Flags()
+	c.SecurityOptions.Bind(f)
+	return f
+}
+
+func (o *BaseNodeImageCommand) runNodeJoinerPod(ctx context.Context, tasks []func(context.Context) error) error {
+	for _, task := range tasks {
+		if err := task(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/cli/admin/nodeimage/basenodeimagecommand.go
+++ b/pkg/cli/admin/nodeimage/basenodeimagecommand.go
@@ -245,6 +245,7 @@ func (c *BaseNodeImageCommand) waitForRunningPod(ctx context.Context) error {
 		time.Minute*15,
 		true,
 		func(ctx context.Context) (done bool, err error) {
+			klog.V(2).Infof("Waiting for running pod %s/%s", c.nodeJoinerNamespace.GetName(), c.nodeJoinerPod.GetName())
 			pod, err := c.Client.CoreV1().Pods(c.nodeJoinerNamespace.GetName()).Get(context.TODO(), c.nodeJoinerPod.GetName(), metav1.GetOptions{})
 			if err == nil {
 				if len(pod.Status.ContainerStatuses) == 0 {

--- a/pkg/cli/admin/nodeimage/create.go
+++ b/pkg/cli/admin/nodeimage/create.go
@@ -67,6 +67,9 @@ var (
 		such case the '--mac-address' is the only mandatory flag - while all the
 		others will be optional (note: any eventual configuration file present
 		will be ignored).
+
+		In case of a command failure a report.json file is automatically created
+		with the error details, and additional troubleshooting information.
 	`)
 
 	createExample = templates.Examples(`
@@ -132,6 +135,8 @@ type CreateOptions struct {
 	OutputName string
 	// GeneratePXEFiles generates files for PXE boot instead of an ISO
 	GeneratePXEFiles bool
+	// GenerateReport allows to save the report in the asset folder
+	GenerateReport bool
 
 	// Simpler interface for creating a single node
 	SingleNodeOpts *singleNodeCreateOptions
@@ -157,6 +162,7 @@ func (o *CreateOptions) AddFlags(cmd *cobra.Command) {
 	flags.StringVar(&o.AssetsDir, "dir", o.AssetsDir, "The path containing the configuration file, used also to store the generated artifacts.")
 	flags.StringVarP(&o.OutputName, "output-name", "o", "", "The name of the output image.")
 	flags.BoolVarP(&o.GeneratePXEFiles, "pxe", "p", false, "Instead of an ISO, create files that can be used for PXE boot")
+	flags.BoolVarP(&o.GenerateReport, "report", "r", false, "When set, the report.json is always generated in the asset folder")
 
 	flags.StringP(snFlagMacAddress, "m", "", "Single node flag. MAC address used to identify the host to apply the configuration. If specified, the nodes-config.yaml config file will not be used.")
 	usageFmt := "Single node flag. %s. Valid only when `mac-address` is defined."
@@ -310,6 +316,12 @@ func (o *CreateOptions) Run() error {
 	err = o.renameImageIfOutputNameIsSpecified()
 	if err != nil {
 		return err
+	}
+
+	if o.GenerateReport {
+		if err = o.saveReport(); err != nil {
+			return err
+		}
 	}
 
 	o.log("Command successfully completed")

--- a/pkg/cli/admin/nodeimage/create_test.go
+++ b/pkg/cli/admin/nodeimage/create_test.go
@@ -173,8 +173,8 @@ func TestRun(t *testing.T) {
 					ErrorMessage: "Some error message",
 				},
 			}),
-			expectedErrorCode: 127,
-			expectedError:     `command execution failed. Reason: Some error message`,
+			expectedErrorCode: 1,
+			expectedError:     `exit`,
 		},
 		{
 			name:          "node-joiner unsupported prior to 4.17",
@@ -268,6 +268,8 @@ func TestRun(t *testing.T) {
 			// Create another fake for the copy action
 			fakeCp := &fakeCopier{}
 
+			var logBuffer bytes.Buffer
+
 			// Prepare the command options with all the fakes
 			o := &CreateOptions{
 				BaseNodeImageCommand: BaseNodeImageCommand{
@@ -277,6 +279,7 @@ func TestRun(t *testing.T) {
 					Client:         fakeClient,
 					Config:         fakeRestConfig,
 					remoteExecutor: fakeRemoteExec,
+					LogOut:         &logBuffer,
 				},
 				FSys: fakeFileSystem,
 				copyStrategy: func(o *rsync.RsyncOptions) rsync.CopyStrategy {

--- a/pkg/cli/admin/nodeimage/create_test.go
+++ b/pkg/cli/admin/nodeimage/create_test.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"slices"
 	"strings"
 	"testing"
@@ -289,6 +290,7 @@ func TestRun(t *testing.T) {
 
 				AssetsDir:        tc.assetsDir,
 				GeneratePXEFiles: tc.generatePXEFiles,
+				fileWriter:       mockFileWriter{},
 			}
 			// Since the fake registry creates a self-signed cert, let's configure
 			// the command options accordingly
@@ -316,6 +318,12 @@ func TestRun(t *testing.T) {
 			}
 		})
 	}
+}
+
+type mockFileWriter struct{}
+
+func (mockFileWriter) WriteFile(name string, data []byte, perm os.FileMode) error {
+	return nil
 }
 
 // fakeRegistry creates a fake Docker registry configured to serve the minimum

--- a/pkg/cli/admin/nodeimage/create_test.go
+++ b/pkg/cli/admin/nodeimage/create_test.go
@@ -34,6 +34,7 @@ import (
 	restclient "k8s.io/client-go/rest"
 	clientgotesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/remotecommand"
+	utilexec "k8s.io/utils/exec"
 
 	"github.com/distribution/distribution/v3/manifest/schema2"
 	configv1 "github.com/openshift/api/config/v1"
@@ -106,12 +107,26 @@ func strPtr(s string) *string {
 	return &s
 }
 
+func createCmdOutput(t *testing.T, r report) string {
+	t.Helper()
+	out, err := json.Marshal(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(out)
+}
+
 func TestRun(t *testing.T) {
 	ClusterVersion_4_16_ObjectFn := func(repo string, manifestDigest string) []runtime.Object {
 		cvobj := defaultClusterVersionObjectFn(repo, manifestDigest)
 		clusterVersion := cvobj[0].(*configv1.ClusterVersion)
 		clusterVersion.Status.Desired.Version = "4.16.6-x86_64"
-
+		return cvobj
+	}
+	ClusterVersion_4_17_ObjectFn := func(repo string, manifestDigest string) []runtime.Object {
+		cvobj := defaultClusterVersionObjectFn(repo, manifestDigest)
+		clusterVersion := cvobj[0].(*configv1.ClusterVersion)
+		clusterVersion.Status.Desired.Version = "4.17.4-x86_64"
 		return cvobj
 	}
 
@@ -124,6 +139,7 @@ func TestRun(t *testing.T) {
 		objects          func(string, string) []runtime.Object
 		remoteExecOutput string
 
+		expectedErrorCode    int
 		expectedError        string
 		expectedPod          func(t *testing.T, pod *corev1.Pod)
 		expectedRsyncInclude string
@@ -145,18 +161,26 @@ func TestRun(t *testing.T) {
 			expectedRsyncInclude: "boot-artifacts/*",
 		},
 		{
-			name:             "node-joiner tool failure",
-			nodesConfig:      defaultNodesConfigYaml,
-			objects:          defaultClusterVersionObjectFn,
-			remoteExecOutput: "1",
-			expectedError:    `image generation error: <nil> (exit code: 1)`,
+			name:        "node-joiner tool failure",
+			nodesConfig: defaultNodesConfigYaml,
+			objects:     defaultClusterVersionObjectFn,
+			remoteExecOutput: createCmdOutput(t, report{
+				stageHeader: stageHeader{
+					EndTime: time.Date(2024, 11, 14, 0, 0, 0, 0, time.UTC),
+				},
+				Result: &reportResult{
+					ExitCode:     127,
+					ErrorMessage: "Some error message",
+				},
+			}),
+			expectedErrorCode: 127,
+			expectedError:     `command execution failed. Reason: Some error message`,
 		},
 		{
-			name:             "node-joiner unsupported prior to 4.17",
-			nodesConfig:      defaultNodesConfigYaml,
-			objects:          ClusterVersion_4_16_ObjectFn,
-			remoteExecOutput: "1",
-			expectedError:    fmt.Sprintf("the 'oc adm node-image' command is only available for OpenShift versions %s and later", nodeJoinerMinimumSupportedVersion),
+			name:          "node-joiner unsupported prior to 4.17",
+			nodesConfig:   defaultNodesConfigYaml,
+			objects:       ClusterVersion_4_16_ObjectFn,
+			expectedError: fmt.Sprintf("the 'oc adm node-image' command is only available for OpenShift versions %s and later", nodeJoinerMinimumSupportedVersion),
 		},
 		{
 			name:          "missing cluster connection",
@@ -204,6 +228,12 @@ func TestRun(t *testing.T) {
 				}
 			},
 		},
+		{
+			name:             "basic report for ocp < 4.18",
+			nodesConfig:      defaultNodesConfigYaml,
+			objects:          ClusterVersion_4_17_ObjectFn,
+			remoteExecOutput: "0",
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -223,6 +253,15 @@ func TestRun(t *testing.T) {
 				objs = tc.objects(fakeReg.URL()[len("https://"):], fakeReg.fakeManifestDigest)
 			}
 
+			fakeRemoteExec.execOut = createCmdOutput(t, report{
+				stageHeader: stageHeader{
+					Identifier: "report-test",
+					EndTime:    time.Date(2024, 11, 14, 0, 0, 0, 0, time.UTC),
+				},
+				Result: &reportResult{
+					ExitCode: 0,
+				},
+			})
 			if tc.remoteExecOutput != "" {
 				fakeRemoteExec.execOut = tc.remoteExecOutput
 			}
@@ -253,7 +292,7 @@ func TestRun(t *testing.T) {
 			o.SecurityOptions.Insecure = true
 
 			err := o.Run()
-			assertContainerImageAndErrors(t, err, fakeReg, fakeClient, tc.expectedError, nodeJoinerContainer)
+			assertContainerImageAndErrors(t, err, fakeReg, fakeClient, tc.expectedErrorCode, tc.expectedError, nodeJoinerContainer)
 
 			// Perform additional checks on the generated node-joiner pod
 			if tc.expectedPod != nil {
@@ -546,7 +585,7 @@ func getTestPod(fakeClient *fake.Clientset, podName string) *corev1.Pod {
 	return pod
 }
 
-func assertContainerImageAndErrors(t *testing.T, runErr error, fakeReg *fakeRegistry, fakeClient *fake.Clientset, expectedError, podName string) {
+func assertContainerImageAndErrors(t *testing.T, runErr error, fakeReg *fakeRegistry, fakeClient *fake.Clientset, expectedErrorCode int, expectedError, podName string) {
 	if expectedError == "" {
 		if runErr != nil {
 			t.Fatalf("unexpected error: %v", runErr)
@@ -561,8 +600,13 @@ func assertContainerImageAndErrors(t *testing.T, runErr error, fakeReg *fakeRegi
 		if runErr == nil {
 			t.Fatalf("expected error not received: %s", expectedError)
 		}
-		if !strings.Contains(runErr.Error(), expectedError) {
-			t.Fatalf("expected error: %s, actual: %v", expectedError, runErr.Error())
+		if codeExitErr, ok := runErr.(utilexec.CodeExitError); ok {
+			if codeExitErr.Code != expectedErrorCode {
+				t.Fatalf("expected error code: %d, actual: %d", expectedErrorCode, codeExitErr.Code)
+			}
+		}
+		if runErr.Error() != expectedError {
+			t.Fatalf("expected error: %s, actual: %s", expectedError, runErr.Error())
 		}
 	}
 }

--- a/pkg/cli/admin/nodeimage/monitor.go
+++ b/pkg/cli/admin/nodeimage/monitor.go
@@ -146,6 +146,7 @@ func (o *MonitorOptions) Run() error {
 	defer o.cleanup(ctx)
 
 	tasks := []func(context.Context) error{
+		o.checkMinSupportedVersion,
 		o.getNodeJoinerPullSpec,
 		o.createNamespace,
 		o.createServiceAccount,

--- a/pkg/cli/admin/nodeimage/monitor.go
+++ b/pkg/cli/admin/nodeimage/monitor.go
@@ -161,7 +161,7 @@ func (o *MonitorOptions) Run() error {
 
 	podName := o.nodeJoinerPod.GetName()
 
-	if err := o.waitForContainerRunning(ctx); err != nil {
+	if err := o.waitForRunningPod(ctx); err != nil {
 		klog.Errorf("monitoring did not start: %s", err)
 		return fmt.Errorf("monitoring did not start for pod %s: %s", podName, err)
 	}

--- a/pkg/cli/admin/nodeimage/monitor_test.go
+++ b/pkg/cli/admin/nodeimage/monitor_test.go
@@ -123,7 +123,7 @@ func TestMonitorRun(t *testing.T) {
 			o.SecurityOptions.Insecure = true
 
 			err := o.Run()
-			assertContainerImageAndErrors(t, err, fakeReg, fakeClient, tc.expectedError, nodeJoinerMonitorContainer)
+			assertContainerImageAndErrors(t, err, fakeReg, fakeClient, -1, tc.expectedError, nodeJoinerMonitorContainer)
 			if tc.expectedError == "" {
 				if fakeLogContent != logContents.String() {
 					t.Errorf("expected %v, actual %v", fakeLogContent, logContents.String())


### PR DESCRIPTION
This patch refactors the `create` command output by streaming the workflow report generated (and continuously updated) by the node-joiner tool during the command execution, in order to provide a more informative live feedback to the user.

In case of command error the report is automatically saved in the asset folder as `report.json`, and error details are saved within.
If the command doesn't not complete correctly (for any reason), the pod logs are also stored in the report.json (if available.

A new command option flag `--report` is provided to allow saving always the report file.

(note: the new improved output (as well as the report.json) will be available only for 4.18+)

Sample output:
```
2024-11-15T15:03:00Z [node-image create] Launching command
2024-11-15T15:03:05Z [node-image create] Gathering additional information from the target cluster
2024-11-15T15:03:05Z [node-image create] Creating internal configuration manifests
2024-11-15T15:03:05Z [node-image create] Rendering ISO ignition
2024-11-15T15:03:05Z [node-image create] Retrieving the base ISO image
2024-11-15T15:03:05Z [node-image create]   Extracting base image from release payload
2024-11-15T15:03:45Z [node-image create]   Verifying base image version
2024-11-15T15:04:25Z [node-image create] Creating agent artifacts for the final image
2024-11-15T15:04:25Z [node-image create]   Extracting required artifacts from release payload
2024-11-15T15:04:40Z [node-image create]   Preparing artifacts
2024-11-15T15:04:40Z [node-image create] Assembling ISO image
2024-11-15T15:04:40Z [node-image create] Saving ISO image to /home/user/work-dir
2024-11-15T15:04:48Z [node-image create] Saving report file
2024-11-15T15:04:48Z [node-image create] Command successfully completed
```

Sample error:
```
2024-11-14T16:19:56Z [node-image create] Launching command
2024-11-14T16:20:06Z [node-image create] Gathering additional information from the target cluster
2024-11-14T16:20:06Z [node-image create] command execution failed. Reason: address conflict found. The configured address 192.168.111.83 is already used by the cluster node extraworker-0
```