### PR TITLE
OCPBUGS-50660: use destination client on v1 conversion

### DIFF
--- a/pkg/cli/image/append/append.go
+++ b/pkg/cli/image/append/append.go
@@ -559,7 +559,7 @@ func (o *AppendImageOptions) append(ctx context.Context, createdAt *time.Time,
 	if skipTagging {
 		tag = ""
 	}
-	toDigest, err := imagemanifest.PutManifestInCompatibleSchema(ctx, manifest, tag, toManifests, toRepo.Named(), fromRepo.Blobs(ctx), configJSON)
+	toDigest, err := imagemanifest.PutManifestInCompatibleSchema(ctx, manifest, tag, toManifests, toRepo.Named(), toRepo.Blobs(ctx), configJSON)
 	if err != nil {
 		return fmt.Errorf("unable to convert the image to a compatible schema version: %v", err)
 	}


### PR DESCRIPTION
_Note for the reviewer of this: please check the comment section in the linked OCPBUGS-50660, there are a lot of things there, it is quite impossible to reproduce everything here in the description_

I suspect we always knew that our manifest v2 implementation was somewhat failing (for the `oc image append` that is). I say that because when we fail to upload a v2 we attempt to convert it back to v1 and push it again.
[Here](https://github.com/openshift/oc/blob/master/pkg/cli/image/manifest/manifest.go#L593-L594) is where we do such a thing (if we [fail to push the v2 due to Invalid Manifest](https://github.com/openshift/oc/blob/master/pkg/cli/image/manifest/manifest.go#L580-L583)).

Here is where things go sideways: Docker Hub simply accepts the v2 we produce but Quay doesn't, so for the latter we gonna attempt the conversion to v1 and that should work but it doesn't.

We didn't know why it fails because [we masked the actual error](https://github.com/openshift/oc/blob/master/pkg/cli/image/manifest/manifest.go#L594-L602) (the actual error is "convertErr" but we return "err"). With a verbose 2 we can see what actually happens: when we try to push the v1 after the conversion we fail with "permission denied". This code has been around for quite a while and we only now see it failing.

These operations of conversion to v1 should go away and we should produce compatible v2 manifests, I guess. In the meantime if we replace the blob service used during the conversion we ensure that we have enough permissions to read the blobs.

**NOTE** that v1 has longer been deprecated and Docker will stop supporting it on its next version:

```
$ docker pull quay.io/repo/v1:latest
latest: Pulling from repo/v1:latest
[DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest
version 2, schema 1 support is disabled by default and will be removed
in an upcoming release. Suggest the author of
quay.io/repo/v1:latest to upgrade the image to the OCI Format
or Docker Image manifest v2, schema 2. More information at
https://docs.docker.com/go/deprecated-image-specs/
$
```