### PR TITLE
OCPBUGS-45022: Obfuscate sensitive data in Proxy resource while inspection

### DIFF
--- a/pkg/cli/admin/inspect/proxy.go
+++ b/pkg/cli/admin/inspect/proxy.go
@@ -1,0 +1,61 @@
+package inspect
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"regexp"
+
+	"k8s.io/cli-runtime/pkg/resource"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+var proxyRegex = regexp.MustCompile(`(https?://)([^:]+):([^@]+)@`)
+
+type proxyList struct {
+	*configv1.ProxyList
+}
+
+func (c *proxyList) addItem(obj interface{}) error {
+	structuredItem, ok := obj.(*configv1.Proxy)
+	if !ok {
+		return fmt.Errorf("unhandledStructuredItemType: %T", obj)
+	}
+	c.Items = append(c.Items, *structuredItem)
+	return nil
+}
+
+func inspectProxyInfo(info *resource.Info, o *InspectOptions) error {
+	structuredObj, err := toStructuredObject[configv1.Proxy, configv1.ProxyList](info.Object)
+	if err != nil {
+		return err
+	}
+
+	switch castObj := structuredObj.(type) {
+	case *configv1.Proxy:
+		elideProxy(castObj)
+
+	case *configv1.ProxyList:
+		for i := range castObj.Items {
+			elideProxy(&castObj.Items[i])
+		}
+	}
+
+	// save the current object to disk
+	dirPath := dirPathForInfo(o.DestDir, info)
+	filename := filenameForInfo(info)
+	// ensure destination path exists
+	if err := os.MkdirAll(dirPath, os.ModePerm); err != nil {
+		return err
+	}
+	return o.fileWriter.WriteFromResource(path.Join(dirPath, filename), structuredObj)
+}
+
+// elideProxy obfuscates the sensitive information from proxy object.
+func elideProxy(proxy *configv1.Proxy) {
+	proxy.Spec.HTTPProxy = proxyRegex.ReplaceAllString(proxy.Spec.HTTPProxy, `${1}${2}:****@`)
+	proxy.Spec.HTTPSProxy = proxyRegex.ReplaceAllString(proxy.Spec.HTTPSProxy, `${1}${2}:****@`)
+	proxy.Status.HTTPProxy = proxyRegex.ReplaceAllString(proxy.Status.HTTPProxy, `${1}${2}:****@`)
+	proxy.Status.HTTPSProxy = proxyRegex.ReplaceAllString(proxy.Status.HTTPSProxy, `${1}${2}:****@`)
+}

--- a/pkg/cli/admin/inspect/proxy.go
+++ b/pkg/cli/admin/inspect/proxy.go
@@ -13,6 +13,8 @@ import (
 
 var proxyRegex = regexp.MustCompile(`(https?://)([^:]+):([^@]+)@`)
 
+var _ listAccessor = &proxyList{}
+
 type proxyList struct {
 	*configv1.ProxyList
 }

--- a/pkg/cli/admin/inspect/proxy_test.go
+++ b/pkg/cli/admin/inspect/proxy_test.go
@@ -1,0 +1,133 @@
+package inspect
+
+import (
+	"reflect"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+func TestElideProxy(t *testing.T) {
+	tests := []struct {
+		input    configv1.Proxy
+		expected configv1.Proxy
+	}{
+		{
+			input: configv1.Proxy{
+				Spec: configv1.ProxySpec{
+					HTTPProxy:  "",
+					HTTPSProxy: "",
+				},
+				Status: configv1.ProxyStatus{
+					HTTPProxy:  "",
+					HTTPSProxy: "",
+				},
+			}, expected: configv1.Proxy{
+				Spec: configv1.ProxySpec{
+					HTTPProxy:  "",
+					HTTPSProxy: "",
+				},
+				Status: configv1.ProxyStatus{
+					HTTPProxy:  "",
+					HTTPSProxy: "",
+				},
+			},
+		},
+		{
+			input: configv1.Proxy{
+				Spec: configv1.ProxySpec{
+					HTTPProxy:  "http://user:pass@endpoint.com",
+					HTTPSProxy: "https://user:pass@endpoint.com",
+				},
+				Status: configv1.ProxyStatus{
+					HTTPProxy:  "http://user:pass@endpoint.com",
+					HTTPSProxy: "https://user:pass@endpoint.com",
+				},
+			}, expected: configv1.Proxy{
+				Spec: configv1.ProxySpec{
+					HTTPProxy:  "http://user:****@endpoint.com",
+					HTTPSProxy: "https://user:****@endpoint.com",
+				},
+				Status: configv1.ProxyStatus{
+					HTTPProxy:  "http://user:****@endpoint.com",
+					HTTPSProxy: "https://user:****@endpoint.com",
+				},
+			},
+		},
+		{
+			input: configv1.Proxy{
+				Spec: configv1.ProxySpec{
+					HTTPProxy:  "http://user@endpoint.com",
+					HTTPSProxy: "https://user@endpoint.com",
+				},
+				Status: configv1.ProxyStatus{
+					HTTPProxy:  "http://user@endpoint.com",
+					HTTPSProxy: "https://user@endpoint.com",
+				},
+			}, expected: configv1.Proxy{
+				Spec: configv1.ProxySpec{
+					HTTPProxy:  "http://user@endpoint.com",
+					HTTPSProxy: "https://user@endpoint.com",
+				},
+				Status: configv1.ProxyStatus{
+					HTTPProxy:  "http://user@endpoint.com",
+					HTTPSProxy: "https://user@endpoint.com",
+				},
+			},
+		},
+		{
+			input: configv1.Proxy{
+				Spec: configv1.ProxySpec{
+					HTTPProxy:  "http://user:@endpoint.com",
+					HTTPSProxy: "https://user:@endpoint.com",
+				},
+				Status: configv1.ProxyStatus{
+					HTTPProxy:  "http://user:@endpoint.com",
+					HTTPSProxy: "https://user:@endpoint.com",
+				},
+			}, expected: configv1.Proxy{
+				Spec: configv1.ProxySpec{
+					HTTPProxy:  "http://user:@endpoint.com",
+					HTTPSProxy: "https://user:@endpoint.com",
+				},
+				Status: configv1.ProxyStatus{
+					HTTPProxy:  "http://user:@endpoint.com",
+					HTTPSProxy: "https://user:@endpoint.com",
+				},
+			},
+		},
+		{
+			input: configv1.Proxy{
+				Spec: configv1.ProxySpec{
+					HTTPProxy:  "http://openshift.com",
+					HTTPSProxy: "https://openshift.com",
+				},
+				Status: configv1.ProxyStatus{
+					HTTPProxy:  "http://openshift.com",
+					HTTPSProxy: "https://openshift.com",
+				},
+			}, expected: configv1.Proxy{
+				Spec: configv1.ProxySpec{
+					HTTPProxy:  "http://openshift.com",
+					HTTPSProxy: "https://openshift.com",
+				},
+				Status: configv1.ProxyStatus{
+					HTTPProxy:  "http://openshift.com",
+					HTTPSProxy: "https://openshift.com",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			elideProxy(&test.input)
+			if !reflect.DeepEqual(test.input.Spec, test.expected.Spec) {
+				t.Errorf("expected %v, got %v", test.expected.Spec, test.input.Spec)
+			}
+			if !reflect.DeepEqual(test.input.Status, test.expected.Status) {
+				t.Errorf("expected %v, got %v", test.expected.Status, test.input.Status)
+			}
+		})
+	}
+}

--- a/pkg/cli/admin/inspect/resource.go
+++ b/pkg/cli/admin/inspect/resource.go
@@ -101,6 +101,12 @@ func InspectResource(info *resource.Info, context *resourceContext, o *InspectOp
 		}
 		return nil
 
+	case configv1.GroupVersion.WithResource("proxies").GroupResource():
+		if err := inspectProxyInfo(info, o); err != nil {
+			return err
+		}
+		return nil
+
 	case admissionregistrationv1.SchemeGroupVersion.WithResource("mutatingwebhookconfigurations").GroupResource():
 		if err := gatherMutatingAdmissionWebhook(context, info, o); err != nil {
 			return err
@@ -141,6 +147,9 @@ func newListAccessor(structuredList interface{}) (listAccessor, error) {
 
 	case *routev1.RouteList:
 		return &routeList{castObj}, nil
+
+	case *configv1.ProxyList:
+		return &proxyList{castObj}, nil
 
 	default:
 		return nil, fmt.Errorf("unhandledStructuredListType: %T", castObj)

--- a/pkg/cli/admin/inspect/route.go
+++ b/pkg/cli/admin/inspect/route.go
@@ -9,6 +9,8 @@ import (
 	"k8s.io/cli-runtime/pkg/resource"
 )
 
+var _ listAccessor = &routeList{}
+
 type routeList struct {
 	*routev1.RouteList
 }

--- a/pkg/cli/admin/inspect/route_test.go
+++ b/pkg/cli/admin/inspect/route_test.go
@@ -1,0 +1,53 @@
+package inspect
+
+import (
+	"reflect"
+	"testing"
+
+	v1 "github.com/openshift/api/route/v1"
+)
+
+func TestElideRoute(t *testing.T) {
+	tests := []struct {
+		input    v1.Route
+		expected v1.Route
+	}{
+		{
+			input: v1.Route{
+				Spec: v1.RouteSpec{
+					TLS: &v1.TLSConfig{
+						Key: "testkey",
+					},
+				},
+			},
+			expected: v1.Route{
+				Spec: v1.RouteSpec{
+					TLS: &v1.TLSConfig{
+						Key: "",
+					},
+				},
+			},
+		},
+		{
+			input: v1.Route{
+				Spec: v1.RouteSpec{
+					TLS: nil,
+				},
+			},
+			expected: v1.Route{
+				Spec: v1.RouteSpec{
+					TLS: nil,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			elideRoute(&test.input)
+			if !reflect.DeepEqual(test.input.Spec, test.expected.Spec) {
+				t.Errorf("expected %v, got %v", test.expected.Spec, test.input.Spec)
+			}
+		})
+	}
+}

--- a/pkg/cli/admin/inspect/secret.go
+++ b/pkg/cli/admin/inspect/secret.go
@@ -10,6 +10,8 @@ import (
 	"k8s.io/cli-runtime/pkg/resource"
 )
 
+var _ listAccessor = &secretList{}
+
 type secretList struct {
 	*corev1.SecretList
 }

--- a/pkg/cli/admin/inspect/secret_test.go
+++ b/pkg/cli/admin/inspect/secret_test.go
@@ -1,0 +1,64 @@
+package inspect
+
+import (
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	secret "k8s.io/api/core/v1"
+)
+
+func TestElideSecret(t *testing.T) {
+	tests := []struct {
+		input    secret.Secret
+		expected secret.Secret
+	}{
+		{
+			input: secret.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"openshift.io/token-secret.value":                  "test",
+						"kubectl.kubernetes.io/last-applied-configuration": "test",
+						"another-annotation":                               "another-annotation",
+					},
+				},
+				Data: map[string][]byte{
+					"tls.crt":        []byte("test"),
+					"ca.crt":         []byte("test"),
+					"service-ca.crt": []byte("test"),
+					"tls.key":        []byte("test"),
+					"another.key":    []byte("test"),
+				},
+			},
+			expected: secret.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"openshift.io/token-secret.value":                  "",
+						"kubectl.kubernetes.io/last-applied-configuration": "",
+						"another-annotation":                               "another-annotation",
+					},
+				},
+				Data: map[string][]byte{
+					"tls.crt":        []byte("test"),
+					"ca.crt":         []byte("test"),
+					"service-ca.crt": []byte("test"),
+					"tls.key":        []byte("4 bytes long"),
+					"another.key":    []byte("4 bytes long"),
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			elideSecret(&test.input)
+			if !reflect.DeepEqual(test.input.Annotations, test.expected.Annotations) {
+				t.Errorf("expected %v, got %v", test.expected.Annotations, test.input.Annotations)
+			}
+			if !reflect.DeepEqual(test.input.Data, test.expected.Data) {
+				t.Errorf("expected %v, got %v", test.expected.Data, test.input.Data)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Proxy resource can contain sensitive information and inspect command should obfuscate all these fields. This PR achieves this.