### PR TITLE
OTA-1393: status: recognize multi-arch in node phase

### DIFF
--- a/pkg/cli/admin/upgrade/status/examples/to-multi-arch.detailed-output
+++ b/pkg/cli/admin/upgrade/status/examples/to-multi-arch.detailed-output
@@ -10,18 +10,22 @@ Updating Cluster Operators
 NAME             SINCE   REASON   MESSAGE
 machine-config   6m5s    -        Working towards 4.18.0-ec.3
 
-All control plane nodes successfully updated to 4.18.0-ec.3
+Control Plane Nodes
+NAME                                        ASSESSMENT    PHASE      VERSION       EST   MESSAGE
+ip-10-0-33-81.us-east-2.compute.internal    Progressing   Updating   4.18.0-ec.3   +5m   
+ip-10-0-45-170.us-east-2.compute.internal   Completed     Updated    4.18.0-ec.3   -     
+ip-10-0-95-224.us-east-2.compute.internal   Completed     Updated    4.18.0-ec.3   -     
 
 = Worker Upgrade =
 
-WORKER POOL   ASSESSMENT   COMPLETION   STATUS
-worker        Completed    100% (3/3)   2 Available, 0 Progressing, 0 Draining
+WORKER POOL   ASSESSMENT    COMPLETION   STATUS
+worker        Progressing   67% (2/3)    2 Available, 1 Progressing, 1 Draining
 
 Worker Pool Nodes: worker
-NAME                                        ASSESSMENT    PHASE     VERSION       EST   MESSAGE
-ip-10-0-22-179.us-east-2.compute.internal   Unavailable   Updated   4.18.0-ec.3   -     Node is marked unschedulable
-ip-10-0-17-117.us-east-2.compute.internal   Completed     Updated   4.18.0-ec.3   -     
-ip-10-0-72-40.us-east-2.compute.internal    Completed     Updated   4.18.0-ec.3   -     
+NAME                                        ASSESSMENT    PHASE      VERSION       EST    MESSAGE
+ip-10-0-22-179.us-east-2.compute.internal   Progressing   Draining   4.18.0-ec.3   +10m   
+ip-10-0-17-117.us-east-2.compute.internal   Completed     Updated    4.18.0-ec.3   -      
+ip-10-0-72-40.us-east-2.compute.internal    Completed     Updated    4.18.0-ec.3   -      
 
 = Update Health =
 SINCE   LEVEL   IMPACT   MESSAGE

--- a/pkg/cli/admin/upgrade/status/examples/to-multi-arch.output
+++ b/pkg/cli/admin/upgrade/status/examples/to-multi-arch.output
@@ -6,18 +6,22 @@ Completion:      97% (32 operators updated, 1 updating, 0 waiting)
 Duration:        6m55s (Est. Time Remaining: 1h4m)
 Operator Health: 33 Healthy
 
-All control plane nodes successfully updated to 4.18.0-ec.3
+Control Plane Nodes
+NAME                                        ASSESSMENT    PHASE      VERSION       EST   MESSAGE
+ip-10-0-33-81.us-east-2.compute.internal    Progressing   Updating   4.18.0-ec.3   +5m   
+ip-10-0-45-170.us-east-2.compute.internal   Completed     Updated    4.18.0-ec.3   -     
+ip-10-0-95-224.us-east-2.compute.internal   Completed     Updated    4.18.0-ec.3   -     
 
 = Worker Upgrade =
 
-WORKER POOL   ASSESSMENT   COMPLETION   STATUS
-worker        Completed    100% (3/3)   2 Available, 0 Progressing, 0 Draining
+WORKER POOL   ASSESSMENT    COMPLETION   STATUS
+worker        Progressing   67% (2/3)    2 Available, 1 Progressing, 1 Draining
 
 Worker Pool Nodes: worker
-NAME                                        ASSESSMENT    PHASE     VERSION       EST   MESSAGE
-ip-10-0-22-179.us-east-2.compute.internal   Unavailable   Updated   4.18.0-ec.3   -     Node is marked unschedulable
-ip-10-0-17-117.us-east-2.compute.internal   Completed     Updated   4.18.0-ec.3   -     
-ip-10-0-72-40.us-east-2.compute.internal    Completed     Updated   4.18.0-ec.3   -     
+NAME                                        ASSESSMENT    PHASE      VERSION       EST    MESSAGE
+ip-10-0-22-179.us-east-2.compute.internal   Progressing   Draining   4.18.0-ec.3   +10m   
+ip-10-0-17-117.us-east-2.compute.internal   Completed     Updated    4.18.0-ec.3   -      
+ip-10-0-72-40.us-east-2.compute.internal    Completed     Updated    4.18.0-ec.3   -      
 
 = Update Health =
 SINCE   LEVEL   IMPACT   MESSAGE


### PR DESCRIPTION
Address https://github.com/openshift/oc/pull/1920#discussion_r1854403418

I thought we would need something from the MCO side to recognize the transactions between node phases (as the operator image pull spec is a new thing). While thinking about it again, MCO must have known if it needs to update the nodes without the pull spec and found the annotations. I checked the machine configs for multi-arch migration (see the following bash output): `master` (`worker` respectively) has two with `4.18.0-ec.3` and each of them should be for before-and-after the update.

The `status` command does not need to use these annotations as [the version annotation](https://github.com/openshift/oc/blob/21c3b92e2d5aa8771795f147178369414f15605a/pkg/cli/admin/upgrade/status/workerpool.go#L245) is enough until the multi-arch migration is under consideration because the version stays the same.

```
$ cat pkg/cli/admin/upgrade/status/examples/to-multi-arch-mc.yaml | yq  '.items[]|select(.metadata.annotations["machineconfiguration.openshift.io/release-image-version"]=="4.18.0-ec.3")|[.metadata.name, .spec.baseOSExtensionsContainerImage, .metadata.creationTimestamp]'
[
  "rendered-master-1f718b5bc3667e49797e9a47d9f48725",
  "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:f135a14056f31c9c21782ac194f527e358d59a67e20ccf75f08706cc68c8c980",
  "2024-11-20T23:24:40Z"
]
[
  "rendered-master-909adc791f502a35c20ba70158c4c582",
  "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:c3a4fec8e58e41a24e4bc15de9c1261b917448246d62b37dc83e4871837e3fbb",
  "2024-11-20T22:36:32Z"
]
[
  "rendered-worker-869799cd72c887a5da8248efd58bb2a9",
  "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:c3a4fec8e58e41a24e4bc15de9c1261b917448246d62b37dc83e4871837e3fbb",
  "2024-11-20T22:36:32Z"
]
[
  "rendered-worker-a079988a31206987bed827f0242d7b3f",
  "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:f135a14056f31c9c21782ac194f527e358d59a67e20ccf75f08706cc68c8c980",
  "2024-11-20T23:24:40Z"
]
```

/cc @petr-muller @DavidHurta 