### PR TITLE
[NO-ISSUE] Test case for lowercase Jira ticket names

### DIFF
--- a/pkg/cli/admin/release/bug_test.go
+++ b/pkg/cli/admin/release/bug_test.go
@@ -87,6 +87,11 @@ func TestExtractBugs(t *testing.T) {
 			},
 			msg: "test",
 		},
+		{
+			input: "ocpbugs-17: test",
+			bugs:  RefList{},
+			msg:   "ocpbugs-17: test",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
We had a scenario come up where the release-controller did not take the expected action, on a JIRA ticket, when it was included in a nightly build.  After some digging, it turned out that the commit message contained the ticket id in lowercase.

Jira ticket: https://issues.redhat.com/browse/OCPBUGS-48504
PR: https://github.com/openshift/oc-mirror/pull/1008
First Accepted nightly, post merge: https://amd64.ocp.releases.ci.openshift.org/releasestream/4.18.0-0.nightly/release/4.18.0-0.nightly-2025-01-21-015441

Corresponding Release-controller changelog:
![image](https://github.com/user-attachments/assets/ed4b2fa4-85bc-4ff2-93f2-9d9eb4e79e40)

This PR adds a test case that illustrates the expected behavior if/when a commit message comes in that doesn't match the expected regex [here](https://github.com/openshift/oc/blob/e005223acd7c478bac070134c16f5533a258be12/pkg/cli/admin/release/bug.go#L34-L35)

The result is that there is no associated reference to a valid Bug.