### PR TITLE
NO-ISSUE: admin/upgrade/status/examples/README: Document *-alerts.json

### DIFF
--- a/pkg/cli/admin/upgrade/status/examples/README.md
+++ b/pkg/cli/admin/upgrade/status/examples/README.md
@@ -1,13 +1,14 @@
 # Examples for `oc adm upgrade status`
 
-Each example consists of five inputs and two outputs, matched by a common substring:
-1. `TESTCASE-cv.yaml`(input): ClusterVersion object (created by `oc get clusterversion version -o yaml`)
-2. `TESTCASE-co.yaml`(input): list of ClusterOperators (created by `oc get clusteroperators -o yaml`)
-3.  `TESTCASE-mc.yaml`(input): list of MachineConfigs (created by `oc get machineconfigs -o yaml`)
-4.  `TESTCASE-mcp.yaml`(input): list of MachineConfigPools (created by `oc get machineconfigpools -o yaml`)
-5.  `TESTCASE-node.yaml`(input): list of Nodes (created by `oc get nodes -o yaml`)
-6. `TESTCASE.output`(output): expected output of `oc adm upgrade status`
-7. `TESTCASE.detailed-output`(output): expected output of `oc adm upgrade status --details=all`
+Each example consists of multiple inputs and outputs, matched by a common substring:
+* `TESTCASE-cv.yaml`(input): ClusterVersion object (created by `oc get clusterversion version -o yaml`)
+* `TESTCASE-co.yaml`(input): list of ClusterOperators (created by `oc get clusteroperators -o yaml`)
+* `TESTCASE-mc.yaml`(input): list of MachineConfigs (created by `oc get machineconfigs -o yaml`)
+* `TESTCASE-mcp.yaml`(input): list of MachineConfigPools (created by `oc get machineconfigpools -o yaml`)
+* `TESTCASE-node.yaml`(input): list of Nodes (created by `oc get nodes -o yaml`)
+* `TESTCASE-alerts.json` (optional input): current alerts (created by `OC_ENABLE_CMD_INSPECT_ALERTS=true oc adm inspect-alerts`)
+* `TESTCASE.output`(output): expected output of `oc adm upgrade status`
+* `TESTCASE.detailed-output`(output): expected output of `oc adm upgrade status --details=all`
 
 The `TestExamples` test in `examples_test.go` file above validates all examples. When the testcase
 is executed with a non-empty `UPDATE` environmental variable, it will update the `TESTCASE.out`


### PR DESCRIPTION
Catching the docs up with 10c41f5262 (#1740).

Also drop the enumeration that started when the file was created in 57e984491c (#1595).  Folks who care how many inputs and outputs there currently are can count for themselves, and this content is easier to maintain without having to bump later entry numbers when inserting an earlier entry.