### PR TITLE
OTA-1224: status: simplify worker status line (2)

### DIFF
--- a/pkg/cli/admin/upgrade/status/examples/4.14.1-workers-started-updating-multiple-pools.detailed-output
+++ b/pkg/cli/admin/upgrade/status/examples/4.14.1-workers-started-updating-multiple-pools.detailed-output
@@ -19,8 +19,8 @@ ip-10-0-92-180.us-east-2.compute.internal   Outdated      Pending    4.14.0    ?
 = Worker Upgrade =
 
 WORKER POOL   ASSESSMENT    COMPLETION   STATUS
-worker        Progressing   0% (0/2)     1 Available, 1 Progressing, 1 Draining
-infra         Progressing   0% (0/2)     1 Available, 1 Progressing, 1 Draining
+worker        Progressing   0% (0/2)     1 Available, 1 Unavailable (1 Progressing), 1 Progressing, 1 Draining
+infra         Progressing   0% (0/2)     1 Available, 1 Unavailable (1 Progressing), 1 Progressing, 1 Draining
 
 Worker Pool Nodes: worker
 NAME                                       ASSESSMENT    PHASE      VERSION   EST    MESSAGE

--- a/pkg/cli/admin/upgrade/status/examples/4.14.1-workers-started-updating-multiple-pools.output
+++ b/pkg/cli/admin/upgrade/status/examples/4.14.1-workers-started-updating-multiple-pools.output
@@ -15,8 +15,8 @@ ip-10-0-92-180.us-east-2.compute.internal   Outdated      Pending    4.14.0    ?
 = Worker Upgrade =
 
 WORKER POOL   ASSESSMENT    COMPLETION   STATUS
-worker        Progressing   0% (0/2)     1 Available, 1 Progressing, 1 Draining
-infra         Progressing   0% (0/2)     1 Available, 1 Progressing, 1 Draining
+worker        Progressing   0% (0/2)     1 Available, 1 Unavailable (1 Progressing), 1 Progressing, 1 Draining
+infra         Progressing   0% (0/2)     1 Available, 1 Unavailable (1 Progressing), 1 Progressing, 1 Draining
 
 Worker Pool Nodes: worker
 NAME                                       ASSESSMENT    PHASE      VERSION   EST    MESSAGE

--- a/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.detailed-output
+++ b/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.detailed-output
@@ -6,7 +6,7 @@ All control plane nodes successfully updated to 4.16.0-ec.3
 = Worker Upgrade =
 
 WORKER POOL   ASSESSMENT   COMPLETION    STATUS
-worker        Degraded     37% (22/59)   44 Available, 5 Progressing, 12 Draining, 7 Degraded
+worker        Degraded     37% (22/59)   44 Available (23 Outdated), 15 Unavailable (5 Progressing), 5 Progressing, 12 Draining, 7 Degraded
 
 Worker Pool Nodes: worker
 NAME                                                              ASSESSMENT    PHASE      VERSION       EST    MESSAGE

--- a/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.output
+++ b/pkg/cli/admin/upgrade/status/examples/4.16.0-ec2-control-plane-updated-pdb-prohibits-draining.output
@@ -6,7 +6,7 @@ All control plane nodes successfully updated to 4.16.0-ec.3
 = Worker Upgrade =
 
 WORKER POOL   ASSESSMENT   COMPLETION    STATUS
-worker        Degraded     37% (22/59)   44 Available, 5 Progressing, 12 Draining, 7 Degraded
+worker        Degraded     37% (22/59)   44 Available (23 Outdated), 15 Unavailable (5 Progressing), 5 Progressing, 12 Draining, 7 Degraded
 
 Worker Pool Nodes: worker
 NAME                                      ASSESSMENT    PHASE      VERSION       EST   MESSAGE

--- a/pkg/cli/admin/upgrade/status/workerpool_test.go
+++ b/pkg/cli/admin/upgrade/status/workerpool_test.go
@@ -1131,10 +1131,11 @@ func Test_assessMachineConfigPool(t *testing.T) {
 				Assessment: assessmentStateProgressing,
 				Completion: 50,
 				NodesOverview: nodesOverviewDisplayData{
-					Total:       2,
-					Available:   1,
-					Progressing: 1,
-					Outdated:    1,
+					Total:                     2,
+					Available:                 1,
+					Progressing:               1,
+					Outdated:                  1,
+					UnavailableAndProgressing: 1,
 				},
 				Nodes: []nodeDisplayData{
 					{
@@ -1279,10 +1280,11 @@ func Test_assessMachineConfigPool(t *testing.T) {
 				Assessment: assessmentStateExcluded,
 				Completion: 0,
 				NodesOverview: nodesOverviewDisplayData{
-					Total:     1,
-					Available: 1,
-					Excluded:  1,
-					Outdated:  1,
+					Total:                1,
+					Available:            1,
+					Excluded:             1,
+					Outdated:             1,
+					AvailableAndOutdated: 1,
 				},
 				Nodes: []nodeDisplayData{
 					{


### PR DESCRIPTION
- Show the number of available and outdated nodes (and thus the number of available and updated can be calculated) if workers' upgrading is started.
- Show the number of unavailable and progressing nodes if there are unavailable nodes.

/cc @DavidHurta @petr-muller 