### PR TITLE
OCPBUGS-38975: monitor should not exit for temp api disconnect

### DIFF
--- a/pkg/cli/admin/nodeimage/monitor.go
+++ b/pkg/cli/admin/nodeimage/monitor.go
@@ -2,8 +2,10 @@ package nodeimage
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
+	"net/url"
 	"strings"
 	"time"
 
@@ -218,6 +220,11 @@ func (o *MonitorOptions) isMonitoringDone(ctx context.Context) (bool, error) {
 	if err != nil {
 		// at this stage pod should exist, return false to retry if client error
 		if retry.IsHTTPClientError(err) {
+			return false, nil
+		}
+		// api server may become temporarily unavailable, return false to retry
+		var urlErr *url.Error
+		if errors.As(err, &urlErr) {
 			return false, nil
 		}
 		klog.V(2).Infof("pod should exist but is not found: %v", err)


### PR DESCRIPTION
This commit updates the isMonitoringDone function to retry and not exit if the error from reading the node-joiner pod is

Get "https://api.ostest.test.metalkube.org:6443/api/v1/namespaces/openshift-node-joiner-zfbp9/pods/node-joiner-monitor-4lx8l": EOF

This happens if the oc client is temporarily disconnected from the api server. The error returned is type net/url/Error.