### PR TITLE
OTA-1010: release extract: --include works for a minor level update

### DIFF
--- a/pkg/cli/admin/release/extract_tools_test.go
+++ b/pkg/cli/admin/release/extract_tools_test.go
@@ -2,7 +2,22 @@ package release
 
 import (
 	"bytes"
+	"context"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	configv1 "github.com/openshift/api/config/v1"
+	fakeconfigv1client "github.com/openshift/client-go/config/clientset/versioned/fake"
+	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakekubeclient "k8s.io/client-go/kubernetes/fake"
+	appsv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
+	"k8s.io/utils/ptr"
 )
 
 func Test_copyAndReplace(t *testing.T) {
@@ -229,6 +244,206 @@ func Test_copyAndReplace(t *testing.T) {
 			actual := w.String()
 			if actual != tt.expected {
 				t.Fatalf("unexpected response body: %q != %q", actual, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFindClusterIncludeConfig(t *testing.T) {
+	tests := []struct {
+		name           string
+		configv1client configv1client.ConfigV1Interface
+		appsv1client   appsv1client.AppsV1Interface
+		expected       manifestInclusionConfiguration
+		expectedErr    error
+	}{
+		{
+			name: "no known disabled capabilities become enabled",
+			configv1client: fakeconfigv1client.NewClientset(
+				&configv1.ClusterVersion{
+					ObjectMeta: metav1.ObjectMeta{Name: "version"},
+					Spec: configv1.ClusterVersionSpec{
+						Capabilities: &configv1.ClusterVersionCapabilitiesSpec{
+							BaselineCapabilitySet: configv1.ClusterVersionCapabilitySetNone,
+						},
+					},
+					Status: configv1.ClusterVersionStatus{
+						Capabilities: configv1.ClusterVersionCapabilitiesStatus{
+							// no capabilities are enabled
+							KnownCapabilities: configv1.KnownClusterVersionCapabilities,
+						},
+					},
+				},
+				&configv1.FeatureGate{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Spec: configv1.FeatureGateSpec{
+						FeatureGateSelection: configv1.FeatureGateSelection{
+							FeatureSet: configv1.DevPreviewNoUpgrade,
+						},
+					},
+				},
+				&configv1.Infrastructure{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status: configv1.InfrastructureStatus{
+						PlatformStatus: &configv1.PlatformStatus{Type: configv1.AWSPlatformType},
+					},
+				},
+			).ConfigV1(),
+			appsv1client: fakekubeclient.NewClientset(
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster-version-operator", Namespace: "openshift-cluster-version"},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Env: []corev1.EnvVar{{Name: "CLUSTER_PROFILE", Value: "some-profile"}}}},
+							},
+						},
+					},
+				},
+			).AppsV1(),
+			expected: manifestInclusionConfiguration{
+				Platform:           ptr.To[string]("aws"),
+				Profile:            ptr.To[string]("some-profile"),
+				RequiredFeatureSet: ptr.To[string](string(configv1.DevPreviewNoUpgrade)),
+				Capabilities: &configv1.ClusterVersionCapabilitiesStatus{
+					KnownCapabilities: configv1.KnownClusterVersionCapabilities,
+				},
+			},
+		},
+		{
+			// no known capabilities at all, i.e., all capabilities are new
+			name: "all new capabilities become enabled",
+			configv1client: fakeconfigv1client.NewClientset(
+				&configv1.ClusterVersion{
+					ObjectMeta: metav1.ObjectMeta{Name: "version"},
+					Spec: configv1.ClusterVersionSpec{
+						Capabilities: &configv1.ClusterVersionCapabilitiesSpec{
+							BaselineCapabilitySet: configv1.ClusterVersionCapabilitySetNone,
+						},
+					},
+				},
+				&configv1.FeatureGate{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Spec: configv1.FeatureGateSpec{
+						FeatureGateSelection: configv1.FeatureGateSelection{
+							FeatureSet: configv1.DevPreviewNoUpgrade,
+						},
+					},
+				},
+				&configv1.Infrastructure{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status: configv1.InfrastructureStatus{
+						PlatformStatus: &configv1.PlatformStatus{Type: configv1.AWSPlatformType},
+					},
+				},
+			).ConfigV1(),
+			appsv1client: fakekubeclient.NewClientset(
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster-version-operator", Namespace: "openshift-cluster-version"},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Env: []corev1.EnvVar{{Name: "CLUSTER_PROFILE", Value: "some-profile"}}}},
+							},
+						},
+					},
+				},
+			).AppsV1(),
+			expected: manifestInclusionConfiguration{
+				Platform:           ptr.To[string]("aws"),
+				Profile:            ptr.To[string]("some-profile"),
+				RequiredFeatureSet: ptr.To[string](string(configv1.DevPreviewNoUpgrade)),
+				Capabilities: &configv1.ClusterVersionCapabilitiesStatus{
+					EnabledCapabilities: configv1.KnownClusterVersionCapabilities,
+					KnownCapabilities:   configv1.KnownClusterVersionCapabilities,
+				},
+			},
+		},
+		{
+			name: "default baseline capabilities become enabled",
+			configv1client: fakeconfigv1client.NewClientset(
+				&configv1.ClusterVersion{
+					ObjectMeta: metav1.ObjectMeta{Name: "version"},
+				},
+				&configv1.FeatureGate{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Spec: configv1.FeatureGateSpec{
+						FeatureGateSelection: configv1.FeatureGateSelection{
+							FeatureSet: configv1.DevPreviewNoUpgrade,
+						},
+					},
+				},
+				&configv1.Infrastructure{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status: configv1.InfrastructureStatus{
+						PlatformStatus: &configv1.PlatformStatus{Type: configv1.AWSPlatformType},
+					},
+				},
+			).ConfigV1(),
+			appsv1client: fakekubeclient.NewClientset(
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster-version-operator", Namespace: "openshift-cluster-version"},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Env: []corev1.EnvVar{{Name: "CLUSTER_PROFILE", Value: "some-profile"}}}},
+							},
+						},
+					},
+				},
+			).AppsV1(),
+			expected: manifestInclusionConfiguration{
+				Platform:           ptr.To[string]("aws"),
+				Profile:            ptr.To[string]("some-profile"),
+				RequiredFeatureSet: ptr.To[string](string(configv1.DevPreviewNoUpgrade)),
+				Capabilities: &configv1.ClusterVersionCapabilitiesStatus{
+					EnabledCapabilities: configv1.ClusterVersionCapabilitySets[configv1.ClusterVersionCapabilitySetCurrent],
+					KnownCapabilities:   configv1.KnownClusterVersionCapabilities,
+				},
+			},
+		},
+		{
+			name: "err on no cvo deployment",
+			configv1client: fakeconfigv1client.NewClientset(
+				&configv1.ClusterVersion{
+					ObjectMeta: metav1.ObjectMeta{Name: "version"},
+				},
+				&configv1.FeatureGate{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Spec: configv1.FeatureGateSpec{
+						FeatureGateSelection: configv1.FeatureGateSelection{
+							FeatureSet: configv1.DevPreviewNoUpgrade,
+						},
+					},
+				},
+				&configv1.Infrastructure{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status: configv1.InfrastructureStatus{
+						PlatformStatus: &configv1.PlatformStatus{Type: configv1.AWSPlatformType},
+					},
+				},
+			).ConfigV1(),
+			appsv1client: fakekubeclient.NewClientset().AppsV1(),
+			expectedErr:  &errors.StatusError{ErrStatus: metav1.Status{Message: `deployments.apps "cluster-version-operator" not found`}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, actualErr := findClusterIncludeConfig(context.TODO(), tt.configv1client, tt.appsv1client, "x.y.z")
+			if diff := cmp.Diff(tt.expectedErr, actualErr, cmp.Comparer(func(x, y error) bool {
+				if x == nil || y == nil {
+					return x == nil && y == nil
+				}
+				return x.Error() == y.Error()
+			})); diff != "" {
+				t.Errorf("%s: actualErr differs from expected:\n%s", tt.name, diff)
+			}
+			if tt.expectedErr == nil {
+				// Ignore the diff on nil and []v1.ClusterVersionCapability{}
+				// Ignore the order on []configv1.ClusterVersionCapability
+				if diff := cmp.Diff(tt.expected, actual, cmpopts.EquateEmpty(), cmpopts.SortSlices(func(a, b configv1.ClusterVersionCapability) bool { return a < b })); diff != "" {
+					t.Errorf("%s: actual differs from expected:\n%s", tt.name, diff)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
This is still a patch on the `extract` command.
Comparing the the current solution that disables the net-new capabilities by default and enabled a few that handles the 4.13-4.14 upgrade only, the current patch enables the net-new capabilities by default. 
The advantage is that it avoids enumeration of growing releases but the disadvantage is that it might exclude expected manifests.

The ideal solution is to compute the exact set of capabilities after upgrading to the incoming release but it would involve significant changes on the code. We plan to develop some functions in the go-lib that can be shared by oc-cli and cvo.


/cc @wking @petr-muller 

Edit on Feb 14:

If https://github.com/openshift/oc/pull/1958 gets in, we do not need this one any more.