### PR TITLE
OCPBUGS-50682: OCPBUGS-50683: Correct oc adm top pvc messages

### DIFF
--- a/pkg/cli/admin/toppvc/persistentvolumeclaims.go
+++ b/pkg/cli/admin/toppvc/persistentvolumeclaims.go
@@ -159,10 +159,10 @@ func (o *options) Run(ctx context.Context, args []string) error {
 
 	if len(promOutput.Data.Result) == 0 {
 		if o.namespace == "" {
-			return fmt.Errorf("no persistentvolumeclaims found.")
+			return fmt.Errorf("no persistentvolumeclaims found or mounted.")
 		}
 		if len(args) == 0 {
-			return fmt.Errorf("no persistentvolumeclaims found in %s namespace.", o.namespace)
+			return fmt.Errorf("no persistentvolumeclaims found or mounted in %s namespace.", o.namespace)
 		}
 		return fmt.Errorf("persistentvolumeclaim %q not found in %s namespace.", args[0], o.namespace)
 
@@ -190,7 +190,7 @@ func (o *options) Run(ctx context.Context, args []string) error {
 		pvcName := promOutputDataResult.Metric["persistentvolumeclaim"]
 		usagePercentage := promOutputDataResult.Value[1]
 		valueFloatLong, _ := strconv.ParseFloat(usagePercentage.(string), 64)
-		valueFloat := fmt.Sprintf("%.2f", valueFloatLong)
+		valueFloat := fmt.Sprintf("%.2f%%", valueFloatLong)
 		if len(pvcInfos) > 0 {
 			if !(namespaceName == pvcInfos[len(pvcInfos)-1].namespace && pvcName == pvcInfos[len(pvcInfos)-1].name) {
 				pvcInfos = append(pvcInfos, persistentVolumeClaimInfo{namespace: namespaceName, name: pvcName, usagePercentage: valueFloat})

--- a/pkg/cli/admin/toppvc/persistentvolumeclaims.go
+++ b/pkg/cli/admin/toppvc/persistentvolumeclaims.go
@@ -159,10 +159,10 @@ func (o *options) Run(ctx context.Context, args []string) error {
 
 	if len(promOutput.Data.Result) == 0 {
 		if o.namespace == "" {
-			return fmt.Errorf("no persistentvolumeclaims found or mounted.")
+			return fmt.Errorf("no persistentvolumeclaims found in use.")
 		}
 		if len(args) == 0 {
-			return fmt.Errorf("no persistentvolumeclaims found or mounted in %s namespace.", o.namespace)
+			return fmt.Errorf("no persistentvolumeclaims found in use in %s namespace.", o.namespace)
 		}
 		return fmt.Errorf("persistentvolumeclaim %q not found in %s namespace.", args[0], o.namespace)
 


### PR DESCRIPTION
Hi Team, 

PTAL for the issue:
https://issues.redhat.com/browse/OCPBUGS-50682
https://issues.redhat.com/browse/OCPBUGS-50683 

Output Verification after fix:
oc adm top pvc --insecure-skip-tls-verify=true -n testropatil 
error: no persistentvolumeclaims found or mounted in testropatil namespace.

oc adm top pvc --insecure-skip-tls-verify=true -n testropatil 
NAMESPACE   NAME         USAGE(%) 
testropatil mypvc-fs-gp2 0.00%    
testropatil mypvc-fs-gp3 0.00% 