### PR TITLE
NO-ISSUE: Remove experimental tag for --report and --pxe

### DIFF
--- a/pkg/cli/admin/nodeimage/create.go
+++ b/pkg/cli/admin/nodeimage/create.go
@@ -161,8 +161,8 @@ func (o *CreateOptions) AddFlags(cmd *cobra.Command) {
 
 	flags.StringVar(&o.AssetsDir, "dir", o.AssetsDir, "The path containing the configuration file, used also to store the generated artifacts.")
 	flags.StringVarP(&o.OutputName, "output-name", "o", "", "The name of the output image.")
-	flags.BoolVarP(&o.GeneratePXEFiles, "pxe", "p", false, "Experimental: Instead of an ISO, create files that can be used for PXE boot")
-	flags.BoolVarP(&o.GenerateReport, "report", "r", false, "Experimental: When set, the report.json is always generated in the asset folder")
+	flags.BoolVarP(&o.GeneratePXEFiles, "pxe", "p", false, "Instead of an ISO, create files that can be used for PXE boot")
+	flags.BoolVarP(&o.GenerateReport, "report", "r", false, "When set, the report.json is always generated in the asset folder")
 
 	flags.StringP(snFlagMacAddress, "m", "", "Single node flag. MAC address used to identify the host to apply the configuration. If specified, the nodes-config.yaml config file will not be used.")
 	usageFmt := "Single node flag. %s. Valid only when `mac-address` is defined."


### PR DESCRIPTION
The experimental tag can be removed before next release. It was added to master for a backport to the release-4.18 branch.