### PR TITLE
trt-1995: Update Unconditional Feature Gate Notation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/openshift/api v0.0.0-20250130025500-d9e1a2e1fe6b
 	github.com/openshift/build-machinery-go v0.0.0-20250102153059-e85a1a7ecb5c
 	github.com/openshift/client-go v0.0.0-20250125113824-8e1f0b8fa9a7
-	github.com/openshift/library-go v0.0.0-20250129210218-fe56c2cf5d70
+	github.com/openshift/library-go v0.0.0-20250218150059-017e5b6cf27c
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.19.1

--- a/go.sum
+++ b/go.sum
@@ -497,8 +497,8 @@ github.com/openshift/client-go v0.0.0-20250125113824-8e1f0b8fa9a7 h1:4iliLcvr1P9
 github.com/openshift/client-go v0.0.0-20250125113824-8e1f0b8fa9a7/go.mod h1:2tcufBE4Cu6RNgDCxcUJepa530kGo5GFVfR9BSnndhI=
 github.com/openshift/gssapi v0.0.0-20161010215902-5fb4217df13b h1:it0YPE/evO6/m8t8wxis9KFI2F/aleOKsI6d9uz0cEk=
 github.com/openshift/gssapi v0.0.0-20161010215902-5fb4217df13b/go.mod h1:tNrEB5k8SI+g5kOlsCmL2ELASfpqEofI0+FLBgBdN08=
-github.com/openshift/library-go v0.0.0-20250129210218-fe56c2cf5d70 h1:VLj8CU9q009xlMuR4wNcqDX4lVa2Ji3u/iYnBLHtQUc=
-github.com/openshift/library-go v0.0.0-20250129210218-fe56c2cf5d70/go.mod h1:TQx0VEhZ/92qRXIMDu2Wg4bUPmw5HRNE6wpSZ+IsP0Y=
+github.com/openshift/library-go v0.0.0-20250218150059-017e5b6cf27c h1:lW/rlxNTLYbHBoB9NBLEykzGriHyc/s/52bTQRUgH9U=
+github.com/openshift/library-go v0.0.0-20250218150059-017e5b6cf27c/go.mod h1:GHwvopE5KXXCz4ULHp871sTPLLW+FB+hu/RIzlNwxx8=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=

--- a/vendor/github.com/openshift/library-go/pkg/certs/cert-inspection/certgraphanalysis/certkeypair.go
+++ b/vendor/github.com/openshift/library-go/pkg/certs/cert-inspection/certgraphanalysis/certkeypair.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/openshift/library-go/pkg/certs/cert-inspection/certgraphapi"
 	"k8s.io/apimachinery/pkg/util/duration"
@@ -108,6 +109,8 @@ func toCertKeyMetadata(certificate *x509.Certificate) certgraphapi.CertKeyMetada
 		},
 		SignatureAlgorithm: certificate.SignatureAlgorithm.String(),
 		PublicKeyAlgorithm: certificate.PublicKeyAlgorithm.String(),
+		NotBefore:          certificate.NotBefore.Format(time.RFC3339),
+		NotAfter:           certificate.NotAfter.Format(time.RFC3339),
 		ValidityDuration:   duration.HumanDuration(certificate.NotAfter.Sub(certificate.NotBefore)),
 	}
 

--- a/vendor/github.com/openshift/library-go/pkg/certs/cert-inspection/certgraphapi/types.go
+++ b/vendor/github.com/openshift/library-go/pkg/certs/cert-inspection/certgraphapi/types.go
@@ -157,6 +157,8 @@ type CertKeyMetadata struct {
 	SignatureAlgorithm string
 	PublicKeyAlgorithm string
 	PublicKeyBitSize   string
+	NotBefore          string `json:"-"`
+	NotAfter           string `json:"-"`
 	ValidityDuration   string
 	Usages             []string
 	ExtendedUsages     []string

--- a/vendor/github.com/openshift/library-go/pkg/features/feature_diff_summary.go
+++ b/vendor/github.com/openshift/library-go/pkg/features/feature_diff_summary.go
@@ -71,7 +71,7 @@ func (i *ReleaseFeatureDiffInfo) GetOrderedFeatureGates() []string {
 	counts := map[string]int{}
 	for _, curr := range allInfo {
 		for featureGate, changedFeatureGate := range curr.ChangedFeatureGates {
-			if strings.HasSuffix(changedFeatureGate, "Unconditional") {
+			if strings.HasSuffix(changedFeatureGate, "Unconditionally Enabled") {
 				counts[featureGate] = counts[featureGate] - 100
 			}
 			if strings.HasSuffix(changedFeatureGate, "(Changed)") {

--- a/vendor/github.com/openshift/library-go/pkg/features/summarizer.go
+++ b/vendor/github.com/openshift/library-go/pkg/features/summarizer.go
@@ -124,7 +124,7 @@ func (i *ReleaseFeatureInfo) CalculateDiff(ctx context.Context, from *ReleaseFea
 					toEnabled, toOk := toFeatureInfo.AllFeatureGates[featureGate]
 					switch {
 					case !toOk:
-						currDiffInfo.ChangedFeatureGates[featureGate] = "Unconditional (New)"
+						currDiffInfo.ChangedFeatureGates[featureGate] = "Unconditionally Enabled (New)"
 					case toEnabled:
 						currDiffInfo.ChangedFeatureGates[featureGate] = "Enabled (New)"
 					case !toEnabled:
@@ -159,12 +159,12 @@ func (i *ReleaseFeatureInfo) CalculateDiff(ctx context.Context, from *ReleaseFea
 				case !toOk && fromOk:
 					switch {
 					case fromEnabled:
-						currDiffInfo.ChangedFeatureGates[featureGate] = "Unconditional (Changed)"
+						currDiffInfo.ChangedFeatureGates[featureGate] = "Unconditionally Enabled (Changed)"
 					case !fromEnabled:
-						currDiffInfo.ChangedFeatureGates[featureGate] = "Unconditional (Changed)"
+						currDiffInfo.ChangedFeatureGates[featureGate] = "Unconditionally Enabled (Changed)"
 					}
 				case !toOk && !fromOk:
-					currDiffInfo.ChangedFeatureGates[featureGate] = "Unconditional"
+					currDiffInfo.ChangedFeatureGates[featureGate] = "Unconditionally Enabled"
 				}
 			}
 			releaseFeatureDiffInfo.featureInfo[clusterProfile][featureSet] = currDiffInfo

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/annotations.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/annotations.go
@@ -1,8 +1,10 @@
 package certrotation
 
 import (
+	"github.com/google/go-cmp/cmp"
 	"github.com/openshift/api/annotations"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -25,14 +27,20 @@ func (a AdditionalAnnotations) EnsureTLSMetadataUpdate(meta *metav1.ObjectMeta) 
 		meta.Annotations = make(map[string]string)
 	}
 	if len(a.JiraComponent) > 0 && meta.Annotations[annotations.OpenShiftComponent] != a.JiraComponent {
+		diff := cmp.Diff(meta.Annotations[annotations.OpenShiftComponent], a.JiraComponent)
+		klog.V(2).Infof("Updating %q annotation for %s/%s, diff: %s", annotations.OpenShiftComponent, meta.Name, meta.Namespace, diff)
 		meta.Annotations[annotations.OpenShiftComponent] = a.JiraComponent
 		modified = true
 	}
 	if len(a.Description) > 0 && meta.Annotations[annotations.OpenShiftDescription] != a.Description {
+		diff := cmp.Diff(meta.Annotations[annotations.OpenShiftDescription], a.Description)
+		klog.V(2).Infof("Updating %q annotation for %s/%s, diff: %s", annotations.OpenShiftDescription, meta.Name, meta.Namespace, diff)
 		meta.Annotations[annotations.OpenShiftDescription] = a.Description
 		modified = true
 	}
 	if len(a.AutoRegenerateAfterOfflineExpiry) > 0 && meta.Annotations[AutoRegenerateAfterOfflineExpiryAnnotation] != a.AutoRegenerateAfterOfflineExpiry {
+		diff := cmp.Diff(meta.Annotations[AutoRegenerateAfterOfflineExpiryAnnotation], a.AutoRegenerateAfterOfflineExpiry)
+		klog.V(2).Infof("Updating %q annotation for %s/%s, diff: %s", AutoRegenerateAfterOfflineExpiryAnnotation, meta.Name, meta.Namespace, diff)
 		meta.Annotations[AutoRegenerateAfterOfflineExpiryAnnotation] = a.AutoRegenerateAfterOfflineExpiry
 		modified = true
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -778,7 +778,7 @@ github.com/openshift/client-go/user/clientset/versioned/fake
 github.com/openshift/client-go/user/clientset/versioned/scheme
 github.com/openshift/client-go/user/clientset/versioned/typed/user/v1
 github.com/openshift/client-go/user/clientset/versioned/typed/user/v1/fake
-# github.com/openshift/library-go v0.0.0-20250129210218-fe56c2cf5d70
+# github.com/openshift/library-go v0.0.0-20250218150059-017e5b6cf27c
 ## explicit; go 1.23.0
 github.com/openshift/library-go/pkg/apiserver/jsonpatch
 github.com/openshift/library-go/pkg/apps/appsserialization


### PR DESCRIPTION
This pr bumps library-go to pull in an enhancement request from [TRT-1995](https://issues.redhat.com/browse/TRT-1995) to change Feature Gate
 `Unconditional` -> `Unconditionally Enabled` 

That change came in via [library-go#1933](https://github.com/openshift/library-go/pull/1933)