### PR TITLE
OCPBUGS-19824: release new: replace 0.0.1-snapshot in all manifests

### DIFF
--- a/pkg/cli/admin/release/image_mapper.go
+++ b/pkg/cli/admin/release/image_mapper.go
@@ -234,12 +234,6 @@ func NopManifestMapper(data []byte) []byte {
 	return data
 }
 
-func fallible(mapper SafeManifestMapper) ManifestMapper {
-	return func(data []byte) ([]byte, error) {
-		return mapper(data), nil
-	}
-}
-
 // patternImageFormat attempts to match a docker pull spec by prefix (%s) and capture the
 // prefix and either a tag or digest. It requires leading and trailing whitespace, quotes, or
 // end of file.
@@ -335,6 +329,14 @@ func ComponentReferencesForImageStream(is *imageapi.ImageStream) (func(string) i
 		}
 		return ref
 	}, nil
+}
+
+// NewSimpleVersionsMapper substitutes strings of the form 0.0.1-snapshot with releaseName, and
+// errors out if the manifest contains any other version references.
+//
+// If the input release name is not a semver, a request for `0.0.1-snapshot` will be left unmodified.
+func NewSimpleVersionsMapper(releaseName string) ManifestMapper {
+	return NewComponentVersionsMapper(releaseName, nil, nil)
 }
 
 var componentVersionRe = regexp.MustCompile(`(\W|^)0\.0\.1-snapshot([a-z0-9\-]*)`)

--- a/pkg/cli/admin/release/new.go
+++ b/pkg/cli/admin/release/new.go
@@ -1392,7 +1392,7 @@ func writePayload(w io.Writer, is *imageapi.ImageStream, cm *CincinnatiMetadata,
 
 	// read each directory, processing the manifests in order and updating the contents into the tar output
 	if err := iterateExtractedManifests(ordered, metadata, func(directory string, contents []os.FileInfo, operator string) error {
-		transform := fallible(NopManifestMapper)
+		transform := NewSimpleVersionsMapper(is.Name)
 
 		// If there is an image-references file in the directory, we will need to replace image references in the manifests
 		// See: https://github.com/openshift/enhancements/blob/068e863988b58f70b5184e4ef49c0ad1c2913dfb/dev-guide/cluster-version-operator/dev/operators.md?plain=1#L157-L189


### PR DESCRIPTION
Previously the substitution was performed only on manifests extracted from images that supplied `image-references`. It should be possible to perform the basic version (but not component versions like 0.0.1-snapshot-component or things like pullspecs) substitution on such manifests safely.