### PR TITLE
OTA-1426: pkg/cli/admin/upgrade: Check and display interesting alerts

### DIFF
--- a/pkg/cli/admin/upgrade/recommend/alerts.go
+++ b/pkg/cli/admin/upgrade/recommend/alerts.go
@@ -97,6 +97,8 @@ func (o *options) alerts(ctx context.Context) ([]metav1.Condition, error) {
 			haveCritical = true
 			if alertName == "PodDisruptionBudgetLimit" {
 				havePodDisruptionBudget = true
+				// ideally the upstream PodDisruptionBudget*Limit alerts templated in the namespace and PDB, but until they do, inject those ourselves
+				details = fmt.Sprintf("Namespace=%s, PodDisruptionBudget=%s. %s", alert.Labels.Namespace, alert.Labels.PodDisruptionBudget, details)
 			}
 			conditions = append(conditions, metav1.Condition{
 				Type:    fmt.Sprintf("recommended/CriticalAlerts/%s/%d", alertName, i),
@@ -110,6 +112,8 @@ func (o *options) alerts(ctx context.Context) ([]metav1.Condition, error) {
 
 		if alertName == "PodDisruptionBudgetAtLimit" {
 			havePodDisruptionBudget = true
+			// ideally the upstream PodDisruptionBudget*Limit alerts templated in the namespace and PDB, but until they do, inject those ourselves
+			details = fmt.Sprintf("Namespace=%s, PodDisruptionBudget=%s. %s", alert.Labels.Namespace, alert.Labels.PodDisruptionBudget, details)
 			conditions = append(conditions, metav1.Condition{
 				Type:    fmt.Sprintf("recommended/PodDisruptionBudgetAlerts/%s/%d", alertName, i),
 				Status:  metav1.ConditionFalse,

--- a/pkg/cli/admin/upgrade/recommend/alerts.go
+++ b/pkg/cli/admin/upgrade/recommend/alerts.go
@@ -1,0 +1,103 @@
+package recommend
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	routev1 "github.com/openshift/api/route/v1"
+	routev1client "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/oc/pkg/cli/admin/inspectalerts"
+	"github.com/openshift/oc/pkg/cli/admin/upgrade/status"
+)
+
+// alerts retrieves the clusters currently firing alerts, and returns
+// Conditions that are True for happy signals, False for sad signals,
+// and Unknown when we do not have enough information to make a
+// happy-or-sad determination.
+func (o *options) alerts(ctx context.Context) ([]metav1.Condition, error) {
+	var alertsBytes []byte
+	if o.mockData.alertsPath != "" {
+		if len(o.mockData.alerts) == 0 {
+			return []metav1.Condition{{
+				Type:    "recommended/Alert",
+				Status:  metav1.ConditionUnknown,
+				Reason:  "NoTestData",
+				Message: fmt.Sprintf("This --mock-clusterversion run did not have alert data available at %v", o.mockData.alertsPath),
+			}}, nil
+		}
+		alertsBytes = o.mockData.alerts
+	} else {
+		client, err := routev1client.NewForConfig(o.RESTConfig)
+		if err != nil {
+			return nil, err
+		}
+		routeGetter := func(ctx context.Context, namespace string, name string, opts metav1.GetOptions) (*routev1.Route, error) {
+			return client.Routes(namespace).Get(ctx, name, opts)
+		}
+
+		alertsBytes, err = inspectalerts.GetAlerts(ctx, routeGetter, o.RESTConfig.BearerToken)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var alertData status.AlertData
+	err := json.Unmarshal(alertsBytes, &alertData)
+	if err != nil {
+		return nil, fmt.Errorf("parsing alerts: %w", err)
+	}
+
+	var conditions []metav1.Condition
+	haveCritical := false
+	havePodDisruptionBudget := false
+	havePullWaiting := false
+	haveNodes := false
+	for _, alert := range alertData.Data.Alerts {
+		var alertName string
+		if alertName = alert.Labels.AlertName; alertName == "" {
+			continue
+		}
+		fmt.Printf("alert: %v\n", alert)
+	}
+
+	if !haveCritical {
+		conditions = append(conditions, metav1.Condition{
+			Type:    "recommended/CriticalAlerts",
+			Status:  metav1.ConditionTrue,
+			Reason:  "AsExpected",
+			Message: "No critical alerts firing.",
+		})
+	}
+
+	if !havePodDisruptionBudget {
+		conditions = append(conditions, metav1.Condition{
+			Type:    "recommended/PodDisruptionBudgetAlerts",
+			Status:  metav1.ConditionTrue,
+			Reason:  "AsExpected",
+			Message: "No PodDisruptionBudget alerts firing.",
+		})
+	}
+
+	if !havePullWaiting {
+		conditions = append(conditions, metav1.Condition{
+			Type:    "recommended/PodImagePullAlerts",
+			Status:  metav1.ConditionTrue,
+			Reason:  "AsExpected",
+			Message: "No Pod container image pull alerts firing.",
+		})
+	}
+
+	if !haveNodes {
+		conditions = append(conditions, metav1.Condition{
+			Type:    "recommended/NodeAlerts",
+			Status:  metav1.ConditionTrue,
+			Reason:  "AsExpected",
+			Message: "No Node alerts firing.",
+		})
+	}
+
+	return conditions, nil
+}

--- a/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-not-recommended.output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-not-recommended.output
@@ -1,3 +1,10 @@
+The following conditions found cause for concern in updating this cluster to later releases: recommended/Alert
+
+recommended/Alert=Unknown:
+
+  Reason: NoTestData
+  Message: This --mock-clusterversion run did not have alert data available at examples/4.12.16-longest-not-recommended-alerts.json
+
 Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: stable-4.13 (available channels: candidate-4.12, candidate-4.13, eus-4.12, eus-4.14, fast-4.12, fast-4.13, stable-4.12, stable-4.13)
 

--- a/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-not-recommended.show-outdated-releases-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-not-recommended.show-outdated-releases-output
@@ -1,3 +1,10 @@
+The following conditions found cause for concern in updating this cluster to later releases: recommended/Alert
+
+recommended/Alert=Unknown:
+
+  Reason: NoTestData
+  Message: This --mock-clusterversion run did not have alert data available at examples/4.12.16-longest-not-recommended-alerts.json
+
 Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: stable-4.13 (available channels: candidate-4.12, candidate-4.13, eus-4.12, eus-4.14, fast-4.12, fast-4.13, stable-4.12, stable-4.13)
 

--- a/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-not-recommended.version-4.12.51-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-not-recommended.version-4.12.51-output
@@ -1,3 +1,10 @@
+The following conditions found cause for concern in updating this cluster to later releases: recommended/Alert
+
+recommended/Alert=Unknown:
+
+  Reason: NoTestData
+  Message: This --mock-clusterversion run did not have alert data available at examples/4.12.16-longest-not-recommended-alerts.json
+
 Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: stable-4.13 (available channels: candidate-4.12, candidate-4.13, eus-4.12, eus-4.14, fast-4.12, fast-4.13, stable-4.12, stable-4.13)
 

--- a/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-recommended.output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-recommended.output
@@ -1,3 +1,10 @@
+The following conditions found cause for concern in updating this cluster to later releases: recommended/Alert
+
+recommended/Alert=Unknown:
+
+  Reason: NoTestData
+  Message: This --mock-clusterversion run did not have alert data available at examples/4.12.16-longest-recommended-alerts.json
+
 Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: stable-4.13 (available channels: candidate-4.12, candidate-4.13, eus-4.12, eus-4.14, fast-4.12, fast-4.13, stable-4.12, stable-4.13)
 

--- a/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-recommended.show-outdated-releases-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-recommended.show-outdated-releases-output
@@ -1,3 +1,10 @@
+The following conditions found cause for concern in updating this cluster to later releases: recommended/Alert
+
+recommended/Alert=Unknown:
+
+  Reason: NoTestData
+  Message: This --mock-clusterversion run did not have alert data available at examples/4.12.16-longest-recommended-alerts.json
+
 Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: stable-4.13 (available channels: candidate-4.12, candidate-4.13, eus-4.12, eus-4.14, fast-4.12, fast-4.13, stable-4.12, stable-4.13)
 

--- a/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-recommended.version-4.12.51-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-recommended.version-4.12.51-output
@@ -1,3 +1,10 @@
+The following conditions found cause for concern in updating this cluster to later releases: recommended/Alert
+
+recommended/Alert=Unknown:
+
+  Reason: NoTestData
+  Message: This --mock-clusterversion run did not have alert data available at examples/4.12.16-longest-recommended-alerts.json
+
 Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: stable-4.13 (available channels: candidate-4.12, candidate-4.13, eus-4.12, eus-4.14, fast-4.12, fast-4.13, stable-4.12, stable-4.13)
 

--- a/pkg/cli/admin/upgrade/recommend/examples/4.14.1-all-recommended.output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.14.1-all-recommended.output
@@ -1,6 +1,13 @@
 info: An update is in progress.  You may wish to let this update complete before requesting a new update.
   Working towards 4.14.1: 139 of 859 done (16% complete), waiting on kube-scheduler
 
+The following conditions found cause for concern in updating this cluster to later releases: recommended/Alert
+
+recommended/Alert=Unknown:
+
+  Reason: NoTestData
+  Message: This --mock-clusterversion run did not have alert data available at examples/4.14.1-all-recommended-alerts.json
+
 Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: candidate-4.14 (available channels: candidate-4.14, candidate-4.15, eus-4.14, fast-4.14, stable-4.14)
 

--- a/pkg/cli/admin/upgrade/recommend/examples/4.14.1-all-recommended.output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.14.1-all-recommended.output
@@ -1,5 +1,6 @@
 info: An update is in progress.  You may wish to let this update complete before requesting a new update.
   Working towards 4.14.1: 139 of 859 done (16% complete), waiting on kube-scheduler
+
 Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: candidate-4.14 (available channels: candidate-4.14, candidate-4.15, eus-4.14, fast-4.14, stable-4.14)
 

--- a/pkg/cli/admin/upgrade/recommend/examples/4.14.1-all-recommended.show-outdated-releases-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.14.1-all-recommended.show-outdated-releases-output
@@ -1,6 +1,13 @@
 info: An update is in progress.  You may wish to let this update complete before requesting a new update.
   Working towards 4.14.1: 139 of 859 done (16% complete), waiting on kube-scheduler
 
+The following conditions found cause for concern in updating this cluster to later releases: recommended/Alert
+
+recommended/Alert=Unknown:
+
+  Reason: NoTestData
+  Message: This --mock-clusterversion run did not have alert data available at examples/4.14.1-all-recommended-alerts.json
+
 Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: candidate-4.14 (available channels: candidate-4.14, candidate-4.15, eus-4.14, fast-4.14, stable-4.14)
 

--- a/pkg/cli/admin/upgrade/recommend/examples/4.14.1-all-recommended.show-outdated-releases-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.14.1-all-recommended.show-outdated-releases-output
@@ -1,5 +1,6 @@
 info: An update is in progress.  You may wish to let this update complete before requesting a new update.
   Working towards 4.14.1: 139 of 859 done (16% complete), waiting on kube-scheduler
+
 Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: candidate-4.14 (available channels: candidate-4.14, candidate-4.15, eus-4.14, fast-4.14, stable-4.14)
 

--- a/pkg/cli/admin/upgrade/recommend/examples/4.14.1-all-recommended.version-4.12.51-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.14.1-all-recommended.version-4.12.51-output
@@ -1,6 +1,13 @@
 info: An update is in progress.  You may wish to let this update complete before requesting a new update.
   Working towards 4.14.1: 139 of 859 done (16% complete), waiting on kube-scheduler
 
+The following conditions found cause for concern in updating this cluster to later releases: recommended/Alert
+
+recommended/Alert=Unknown:
+
+  Reason: NoTestData
+  Message: This --mock-clusterversion run did not have alert data available at examples/4.14.1-all-recommended-alerts.json
+
 Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: candidate-4.14 (available channels: candidate-4.14, candidate-4.15, eus-4.14, fast-4.14, stable-4.14)
 

--- a/pkg/cli/admin/upgrade/recommend/examples/4.14.1-all-recommended.version-4.12.51-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.14.1-all-recommended.version-4.12.51-output
@@ -1,5 +1,6 @@
 info: An update is in progress.  You may wish to let this update complete before requesting a new update.
   Working towards 4.14.1: 139 of 859 done (16% complete), waiting on kube-scheduler
+
 Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: candidate-4.14 (available channels: candidate-4.14, candidate-4.15, eus-4.14, fast-4.14, stable-4.14)
 

--- a/pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring-alerts.json
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring-alerts.json
@@ -1,0 +1,270 @@
+{
+  "status": "success",
+  "data": {
+    "alerts": [
+      {
+        "labels": {
+          "alertname": "ClusterNotUpgradeable",
+          "condition": "Upgradeable",
+          "endpoint": "metrics",
+          "name": "version",
+          "namespace": "openshift-cluster-version",
+          "severity": "info"
+        },
+        "annotations": {
+          "description": "In most cases, you will still be able to apply patch releases. Reason PoolUpdating. For more information refer to 'oc adm upgrade' or https://console-openshift-console.apps.ci-ln-4xlhr32-72292.origin-ci-int-gce.dev.rhcloud.com/settings/cluster/.",
+          "summary": "One or more cluster operators have been blocking minor version cluster upgrades for at least an hour."
+        },
+        "state": "firing",
+        "activeAt": "2025-01-28T23:00:54.844366438Z",
+        "value": "0e+00",
+        "partialResponseStrategy": "WARN"
+      },
+      {
+        "labels": {
+          "alertname": "ClusterOperatorDegraded",
+          "name": "monitoring",
+          "namespace": "openshift-cluster-version",
+          "severity": "warning"
+        },
+        "annotations": {
+          "description": "The monitoring operator is degraded because , and the components it manages may have reduced quality of service.  Cluster upgrades may not complete. For more information refer to 'oc get -o yaml clusteroperator monitoring' or https://console-openshift-console.apps.ci-ln-4xlhr32-72292.origin-ci-int-gce.dev.rhcloud.com/settings/cluster/.",
+          "runbook_url": "https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/ClusterOperatorDegraded.md",
+          "summary": "Cluster operator has been degraded for 30 minutes."
+        },
+        "state": "firing",
+        "activeAt": "2025-01-28T23:16:24.844366438Z",
+        "value": "1e+00",
+        "partialResponseStrategy": "WARN"
+      },
+      {
+        "labels": {
+          "alertname": "ClusterOperatorDegraded",
+          "name": "version",
+          "namespace": "openshift-cluster-version",
+          "reason": "ClusterOperatorNotAvailable",
+          "severity": "warning"
+        },
+        "annotations": {
+          "description": "The version operator is degraded because ClusterOperatorNotAvailable, and the components it manages may have reduced quality of service.  Cluster upgrades may not complete. For more information refer to 'oc adm upgrade' or https://console-openshift-console.apps.ci-ln-4xlhr32-72292.origin-ci-int-gce.dev.rhcloud.com/settings/cluster/.",
+          "runbook_url": "https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/ClusterOperatorDegraded.md",
+          "summary": "Cluster operator has been degraded for 30 minutes."
+        },
+        "state": "firing",
+        "activeAt": "2025-01-28T23:17:54.844366438Z",
+        "value": "1e+00",
+        "partialResponseStrategy": "WARN"
+      },
+      {
+        "labels": {
+          "alertname": "ClusterOperatorDown",
+          "name": "monitoring",
+          "namespace": "openshift-cluster-version",
+          "reason": "UpdatingPrometheusFailed",
+          "severity": "critical"
+        },
+        "annotations": {
+          "description": "The monitoring operator may be down or disabled because UpdatingPrometheusFailed, and the components it manages may be unavailable or degraded.  Cluster upgrades may not complete. For more information refer to 'oc get -o yaml clusteroperator monitoring' or https://console-openshift-console.apps.ci-ln-4xlhr32-72292.origin-ci-int-gce.dev.rhcloud.com/settings/cluster/.",
+          "runbook_url": "https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/ClusterOperatorDown.md",
+          "summary": "Cluster operator has not been available for 10 minutes."
+        },
+        "state": "firing",
+        "activeAt": "2025-01-28T23:16:24.844366438Z",
+        "value": "0e+00",
+        "partialResponseStrategy": "WARN"
+      },
+      {
+        "labels": {
+          "alertname": "UpdateAvailable",
+          "channel": "candidate-4.16",
+          "namespace": "openshift-cluster-version",
+          "severity": "info",
+          "upstream": "https://api.integration.openshift.com/api/upgrades_info/graph"
+        },
+        "annotations": {
+          "description": "For more information refer to 'oc adm upgrade' or https://console-openshift-console.apps.ci-ln-4xlhr32-72292.origin-ci-int-gce.dev.rhcloud.com/settings/cluster/.",
+          "summary": "Your upstream update recommendation service recommends you update your cluster."
+        },
+        "state": "firing",
+        "activeAt": "2025-01-28T22:23:02.808943997Z",
+        "value": "4e+00",
+        "partialResponseStrategy": "WARN"
+      },
+      {
+        "labels": {
+          "alertname": "InsightsRecommendationActive",
+          "container": "insights-operator",
+          "description": "MachineConfigPool will never finish updating when the 'unavailableMachineCount' is greater than 'maxUnavailable' in the MachineConfigPool",
+          "endpoint": "https",
+          "info_link": "https://console.redhat.com/openshift/insights/advisor/clusters/bb39d7b1-588e-4cd6-bc8e-b8f2f8509321?first=ccx_rules_ocp.external.rules.mcp_unavailable_machine_count%7CERROR_MCP_UNAVAILABLEMACHINECOUNT",
+          "instance": "10.128.0.23:8443",
+          "job": "metrics",
+          "namespace": "openshift-insights",
+          "pod": "insights-operator-56ddd7744b-fbwrm",
+          "service": "metrics",
+          "severity": "info",
+          "total_risk": "Moderate"
+        },
+        "annotations": {
+          "description": "Insights recommendation \"MachineConfigPool will never finish updating when the 'unavailableMachineCount' is greater than 'maxUnavailable' in the MachineConfigPool\" with total risk \"Moderate\" was detected on the cluster. More information is available at https://console.redhat.com/openshift/insights/advisor/clusters/bb39d7b1-588e-4cd6-bc8e-b8f2f8509321?first=ccx_rules_ocp.external.rules.mcp_unavailable_machine_count%7CERROR_MCP_UNAVAILABLEMACHINECOUNT.",
+          "summary": "An Insights recommendation is active for this cluster."
+        },
+        "state": "firing",
+        "activeAt": "2025-01-29T00:37:28.265768529Z",
+        "value": "1e+00",
+        "partialResponseStrategy": "WARN"
+      },
+      {
+        "labels": {
+          "alertname": "PodDisruptionBudgetAtLimit",
+          "namespace": "openshift-monitoring",
+          "poddisruptionbudget": "prometheus-k8s",
+          "severity": "warning"
+        },
+        "annotations": {
+          "description": "The pod disruption budget is at the minimum disruptions allowed level. The number of current healthy pods is equal to the desired healthy pods.",
+          "runbook_url": "https://github.com/openshift/runbooks/blob/master/alerts/cluster-kube-controller-manager-operator/PodDisruptionBudgetAtLimit.md",
+          "summary": "The pod disruption budget is preventing further disruption to pods."
+        },
+        "state": "firing",
+        "activeAt": "2025-01-28T23:00:23.82540834Z",
+        "value": "1e+00",
+        "partialResponseStrategy": "WARN"
+      },
+      {
+        "labels": {
+          "alertname": "Watchdog",
+          "namespace": "openshift-monitoring",
+          "severity": "none"
+        },
+        "annotations": {
+          "description": "This is an alert meant to ensure that the entire alerting pipeline is functional.\nThis alert is always firing, therefore it should always be firing in Alertmanager\nand always fire against a receiver. There are integrations with various notification\nmechanisms that send a notification when this alert is not firing. For example the\n\"DeadMansSnitch\" integration in PagerDuty.\n",
+          "summary": "An alert that should always be firing to certify that Alertmanager is working properly."
+        },
+        "state": "firing",
+        "activeAt": "2025-01-28T22:23:13.047963988Z",
+        "value": "1e+00",
+        "partialResponseStrategy": "WARN"
+      },
+      {
+        "labels": {
+          "alertname": "AlertmanagerReceiversNotConfigured",
+          "namespace": "openshift-monitoring",
+          "severity": "warning"
+        },
+        "annotations": {
+          "description": "Alerts are not configured to be sent to a notification system, meaning that you may not be notified in a timely fashion when important failures occur. Check the OpenShift documentation to learn how to configure notifications with Alertmanager.",
+          "summary": "Receivers (notification integrations) are not configured on Alertmanager"
+        },
+        "state": "firing",
+        "activeAt": "2025-01-28T22:23:02.529246298Z",
+        "value": "0e+00",
+        "partialResponseStrategy": "WARN"
+      },
+      {
+        "labels": {
+          "alertname": "ClusterMonitoringOperatorReconciliationErrors",
+          "container": "cluster-monitoring-operator",
+          "endpoint": "https",
+          "instance": "10.128.0.25:8443",
+          "job": "cluster-monitoring-operator",
+          "namespace": "openshift-monitoring",
+          "pod": "cluster-monitoring-operator-78dd644bb4-hkhln",
+          "service": "cluster-monitoring-operator",
+          "severity": "warning"
+        },
+        "annotations": {
+          "description": "Errors are occurring during reconciliation cycles. Inspect the cluster-monitoring-operator log for potential root causes.",
+          "summary": "Cluster Monitoring Operator is experiencing unexpected reconciliation errors."
+        },
+        "state": "firing",
+        "activeAt": "2025-01-28T23:11:02.529246298Z",
+        "value": "0e+00",
+        "partialResponseStrategy": "WARN"
+      },
+      {
+        "labels": {
+          "alertname": "KubePodNotScheduled",
+          "container": "kube-rbac-proxy-main",
+          "endpoint": "https-main",
+          "job": "kube-state-metrics",
+          "namespace": "openshift-operator-lifecycle-manager",
+          "pod": "collect-profiles-28968525-bqxg9",
+          "service": "kube-state-metrics",
+          "severity": "warning",
+          "uid": "231f8f39-ba85-41fb-9fba-eaa61f0eb6db"
+        },
+        "annotations": {
+          "description": "Pod openshift-operator-lifecycle-manager/collect-profiles-28968525-bqxg9 cannot be scheduled for more than 30 minutes.\nCheck the details of the pod with the following command:\noc describe -n openshift-operator-lifecycle-manager pod collect-profiles-28968525-bqxg9",
+          "summary": "Pod cannot be scheduled."
+        },
+        "state": "pending",
+        "activeAt": "2025-01-29T00:46:02.529246298Z",
+        "value": "1e+00",
+        "partialResponseStrategy": "WARN"
+      },
+      {
+        "labels": {
+          "alertname": "KubePodNotScheduled",
+          "container": "kube-rbac-proxy-main",
+          "endpoint": "https-main",
+          "job": "kube-state-metrics",
+          "namespace": "openshift-image-registry",
+          "pod": "image-pruner-28968480-vdfbf",
+          "service": "kube-state-metrics",
+          "severity": "warning",
+          "uid": "168e2f86-478a-44a7-bfe6-5f575a984217"
+        },
+        "annotations": {
+          "description": "Pod openshift-image-registry/image-pruner-28968480-vdfbf cannot be scheduled for more than 30 minutes.\nCheck the details of the pod with the following command:\noc describe -n openshift-image-registry pod image-pruner-28968480-vdfbf",
+          "summary": "Pod cannot be scheduled."
+        },
+        "state": "firing",
+        "activeAt": "2025-01-29T00:01:02.529246298Z",
+        "value": "1e+00",
+        "partialResponseStrategy": "WARN"
+      },
+      {
+        "labels": {
+          "alertname": "KubePodNotScheduled",
+          "container": "kube-rbac-proxy-main",
+          "endpoint": "https-main",
+          "job": "kube-state-metrics",
+          "namespace": "openshift-monitoring",
+          "pod": "prometheus-k8s-0",
+          "service": "kube-state-metrics",
+          "severity": "warning",
+          "uid": "e31b2560-9c9b-4be5-853a-75757b45d3e2"
+        },
+        "annotations": {
+          "description": "Pod openshift-monitoring/prometheus-k8s-0 cannot be scheduled for more than 30 minutes.\nCheck the details of the pod with the following command:\noc describe -n openshift-monitoring pod prometheus-k8s-0",
+          "summary": "Pod cannot be scheduled."
+        },
+        "state": "firing",
+        "activeAt": "2025-01-28T23:00:02.529246298Z",
+        "value": "1e+00",
+        "partialResponseStrategy": "WARN"
+      },
+      {
+        "labels": {
+          "alertname": "KubeStatefulSetReplicasMismatch",
+          "container": "kube-rbac-proxy-main",
+          "endpoint": "https-main",
+          "job": "kube-state-metrics",
+          "namespace": "openshift-monitoring",
+          "service": "kube-state-metrics",
+          "severity": "warning",
+          "statefulset": "prometheus-k8s"
+        },
+        "annotations": {
+          "description": "StatefulSet openshift-monitoring/prometheus-k8s has not matched the expected number of replicas for longer than 15 minutes.",
+          "summary": "StatefulSet has not matched the expected number of replicas."
+        },
+        "state": "firing",
+        "activeAt": "2025-01-28T23:00:06.08339311Z",
+        "value": "1e+00",
+        "partialResponseStrategy": "WARN"
+      }
+    ]
+  }
+}

--- a/pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring-cv.yaml
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring-cv.yaml
@@ -1,0 +1,151 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+metadata:
+  creationTimestamp: "2025-01-28T22:03:56Z"
+  generation: 2
+  name: version
+  resourceVersion: "43835"
+  uid: 492c0a24-2d2f-48af-93d9-6520a4c852a7
+spec:
+  channel: candidate-4.16
+  clusterID: bb39d7b1-588e-4cd6-bc8e-b8f2f8509321
+  upstream: https://api.integration.openshift.com/api/upgrades_info/graph
+status:
+  availableUpdates:
+  - channels:
+    - candidate-4.16
+    - candidate-4.17
+    - candidate-4.18
+    image: quay.io/openshift-release-dev/ocp-release@sha256:0e71cb61694473b40e8d95f530eaf250a62616debb98199f31b4034808687dae
+    url: https://access.redhat.com/errata/RHSA-2025:0650
+    version: 4.16.32
+  - channels:
+    - candidate-4.16
+    - candidate-4.17
+    - candidate-4.18
+    - eus-4.16
+    - fast-4.16
+    - fast-4.17
+    - stable-4.16
+    - stable-4.17
+    image: quay.io/openshift-release-dev/ocp-release@sha256:7aacace57ab6ec468dd98b0b3e0f3fc440b29afce21b90bd716fed0db487e9e9
+    url: https://access.redhat.com/errata/RHSA-2025:0140
+    version: 4.16.30
+  - channels:
+    - candidate-4.16
+    - candidate-4.17
+    - candidate-4.18
+    - eus-4.16
+    - fast-4.16
+    - fast-4.17
+    - stable-4.16
+    - stable-4.17
+    image: quay.io/openshift-release-dev/ocp-release@sha256:8e858891fc917f250351ba434f64fce6ec5666232a164310053097c570cba002
+    url: https://access.redhat.com/errata/RHBA-2025:0018
+    version: 4.16.29
+  - channels:
+    - candidate-4.16
+    - candidate-4.17
+    - candidate-4.18
+    - eus-4.16
+    - fast-4.16
+    - fast-4.17
+    - stable-4.16
+    - stable-4.17
+    image: quay.io/openshift-release-dev/ocp-release@sha256:7708f832ae02919f2cdb2798fdbc64e17ce7a576d1e3baabdd78a000d2d62f40
+    url: https://access.redhat.com/errata/RHBA-2024:11502
+    version: 4.16.28
+  capabilities:
+    enabledCapabilities:
+    - Build
+    - CSISnapshot
+    - CloudControllerManager
+    - CloudCredential
+    - Console
+    - DeploymentConfig
+    - ImageRegistry
+    - Ingress
+    - Insights
+    - MachineAPI
+    - NodeTuning
+    - OperatorLifecycleManager
+    - Storage
+    - baremetal
+    - marketplace
+    - openshift-samples
+    knownCapabilities:
+    - Build
+    - CSISnapshot
+    - CloudControllerManager
+    - CloudCredential
+    - Console
+    - DeploymentConfig
+    - ImageRegistry
+    - Ingress
+    - Insights
+    - MachineAPI
+    - NodeTuning
+    - OperatorLifecycleManager
+    - Storage
+    - baremetal
+    - marketplace
+    - openshift-samples
+  conditions:
+  - lastTransitionTime: "2025-01-28T22:04:43Z"
+    status: "True"
+    type: RetrievedUpdates
+  - lastTransitionTime: "2025-01-28T22:04:43Z"
+    message: Capabilities match configured spec
+    reason: AsExpected
+    status: "False"
+    type: ImplicitlyEnabledCapabilities
+  - lastTransitionTime: "2025-01-28T22:04:43Z"
+    message: Payload loaded version="4.16.27" image="registry.build02.ci.openshift.org/ci-ln-4xlhr32/release@sha256:efc3a4f3db634bc6733dcad71cd57040da05c5f203df9447fa7f7a1a9067fa39"
+      architecture="amd64"
+    reason: PayloadLoaded
+    status: "True"
+    type: ReleaseAccepted
+  - lastTransitionTime: "2025-01-28T22:28:59Z"
+    message: Done applying 4.16.27
+    status: "True"
+    type: Available
+  - lastTransitionTime: "2025-01-28T23:17:29Z"
+    message: Cluster operator monitoring is not available
+    reason: ClusterOperatorNotAvailable
+    status: "True"
+    type: Failing
+  - lastTransitionTime: "2025-01-28T22:28:59Z"
+    message: 'Error while reconciling 4.16.27: the cluster operator monitoring is
+      not available'
+    reason: ClusterOperatorNotAvailable
+    status: "False"
+    type: Progressing
+  - lastTransitionTime: "2025-01-28T23:00:40Z"
+    message: 'Cluster operator machine-config should not be upgraded between minor
+      versions: One or more machine config pools are updating, please see `oc get
+      mcp` for further details'
+    reason: PoolUpdating
+    status: "False"
+    type: Upgradeable
+  desired:
+    channels:
+    - candidate-4.16
+    - candidate-4.17
+    - candidate-4.18
+    - eus-4.16
+    - fast-4.16
+    - fast-4.17
+    - stable-4.16
+    - stable-4.17
+    image: registry.build02.ci.openshift.org/ci-ln-4xlhr32/release@sha256:efc3a4f3db634bc6733dcad71cd57040da05c5f203df9447fa7f7a1a9067fa39
+    url: https://access.redhat.com/errata/RHBA-2024:10973
+    version: 4.16.27
+  history:
+  - completionTime: "2025-01-28T22:28:59Z"
+    image: registry.build02.ci.openshift.org/ci-ln-4xlhr32/release@sha256:efc3a4f3db634bc6733dcad71cd57040da05c5f203df9447fa7f7a1a9067fa39
+    startedTime: "2025-01-28T22:04:43Z"
+    state: Completed
+    verified: false
+    version: 4.16.27
+  observedGeneration: 2
+  versionHash: O3k_U_qyZ_Q=

--- a/pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring.output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring.output
@@ -3,6 +3,8 @@ Failing=True:
   Reason: ClusterOperatorNotAvailable
   Message: Cluster operator monitoring is not available
 
+The following conditions found no cause for concern in updating this cluster to later releases: recommended/CriticalAlerts (AsExpected), recommended/NodeAlerts (AsExpected), recommended/PodDisruptionBudgetAlerts (AsExpected), recommended/PodImagePullAlerts (AsExpected)
+
 Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: candidate-4.16 (available channels: candidate-4.16, candidate-4.17, candidate-4.18, eus-4.16, fast-4.16, fast-4.17, stable-4.16, stable-4.17)
 

--- a/pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring.output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring.output
@@ -1,0 +1,13 @@
+Failing=True:
+
+  Reason: ClusterOperatorNotAvailable
+  Message: Cluster operator monitoring is not available
+
+Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
+Channel: candidate-4.16 (available channels: candidate-4.16, candidate-4.17, candidate-4.18, eus-4.16, fast-4.16, fast-4.17, stable-4.16, stable-4.17)
+
+Updates to 4.16:
+  VERSION     ISSUES
+  4.16.32     no known issues relevant to this cluster
+  4.16.30     no known issues relevant to this cluster
+And 2 older 4.16 updates you can see with '--show-outdated-releases' or '--version VERSION'.

--- a/pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring.output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring.output
@@ -3,7 +3,19 @@ Failing=True:
   Reason: ClusterOperatorNotAvailable
   Message: Cluster operator monitoring is not available
 
-The following conditions found no cause for concern in updating this cluster to later releases: recommended/CriticalAlerts (AsExpected), recommended/NodeAlerts (AsExpected), recommended/PodDisruptionBudgetAlerts (AsExpected), recommended/PodImagePullAlerts (AsExpected)
+The following conditions found no cause for concern in updating this cluster to later releases: recommended/NodeAlerts (AsExpected), recommended/PodImagePullAlerts (AsExpected)
+
+The following conditions found cause for concern in updating this cluster to later releases: recommended/CriticalAlerts/ClusterOperatorDown/0, recommended/PodDisruptionBudgetAlerts/PodDisruptionBudgetAtLimit/1
+
+recommended/CriticalAlerts/ClusterOperatorDown/0=False:
+
+  Reason: Alert:firing
+  Message: critical alert ClusterOperatorDown firing, suggesting significant cluster issues worth investigating. Cluster operator has not been available for 10 minutes. The alert description is: The monitoring operator may be down or disabled because UpdatingPrometheusFailed, and the components it manages may be unavailable or degraded.  Cluster upgrades may not complete. For more information refer to 'oc get -o yaml clusteroperator monitoring' or https://console-openshift-console.apps.ci-ln-4xlhr32-72292.origin-ci-int-gce.dev.rhcloud.com/settings/cluster/. https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/ClusterOperatorDown.md
+
+recommended/PodDisruptionBudgetAlerts/PodDisruptionBudgetAtLimit/1=False:
+
+  Reason: Alert:firing
+  Message: warning alert PodDisruptionBudgetAtLimit firing, which might slow node drains. The pod disruption budget is preventing further disruption to pods. The alert description is: The pod disruption budget is at the minimum disruptions allowed level. The number of current healthy pods is equal to the desired healthy pods. https://github.com/openshift/runbooks/blob/master/alerts/cluster-kube-controller-manager-operator/PodDisruptionBudgetAtLimit.md
 
 Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: candidate-4.16 (available channels: candidate-4.16, candidate-4.17, candidate-4.18, eus-4.16, fast-4.16, fast-4.17, stable-4.16, stable-4.17)

--- a/pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring.output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring.output
@@ -15,7 +15,7 @@ recommended/CriticalAlerts/ClusterOperatorDown/0=False:
 recommended/PodDisruptionBudgetAlerts/PodDisruptionBudgetAtLimit/1=False:
 
   Reason: Alert:firing
-  Message: warning alert PodDisruptionBudgetAtLimit firing, which might slow node drains. The pod disruption budget is preventing further disruption to pods. The alert description is: The pod disruption budget is at the minimum disruptions allowed level. The number of current healthy pods is equal to the desired healthy pods. https://github.com/openshift/runbooks/blob/master/alerts/cluster-kube-controller-manager-operator/PodDisruptionBudgetAtLimit.md
+  Message: warning alert PodDisruptionBudgetAtLimit firing, which might slow node drains. Namespace=openshift-monitoring, PodDisruptionBudget=prometheus-k8s. The pod disruption budget is preventing further disruption to pods. The alert description is: The pod disruption budget is at the minimum disruptions allowed level. The number of current healthy pods is equal to the desired healthy pods. https://github.com/openshift/runbooks/blob/master/alerts/cluster-kube-controller-manager-operator/PodDisruptionBudgetAtLimit.md
 
 Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: candidate-4.16 (available channels: candidate-4.16, candidate-4.17, candidate-4.18, eus-4.16, fast-4.16, fast-4.17, stable-4.16, stable-4.17)

--- a/pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring.show-outdated-releases-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring.show-outdated-releases-output
@@ -3,6 +3,8 @@ Failing=True:
   Reason: ClusterOperatorNotAvailable
   Message: Cluster operator monitoring is not available
 
+The following conditions found no cause for concern in updating this cluster to later releases: recommended/CriticalAlerts (AsExpected), recommended/NodeAlerts (AsExpected), recommended/PodDisruptionBudgetAlerts (AsExpected), recommended/PodImagePullAlerts (AsExpected)
+
 Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: candidate-4.16 (available channels: candidate-4.16, candidate-4.17, candidate-4.18, eus-4.16, fast-4.16, fast-4.17, stable-4.16, stable-4.17)
 

--- a/pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring.show-outdated-releases-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring.show-outdated-releases-output
@@ -3,7 +3,19 @@ Failing=True:
   Reason: ClusterOperatorNotAvailable
   Message: Cluster operator monitoring is not available
 
-The following conditions found no cause for concern in updating this cluster to later releases: recommended/CriticalAlerts (AsExpected), recommended/NodeAlerts (AsExpected), recommended/PodDisruptionBudgetAlerts (AsExpected), recommended/PodImagePullAlerts (AsExpected)
+The following conditions found no cause for concern in updating this cluster to later releases: recommended/NodeAlerts (AsExpected), recommended/PodImagePullAlerts (AsExpected)
+
+The following conditions found cause for concern in updating this cluster to later releases: recommended/CriticalAlerts/ClusterOperatorDown/0, recommended/PodDisruptionBudgetAlerts/PodDisruptionBudgetAtLimit/1
+
+recommended/CriticalAlerts/ClusterOperatorDown/0=False:
+
+  Reason: Alert:firing
+  Message: critical alert ClusterOperatorDown firing, suggesting significant cluster issues worth investigating. Cluster operator has not been available for 10 minutes. The alert description is: The monitoring operator may be down or disabled because UpdatingPrometheusFailed, and the components it manages may be unavailable or degraded.  Cluster upgrades may not complete. For more information refer to 'oc get -o yaml clusteroperator monitoring' or https://console-openshift-console.apps.ci-ln-4xlhr32-72292.origin-ci-int-gce.dev.rhcloud.com/settings/cluster/. https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/ClusterOperatorDown.md
+
+recommended/PodDisruptionBudgetAlerts/PodDisruptionBudgetAtLimit/1=False:
+
+  Reason: Alert:firing
+  Message: warning alert PodDisruptionBudgetAtLimit firing, which might slow node drains. The pod disruption budget is preventing further disruption to pods. The alert description is: The pod disruption budget is at the minimum disruptions allowed level. The number of current healthy pods is equal to the desired healthy pods. https://github.com/openshift/runbooks/blob/master/alerts/cluster-kube-controller-manager-operator/PodDisruptionBudgetAtLimit.md
 
 Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: candidate-4.16 (available channels: candidate-4.16, candidate-4.17, candidate-4.18, eus-4.16, fast-4.16, fast-4.17, stable-4.16, stable-4.17)

--- a/pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring.show-outdated-releases-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring.show-outdated-releases-output
@@ -15,7 +15,7 @@ recommended/CriticalAlerts/ClusterOperatorDown/0=False:
 recommended/PodDisruptionBudgetAlerts/PodDisruptionBudgetAtLimit/1=False:
 
   Reason: Alert:firing
-  Message: warning alert PodDisruptionBudgetAtLimit firing, which might slow node drains. The pod disruption budget is preventing further disruption to pods. The alert description is: The pod disruption budget is at the minimum disruptions allowed level. The number of current healthy pods is equal to the desired healthy pods. https://github.com/openshift/runbooks/blob/master/alerts/cluster-kube-controller-manager-operator/PodDisruptionBudgetAtLimit.md
+  Message: warning alert PodDisruptionBudgetAtLimit firing, which might slow node drains. Namespace=openshift-monitoring, PodDisruptionBudget=prometheus-k8s. The pod disruption budget is preventing further disruption to pods. The alert description is: The pod disruption budget is at the minimum disruptions allowed level. The number of current healthy pods is equal to the desired healthy pods. https://github.com/openshift/runbooks/blob/master/alerts/cluster-kube-controller-manager-operator/PodDisruptionBudgetAtLimit.md
 
 Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: candidate-4.16 (available channels: candidate-4.16, candidate-4.17, candidate-4.18, eus-4.16, fast-4.16, fast-4.17, stable-4.16, stable-4.17)

--- a/pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring.show-outdated-releases-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring.show-outdated-releases-output
@@ -1,0 +1,14 @@
+Failing=True:
+
+  Reason: ClusterOperatorNotAvailable
+  Message: Cluster operator monitoring is not available
+
+Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
+Channel: candidate-4.16 (available channels: candidate-4.16, candidate-4.17, candidate-4.18, eus-4.16, fast-4.16, fast-4.17, stable-4.16, stable-4.17)
+
+Updates to 4.16:
+  VERSION     ISSUES
+  4.16.32     no known issues relevant to this cluster
+  4.16.30     no known issues relevant to this cluster
+  4.16.29     no known issues relevant to this cluster
+  4.16.28     no known issues relevant to this cluster

--- a/pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring.version-4.12.51-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring.version-4.12.51-output
@@ -3,6 +3,8 @@ Failing=True:
   Reason: ClusterOperatorNotAvailable
   Message: Cluster operator monitoring is not available
 
+The following conditions found no cause for concern in updating this cluster to later releases: recommended/CriticalAlerts (AsExpected), recommended/NodeAlerts (AsExpected), recommended/PodDisruptionBudgetAlerts (AsExpected), recommended/PodImagePullAlerts (AsExpected)
+
 Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: candidate-4.16 (available channels: candidate-4.16, candidate-4.17, candidate-4.18, eus-4.16, fast-4.16, fast-4.17, stable-4.16, stable-4.17)
 

--- a/pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring.version-4.12.51-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring.version-4.12.51-output
@@ -3,7 +3,19 @@ Failing=True:
   Reason: ClusterOperatorNotAvailable
   Message: Cluster operator monitoring is not available
 
-The following conditions found no cause for concern in updating this cluster to later releases: recommended/CriticalAlerts (AsExpected), recommended/NodeAlerts (AsExpected), recommended/PodDisruptionBudgetAlerts (AsExpected), recommended/PodImagePullAlerts (AsExpected)
+The following conditions found no cause for concern in updating this cluster to later releases: recommended/NodeAlerts (AsExpected), recommended/PodImagePullAlerts (AsExpected)
+
+The following conditions found cause for concern in updating this cluster to later releases: recommended/CriticalAlerts/ClusterOperatorDown/0, recommended/PodDisruptionBudgetAlerts/PodDisruptionBudgetAtLimit/1
+
+recommended/CriticalAlerts/ClusterOperatorDown/0=False:
+
+  Reason: Alert:firing
+  Message: critical alert ClusterOperatorDown firing, suggesting significant cluster issues worth investigating. Cluster operator has not been available for 10 minutes. The alert description is: The monitoring operator may be down or disabled because UpdatingPrometheusFailed, and the components it manages may be unavailable or degraded.  Cluster upgrades may not complete. For more information refer to 'oc get -o yaml clusteroperator monitoring' or https://console-openshift-console.apps.ci-ln-4xlhr32-72292.origin-ci-int-gce.dev.rhcloud.com/settings/cluster/. https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/ClusterOperatorDown.md
+
+recommended/PodDisruptionBudgetAlerts/PodDisruptionBudgetAtLimit/1=False:
+
+  Reason: Alert:firing
+  Message: warning alert PodDisruptionBudgetAtLimit firing, which might slow node drains. The pod disruption budget is preventing further disruption to pods. The alert description is: The pod disruption budget is at the minimum disruptions allowed level. The number of current healthy pods is equal to the desired healthy pods. https://github.com/openshift/runbooks/blob/master/alerts/cluster-kube-controller-manager-operator/PodDisruptionBudgetAtLimit.md
 
 Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: candidate-4.16 (available channels: candidate-4.16, candidate-4.17, candidate-4.18, eus-4.16, fast-4.16, fast-4.17, stable-4.16, stable-4.17)

--- a/pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring.version-4.12.51-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring.version-4.12.51-output
@@ -1,0 +1,9 @@
+Failing=True:
+
+  Reason: ClusterOperatorNotAvailable
+  Message: Cluster operator monitoring is not available
+
+Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
+Channel: candidate-4.16 (available channels: candidate-4.16, candidate-4.17, candidate-4.18, eus-4.16, fast-4.16, fast-4.17, stable-4.16, stable-4.17)
+
+error: no updates to 4.12 available, so cannot display context for the requested release 4.12.51

--- a/pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring.version-4.12.51-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring.version-4.12.51-output
@@ -15,7 +15,7 @@ recommended/CriticalAlerts/ClusterOperatorDown/0=False:
 recommended/PodDisruptionBudgetAlerts/PodDisruptionBudgetAtLimit/1=False:
 
   Reason: Alert:firing
-  Message: warning alert PodDisruptionBudgetAtLimit firing, which might slow node drains. The pod disruption budget is preventing further disruption to pods. The alert description is: The pod disruption budget is at the minimum disruptions allowed level. The number of current healthy pods is equal to the desired healthy pods. https://github.com/openshift/runbooks/blob/master/alerts/cluster-kube-controller-manager-operator/PodDisruptionBudgetAtLimit.md
+  Message: warning alert PodDisruptionBudgetAtLimit firing, which might slow node drains. Namespace=openshift-monitoring, PodDisruptionBudget=prometheus-k8s. The pod disruption budget is preventing further disruption to pods. The alert description is: The pod disruption budget is at the minimum disruptions allowed level. The number of current healthy pods is equal to the desired healthy pods. https://github.com/openshift/runbooks/blob/master/alerts/cluster-kube-controller-manager-operator/PodDisruptionBudgetAtLimit.md
 
 Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: candidate-4.16 (available channels: candidate-4.16, candidate-4.17, candidate-4.18, eus-4.16, fast-4.16, fast-4.17, stable-4.16, stable-4.17)

--- a/pkg/cli/admin/upgrade/recommend/examples_test.go
+++ b/pkg/cli/admin/upgrade/recommend/examples_test.go
@@ -80,6 +80,7 @@ func TestExamples(t *testing.T) {
 				if err := opts.Complete(nil, nil, nil); err != nil {
 					t.Fatalf("Error when completing options: %v", err)
 				}
+				opts.precheckEnabled = true
 
 				var stdout, stderr bytes.Buffer
 				opts.Out = &stdout

--- a/pkg/cli/admin/upgrade/recommend/mockresources.go
+++ b/pkg/cli/admin/upgrade/recommend/mockresources.go
@@ -1,6 +1,7 @@
 package recommend
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -11,8 +12,13 @@ import (
 )
 
 type mockData struct {
-	cvPath         string
+	// inputs
+	cvPath     string
+	alertsPath string
+
+	// outputs
 	clusterVersion *configv1.ClusterVersion
+	alerts         []byte
 }
 
 func asResourceList[T any](objects *corev1.List, decoder runtime.Decoder) ([]T, error) {
@@ -63,6 +69,13 @@ func (o *mockData) load() error {
 		o.clusterVersion = &cvs[0]
 	default:
 		return fmt.Errorf("unexpected object type %T in --mock-clusterversion=%s content", cvObj, o.cvPath)
+	}
+
+	if o.alertsPath != "" {
+		o.alerts, err = os.ReadFile(o.alertsPath)
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/cli/admin/upgrade/recommend/precheck.go
+++ b/pkg/cli/admin/upgrade/recommend/precheck.go
@@ -1,0 +1,30 @@
+package recommend
+
+import (
+	"context"
+	"errors"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type check func(ctx context.Context) ([]metav1.Condition, error)
+
+// precheck runs a set of Condition-generating checkers, and
+// aggregates their results.  The Conditions must use True for happy
+// signals, False for sad signals, and Unknown when we do not have enough
+// information to make a happy-or-sad determination.
+func (o *options) precheck(ctx context.Context) ([]metav1.Condition, error) {
+	var conditions []metav1.Condition
+	var errs []error
+	for _, check := range []check{
+		o.alerts,
+	} {
+		cs, err := check(ctx)
+		if err != nil {
+			errs = append(errs, err)
+		}
+		conditions = append(conditions, cs...)
+	}
+
+	return conditions, errors.Join(errs...)
+}

--- a/pkg/cli/admin/upgrade/recommend/recommend.go
+++ b/pkg/cli/admin/upgrade/recommend/recommend.go
@@ -139,7 +139,7 @@ func (o *options) Run(ctx context.Context) error {
 	}
 
 	if c := findClusterOperatorStatusCondition(cv.Status.Conditions, configv1.OperatorProgressing); c != nil && c.Status == configv1.ConditionTrue && len(c.Message) > 0 {
-		fmt.Fprintf(o.Out, "info: An update is in progress.  You may wish to let this update complete before requesting a new update.\n  %s\n", strings.ReplaceAll(c.Message, "\n", "\n  "))
+		fmt.Fprintf(o.Out, "info: An update is in progress.  You may wish to let this update complete before requesting a new update.\n  %s\n\n", strings.ReplaceAll(c.Message, "\n", "\n  "))
 	}
 
 	if c := findClusterOperatorStatusCondition(cv.Status.Conditions, configv1.RetrievedUpdates); c != nil && c.Status != configv1.ConditionTrue {

--- a/pkg/cli/admin/upgrade/status/alerts.go
+++ b/pkg/cli/admin/upgrade/status/alerts.go
@@ -20,11 +20,12 @@ func (al AllowedAlerts) Contains(alert string) bool {
 }
 
 type AlertLabels struct {
-	AlertName string `json:"alertname,omitempty"`
-	Name      string `json:"name,omitempty"`
-	Namespace string `json:"namespace,omitempty"`
-	Reason    string `json:"reason,omitempty"`
-	Severity  string `json:"severity,omitempty"`
+	AlertName           string `json:"alertname,omitempty"`
+	Name                string `json:"name,omitempty"`
+	Namespace           string `json:"namespace,omitempty"`
+	PodDisruptionBudget string `json:"poddisruptionbudget,omitempty"`
+	Reason              string `json:"reason,omitempty"`
+	Severity            string `json:"severity,omitempty"`
 }
 
 type AlertAnnotations struct {


### PR DESCRIPTION
Retrieving alerts and rendering the interesting ones, as described in [OTA-1426](https://issues.redhat.com/browse/OTA-1426).  See the individual commit messages for me trying to walk through building this in steps, and the new `pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring.output` for the most direct example of the new logic.