### PR TITLE
OCPBUGS-45363: adm node-logs: Also parse logs when encountered with standard html header

### DIFF
--- a/pkg/cli/admin/node/logs.go
+++ b/pkg/cli/admin/node/logs.go
@@ -383,7 +383,9 @@ func outputDirectoryEntriesOrContent(out io.Writer, in io.Reader, prefix []byte)
 
 	// turn href links into lines of output
 	content, _ := buf.Peek(bufferSize)
-	if bytes.HasPrefix(content, []byte("<pre>")) {
+	// Until Go 1.23, kubelet returned with the prefix <pre>, but now
+	// it returns with standard html prefix. We need to support both of them.
+	if bytes.HasPrefix(content, []byte("<pre>")) || bytes.HasPrefix(content, []byte("<!doctype html>")) {
 		reLink := regexp.MustCompile(`href="([^"]+)"`)
 		s := bufio.NewScanner(buf)
 		s.Split(func(data []byte, atEOF bool) (advance int, token []byte, err error) {


### PR DESCRIPTION
@rphillips found that from Go 1.23 and upwards, `FileServer` starts serving the files with extra html headers by this https://github.com/golang/go/commit/e0fc269f77af97f7cf33097d82f92ff7e08a2f06#diff-0661442fffb473f85dc4d4472172edbfb4b9b1837db3ab1a73e838bed3e6ab70L154 commit.

Contrarily, `oc adm node-logs` parses with the assumption that data should have `<pre>` prefix, otherwise it simply prints the plain data. This results in unexpected output and failures in CI. So this PR adds the standard html header into the accepted prefix list to parse the data as html.