### PR TITLE
adm release: simplify safe manifests mappers

### DIFF
--- a/pkg/cli/admin/release/image_mapper_test.go
+++ b/pkg/cli/admin/release/image_mapper_test.go
@@ -202,13 +202,7 @@ func TestNewImageMapper(t *testing.T) {
 			if err != nil {
 				return
 			}
-			out, err := m([]byte(tt.input))
-			if (err != nil) != tt.wantErr {
-				t.Fatal(err)
-			}
-			if err != nil {
-				return
-			}
+			out := m([]byte(tt.input))
 			if string(out) != tt.output {
 				t.Errorf("unexpected output, wanted\n%s\ngot\n%s", tt.output, string(out))
 			}
@@ -250,13 +244,7 @@ func TestNewExactMapper(t *testing.T) {
 			if err != nil {
 				return
 			}
-			out, err := m([]byte(tt.input))
-			if (err != nil) != tt.wantErr {
-				t.Fatal(err)
-			}
-			if err != nil {
-				return
-			}
+			out := m([]byte(tt.input))
 			if string(out) != tt.output {
 				t.Errorf("unexpected output, wanted\n%s\ngot\n%s", tt.output, string(out))
 			}

--- a/pkg/cli/admin/release/new.go
+++ b/pkg/cli/admin/release/new.go
@@ -1392,7 +1392,7 @@ func writePayload(w io.Writer, is *imageapi.ImageStream, cm *CincinnatiMetadata,
 
 	// read each directory, processing the manifests in order and updating the contents into the tar output
 	if err := iterateExtractedManifests(ordered, metadata, func(directory string, contents []os.FileInfo, operator string) error {
-		transform := NopManifestMapper
+		transform := fallible(NopManifestMapper)
 
 		// If there is an image-references file in the directory, we will need to replace image references in the manifests
 		// See: https://github.com/openshift/enhancements/blob/068e863988b58f70b5184e4ef49c0ad1c2913dfb/dev-guide/cluster-version-operator/dev/operators.md?plain=1#L157-L189


### PR DESCRIPTION
Most ManifestMappers never return errors which makes related code unnecessarily complicated: signatures imply there may be errors, but there are none, plus there needs to be more error handling. 

Instead, introduce a `SafeManifestMapper` with simpler signature, and use it internally.

/cc @DavidHurta @hongkailiu @wking 