### PR TITLE
OCPBUGS-44637: Mount proxy certificate to node-joiner pod

### DIFF
--- a/pkg/cli/admin/nodeimage/monitor_test.go
+++ b/pkg/cli/admin/nodeimage/monitor_test.go
@@ -84,7 +84,7 @@ func TestMonitorRun(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			fakeReg, fakeClient, fakeRestConfig, fakeRemoteExec := createFakes(t, nodeJoinerMonitorContainer)
+			fakeReg, fakeClient, fakeRestConfig, fakeRemoteExec := createFakes(t, nodeJoinerMonitorContainer, nil)
 			defer fakeReg.Close()
 
 			// Allow the test case to use the right digest created by the fake registry.


### PR DESCRIPTION
When a proxy is configured with a self-signed certificate, the certificate needs to be made available to the node-joiner pod to allow it to communicate with the proxy.

It is assumed that the proxy certificate is configured in the cluster proxy spec as
    
    spec:
      trustedCA:
        name: user-ca-bundle

The certificate is stored in a config map named "user-ca-bundle" in the "openshift-config" namespace in a file named ca-bundle.crt.
    
    apiVersion: v1
    data:
      ca-bundle.crt: |
        -----BEGIN CERTIFICATE-----
        ** redacted **
        -----END CERTIFICATE-----
    kind: ConfigMap
    metadata:
      name: user-ca-bundle
      namespace: openshift-config
    
If the certificate is included in the additionalTrustBundle field in install-config.yaml prior to cluster installation, the proxy and user-ca-bundle is automatically configured as illustrated
above.

Previously, the certificate wasn't mounted to the node-joiner pod so that when the pod attempted to pull images through the proxy, it failed.

Now the user-ca-bundle config map is copied to the node-joiner pod's namespace and the certificate is mounted and made available as /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem.