### PR TITLE
COS-3023: pkg/cli/admin/release/info: support generating RPM diffs

### DIFF
--- a/pkg/cli/admin/release/annotations.go
+++ b/pkg/cli/admin/release/annotations.go
@@ -36,6 +36,8 @@ const (
 	// This LABEL is the git clone location that an image was built with. Copied
 	// unmodified to the image-references file.
 	annotationBuildSourceLocation = "io.openshift.build.source-location"
+	// This LABEL indicates that an image is capped by a metadata layer.
+	annotationMetalayer = "io.openshift.metalayer"
 
 	urlGithubPrefix = "https://github.com/"
 )

--- a/pkg/cli/admin/release/info.go
+++ b/pkg/cli/admin/release/info.go
@@ -869,7 +869,7 @@ func (o *InfoOptions) LoadReleaseInfo(image string, retrieveImages bool) (*Relea
 	}
 
 	if retrieveImages {
-		if err = o.retrieveReleaseImages(release, verifier); err != nil {
+		if err = o.retrieveReleaseImages(release, verifier, nil); err != nil {
 			return nil, err
 		}
 	}
@@ -887,7 +887,7 @@ func (o *InfoOptions) LoadReleaseInfo(image string, retrieveImages bool) (*Relea
 	return release, nil
 }
 
-func (o *InfoOptions) retrieveReleaseImages(release *ReleaseInfo, verifier imagemanifest.Verifier) error {
+func (o *InfoOptions) retrieveReleaseImages(release *ReleaseInfo, verifier imagemanifest.Verifier, onlyTags map[string]struct{}) error {
 	var lock sync.Mutex
 	release.Images = make(map[string]*Image)
 	images := make(map[string]imagesource.TypedImageReference)
@@ -928,6 +928,11 @@ func (o *InfoOptions) retrieveReleaseImages(release *ReleaseInfo, verifier image
 	for _, tag := range release.References.Spec.Tags {
 		if tag.From == nil || tag.From.Kind != "DockerImage" {
 			continue
+		}
+		if onlyTags != nil {
+			if _, ok := onlyTags[tag.Name]; !ok {
+				continue
+			}
 		}
 		ref, err := imagereference.Parse(tag.From.Name)
 		if err != nil {

--- a/pkg/cli/admin/release/info_unix.go
+++ b/pkg/cli/admin/release/info_unix.go
@@ -1,0 +1,24 @@
+//go:build !windows
+// +build !windows
+
+package release
+
+import "syscall"
+
+func flock(fd int, exclusive bool) error {
+	flag := syscall.LOCK_SH
+	if exclusive {
+		flag = syscall.LOCK_EX
+	}
+	if err := syscall.Flock(fd, flag); err != nil {
+		return err
+	}
+	return nil
+}
+
+func funlock(fd int) error {
+	if err := syscall.Flock(fd, syscall.LOCK_UN); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/cli/admin/release/info_windows.go
+++ b/pkg/cli/admin/release/info_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+// +build windows
+
+package release
+
+// There's definitely a Windows-equivalent API here, but this author can't test
+// it easily and also has doubts it will be exercised meaningfully in practice,
+// so decided to defer on this for now.
+
+func flock(fd int, exclusive bool) error {
+	return nil
+}
+
+func funlock(fd int) error {
+	return nil
+}


### PR DESCRIPTION
It's often useful when looking up release images to know the list of RPM packages that shipped in the node image. Add new switches for this:
- `oc adm release info --rpmdb $IMG` will list all the packages in the node image for the given release image payload
- `oc adm release info --rpmdb-diff $IMG1 $IMG2` will diff the set of packages in the node image for the given release image payloads

The code is generic over the actual target image. By default, the node image is used, but `--rpmdb-image` can be used to select a different one.

The primary motivation for this is
https://github.com/openshift/enhancements/pull/1637, in which the node image will no longer be built within the CoreOS pipeline as a base image. Instead, it will be a layered image built in OpenShift CI/Konflux. As a result, all layered packages will not show up in the CoreOS release browser differ.

With this functionality, the release controller will be able to render RPM diffs in the web UI, greatly de-emphasize the CoreOS differ and effectively dropping the requirement for having VPN access.

Some notes on the implementation:
- The rpmdb for a given image is cached, keyed by the image digest.
- We don't try to be smart here and e.g. only download some layers. There are some issues with doing that. We literally do download the full image, _but_ we only cache the rpmdb content and throw away the rest. That said, the high cost isn't an issue in practice because the release controller can nicely represent operations which take time so it didn't feel worth the effort of trying to optimize this further.

Once we have SBOMs available for all our images, this should be a much cheaper way to query its RPM contents. Additionally/alternatively, for the node image specifically, if we ever end up with lockfiles in the git repo, this would effectively mean that the git changelog _is_ the RPM changelog also, meshing nicely with the existing infrastructure around that.