### PR TITLE
OCPBUGS-45311: fix oc adm node-image create --pxe command to copy the correct artifacts

### DIFF
--- a/pkg/cli/admin/nodeimage/create.go
+++ b/pkg/cli/admin/nodeimage/create.go
@@ -380,8 +380,8 @@ func (o *CreateOptions) copyArtifactsFromNodeJoinerPod() error {
 		RsyncExclude:  []string{"*"},
 	}
 	if o.GeneratePXEFiles {
-		rsyncOptions.RsyncInclude = []string{"boot-artifacts/*"}
-		rsyncOptions.RsyncExclude = []string{}
+		rsyncOptions.Source.Path = "/assets/boot-artifacts/"
+		rsyncOptions.RsyncInclude = []string{"*.img", "*.*vmlinuz", "*.ipxe"}
 		logMessage = "Saving PXE artifacts to %s"
 	}
 	rsyncOptions.Strategy = o.copyStrategy(rsyncOptions)

--- a/pkg/cli/admin/nodeimage/create_test.go
+++ b/pkg/cli/admin/nodeimage/create_test.go
@@ -143,7 +143,7 @@ func TestRun(t *testing.T) {
 		expectedErrorCode    int
 		expectedError        string
 		expectedPod          func(t *testing.T, pod *corev1.Pod)
-		expectedRsyncInclude string
+		expectedRsyncInclude []string
 	}{
 		{
 			name:                 "default",
@@ -151,7 +151,7 @@ func TestRun(t *testing.T) {
 			objects:              defaultClusterVersionObjectFn,
 			assetsDir:            "/my-working-dir",
 			generatePXEFiles:     false,
-			expectedRsyncInclude: "*.iso",
+			expectedRsyncInclude: []string{"*.iso"},
 		},
 		{
 			name:                 "default pxe",
@@ -159,7 +159,7 @@ func TestRun(t *testing.T) {
 			objects:              defaultClusterVersionObjectFn,
 			assetsDir:            "/my-working-dir",
 			generatePXEFiles:     true,
-			expectedRsyncInclude: "boot-artifacts/*",
+			expectedRsyncInclude: []string{"*.img", "*.*vmlinuz", "*.ipxe"},
 		},
 		{
 			name:        "node-joiner tool failure",
@@ -311,9 +311,9 @@ func TestRun(t *testing.T) {
 				}
 			}
 
-			if tc.expectedRsyncInclude != "" {
-				if !slices.Contains(fakeCp.options.RsyncInclude, tc.expectedRsyncInclude) {
-					t.Errorf("expected RSyncOptions to include %v, but doesn't", tc.expectedRsyncInclude)
+			for _, ext := range tc.expectedRsyncInclude {
+				if !slices.Contains(fakeCp.options.RsyncInclude, ext) {
+					t.Errorf("expected RSyncOptions to include %s, but doesn't", ext)
 				}
 			}
 		})


### PR DESCRIPTION
This patch takes care of copying only the required artifacts from the node-joiner pod  when the --pxe command flag is used (instead the copy the whole folder)