### PR TITLE
OCPBUGS-45454: Update to 4.19 and Go 1.23.0

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.22-openshift-4.18
+  tag: rhel-9-release-golang-1.23-openshift-4.19

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/oc
 
-go 1.22.5
+go 1.23.0
 
 require (
 	github.com/AaronO/go-git-http v0.0.0-20161214145340-1d9485b3a98f

--- a/images/cli-artifacts/Dockerfile.rhel
+++ b/images/cli-artifacts/Dockerfile.rhel
@@ -1,16 +1,16 @@
 # This Dockerfile builds an image containing the Mac and Windows version of oc
 # layered on top of the Linux cli image.
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.18 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.23-openshift-4.19 AS builder
 WORKDIR /go/src/github.com/openshift/oc
 COPY . .
 RUN make cross-build --warn-undefined-variables
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 AS builder-rhel-9
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder-rhel-9
 WORKDIR /go/src/github.com/openshift/oc
 COPY . .
 RUN make cross-build --warn-undefined-variables
 
-FROM registry.ci.openshift.org/ocp/4.18:cli
+FROM registry.ci.openshift.org/ocp/4.19:cli
 
 COPY --from=builder-rhel-9 /go/src/github.com/openshift/oc/_output/bin/ /usr/share/openshift/
 

--- a/images/cli/Dockerfile.rhel
+++ b/images/cli/Dockerfile.rhel
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
 WORKDIR /go/src/github.com/openshift/oc
 COPY . .
 RUN make build --warn-undefined-variables
 
-FROM registry.ci.openshift.org/ocp/4.18:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/oc/oc /usr/bin/
 RUN for i in kubectl openshift-deploy openshift-docker-build openshift-sti-build openshift-git-clone openshift-manage-dockerfile openshift-extract-image-content openshift-recycle; do ln -sf /usr/bin/oc /usr/bin/$i; done
 LABEL io.k8s.display-name="OpenShift Client" \

--- a/images/tools/Dockerfile
+++ b/images/tools/Dockerfile
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
 WORKDIR /go/src/github.com/openshift/oc
 COPY . .
 RUN make build --warn-undefined-variables
 
-FROM registry.ci.openshift.org/ocp/4.18:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/oc/oc /usr/bin/
 RUN for i in kubectl openshift-deploy openshift-docker-build openshift-sti-build openshift-git-clone openshift-manage-dockerfile openshift-extract-image-content openshift-recycle; do ln -sf /usr/bin/oc /usr/bin/$i; done
 RUN INSTALL_PKGS="\


### PR DESCRIPTION
This PR is proposed as a replacement of https://github.com/openshift/oc/pull/1935 and the others that will be opened automatically.