### PR TITLE
OCPBUGS-46361: Mark adm pod-network command as hidden and depcated

### DIFF
--- a/pkg/cli/admin/network/pod_network.go
+++ b/pkg/cli/admin/network/pod_network.go
@@ -27,5 +27,7 @@ func NewCmdPodNetwork(f kcmdutil.Factory, streams genericiooptions.IOStreams) *c
 	cmds.AddCommand(NewCmdJoinProjectsNetwork(f, streams))
 	cmds.AddCommand(NewCmdMakeGlobalProjectsNetwork(f, streams))
 	cmds.AddCommand(NewCmdIsolateProjectsNetwork(f, streams))
+	cmds.Hidden = true
+	cmds.Deprecated = "pod-network command only works on OpenShift SDN which has been deprecated."
 	return cmds
 }


### PR DESCRIPTION
`oc adm pod-network` command only works on OpenShift SDN which has been deprecated long time ago. So still advertising this command in help output is misleading. 

This PR marks this command as hidden, so `oc adm --help` will not print it. Besides, this PR marks this command as deprecated, so there will be a deprecation message during its usage.

```sh
$ ./oc adm pod-network
Command "pod-network" is deprecated, pod-network command only works on OpenShift SDN which has been deprecated.
Manage pod network in the cluster
```

Other than that, users still rely on the functionality of this command will continue using it as is (just an additional deprecation message that should not cause any issues).