### PR TITLE
NO-ISSUE: pkg/cli/admin/upgrade/recommend: "Upstream" -> "Upstream update service"

### DIFF
--- a/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-not-recommended.output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-not-recommended.output
@@ -5,7 +5,7 @@ recommended/Alert=Unknown:
   Reason: NoTestData
   Message: This --mock-clusterversion run did not have alert data available at examples/4.12.16-longest-not-recommended-alerts.json
 
-Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
+Upstream update service: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: stable-4.13 (available channels: candidate-4.12, candidate-4.13, eus-4.12, eus-4.14, fast-4.12, fast-4.13, stable-4.12, stable-4.13)
 
 Updates to 4.13:

--- a/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-not-recommended.show-outdated-releases-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-not-recommended.show-outdated-releases-output
@@ -5,7 +5,7 @@ recommended/Alert=Unknown:
   Reason: NoTestData
   Message: This --mock-clusterversion run did not have alert data available at examples/4.12.16-longest-not-recommended-alerts.json
 
-Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
+Upstream update service: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: stable-4.13 (available channels: candidate-4.12, candidate-4.13, eus-4.12, eus-4.14, fast-4.12, fast-4.13, stable-4.12, stable-4.13)
 
 Updates to 4.13:

--- a/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-not-recommended.version-4.12.51-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-not-recommended.version-4.12.51-output
@@ -5,7 +5,7 @@ recommended/Alert=Unknown:
   Reason: NoTestData
   Message: This --mock-clusterversion run did not have alert data available at examples/4.12.16-longest-not-recommended-alerts.json
 
-Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
+Upstream update service: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: stable-4.13 (available channels: candidate-4.12, candidate-4.13, eus-4.12, eus-4.14, fast-4.12, fast-4.13, stable-4.12, stable-4.13)
 
 Update to 4.12.51 Recommended=False:

--- a/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-recommended.output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-recommended.output
@@ -5,7 +5,7 @@ recommended/Alert=Unknown:
   Reason: NoTestData
   Message: This --mock-clusterversion run did not have alert data available at examples/4.12.16-longest-recommended-alerts.json
 
-Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
+Upstream update service: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: stable-4.13 (available channels: candidate-4.12, candidate-4.13, eus-4.12, eus-4.14, fast-4.12, fast-4.13, stable-4.12, stable-4.13)
 
 Updates to 4.13:

--- a/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-recommended.show-outdated-releases-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-recommended.show-outdated-releases-output
@@ -5,7 +5,7 @@ recommended/Alert=Unknown:
   Reason: NoTestData
   Message: This --mock-clusterversion run did not have alert data available at examples/4.12.16-longest-recommended-alerts.json
 
-Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
+Upstream update service: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: stable-4.13 (available channels: candidate-4.12, candidate-4.13, eus-4.12, eus-4.14, fast-4.12, fast-4.13, stable-4.12, stable-4.13)
 
 Updates to 4.13:

--- a/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-recommended.version-4.12.51-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-recommended.version-4.12.51-output
@@ -5,7 +5,7 @@ recommended/Alert=Unknown:
   Reason: NoTestData
   Message: This --mock-clusterversion run did not have alert data available at examples/4.12.16-longest-recommended-alerts.json
 
-Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
+Upstream update service: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: stable-4.13 (available channels: candidate-4.12, candidate-4.13, eus-4.12, eus-4.14, fast-4.12, fast-4.13, stable-4.12, stable-4.13)
 
 Update to 4.12.51 Recommended=False:

--- a/pkg/cli/admin/upgrade/recommend/examples/4.14.1-all-recommended.output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.14.1-all-recommended.output
@@ -8,7 +8,7 @@ recommended/Alert=Unknown:
   Reason: NoTestData
   Message: This --mock-clusterversion run did not have alert data available at examples/4.14.1-all-recommended-alerts.json
 
-Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
+Upstream update service: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: candidate-4.14 (available channels: candidate-4.14, candidate-4.15, eus-4.14, fast-4.14, stable-4.14)
 
 Updates to 4.14:

--- a/pkg/cli/admin/upgrade/recommend/examples/4.14.1-all-recommended.show-outdated-releases-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.14.1-all-recommended.show-outdated-releases-output
@@ -8,7 +8,7 @@ recommended/Alert=Unknown:
   Reason: NoTestData
   Message: This --mock-clusterversion run did not have alert data available at examples/4.14.1-all-recommended-alerts.json
 
-Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
+Upstream update service: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: candidate-4.14 (available channels: candidate-4.14, candidate-4.15, eus-4.14, fast-4.14, stable-4.14)
 
 Updates to 4.14:

--- a/pkg/cli/admin/upgrade/recommend/examples/4.14.1-all-recommended.version-4.12.51-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.14.1-all-recommended.version-4.12.51-output
@@ -8,7 +8,7 @@ recommended/Alert=Unknown:
   Reason: NoTestData
   Message: This --mock-clusterversion run did not have alert data available at examples/4.14.1-all-recommended-alerts.json
 
-Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
+Upstream update service: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: candidate-4.14 (available channels: candidate-4.14, candidate-4.15, eus-4.14, fast-4.14, stable-4.14)
 
 error: no updates to 4.12 available, so cannot display context for the requested release 4.12.51

--- a/pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring.output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring.output
@@ -17,7 +17,7 @@ recommended/PodDisruptionBudgetAlerts/PodDisruptionBudgetAtLimit/1=False:
   Reason: Alert:firing
   Message: warning alert PodDisruptionBudgetAtLimit firing, which might slow node drains. Namespace=openshift-monitoring, PodDisruptionBudget=prometheus-k8s. The pod disruption budget is preventing further disruption to pods. The alert description is: The pod disruption budget is at the minimum disruptions allowed level. The number of current healthy pods is equal to the desired healthy pods. https://github.com/openshift/runbooks/blob/master/alerts/cluster-kube-controller-manager-operator/PodDisruptionBudgetAtLimit.md
 
-Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
+Upstream update service: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: candidate-4.16 (available channels: candidate-4.16, candidate-4.17, candidate-4.18, eus-4.16, fast-4.16, fast-4.17, stable-4.16, stable-4.17)
 
 Updates to 4.16:

--- a/pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring.show-outdated-releases-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring.show-outdated-releases-output
@@ -17,7 +17,7 @@ recommended/PodDisruptionBudgetAlerts/PodDisruptionBudgetAtLimit/1=False:
   Reason: Alert:firing
   Message: warning alert PodDisruptionBudgetAtLimit firing, which might slow node drains. Namespace=openshift-monitoring, PodDisruptionBudget=prometheus-k8s. The pod disruption budget is preventing further disruption to pods. The alert description is: The pod disruption budget is at the minimum disruptions allowed level. The number of current healthy pods is equal to the desired healthy pods. https://github.com/openshift/runbooks/blob/master/alerts/cluster-kube-controller-manager-operator/PodDisruptionBudgetAtLimit.md
 
-Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
+Upstream update service: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: candidate-4.16 (available channels: candidate-4.16, candidate-4.17, candidate-4.18, eus-4.16, fast-4.16, fast-4.17, stable-4.16, stable-4.17)
 
 Updates to 4.16:

--- a/pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring.version-4.12.51-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring.version-4.12.51-output
@@ -17,7 +17,7 @@ recommended/PodDisruptionBudgetAlerts/PodDisruptionBudgetAtLimit/1=False:
   Reason: Alert:firing
   Message: warning alert PodDisruptionBudgetAtLimit firing, which might slow node drains. Namespace=openshift-monitoring, PodDisruptionBudget=prometheus-k8s. The pod disruption budget is preventing further disruption to pods. The alert description is: The pod disruption budget is at the minimum disruptions allowed level. The number of current healthy pods is equal to the desired healthy pods. https://github.com/openshift/runbooks/blob/master/alerts/cluster-kube-controller-manager-operator/PodDisruptionBudgetAtLimit.md
 
-Upstream: https://api.integration.openshift.com/api/upgrades_info/graph
+Upstream update service: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: candidate-4.16 (available channels: candidate-4.16, candidate-4.17, candidate-4.18, eus-4.16, fast-4.16, fast-4.17, stable-4.16, stable-4.17)
 
 error: no updates to 4.12 available, so cannot display context for the requested release 4.12.51

--- a/pkg/cli/admin/upgrade/recommend/recommend.go
+++ b/pkg/cli/admin/upgrade/recommend/recommend.go
@@ -185,9 +185,9 @@ func (o *options) Run(ctx context.Context) error {
 
 	if cv.Spec.Channel != "" {
 		if cv.Spec.Upstream == "" {
-			fmt.Fprint(o.Out, "Upstream is unset, so the cluster will use an appropriate default.\n")
+			fmt.Fprint(o.Out, "Upstream update service is unset, so the cluster will use an appropriate default.\n")
 		} else {
-			fmt.Fprintf(o.Out, "Upstream: %s\n", cv.Spec.Upstream)
+			fmt.Fprintf(o.Out, "Upstream update service: %s\n", cv.Spec.Upstream)
 		}
 		if len(cv.Status.Desired.Channels) > 0 {
 			fmt.Fprintf(o.Out, "Channel: %s (available channels: %s)\n", cv.Spec.Channel, strings.Join(cv.Status.Desired.Channels, ", "))


### PR DESCRIPTION
The ClusterVersion spec property is `spec.upstream`, and that's a v1 API we cannot easily change.  But in freeform text here, we can get closer to [the "OpenShift Update Service" wording we use in docs][1].  I haven't included "OpenShift", because hopefully that context is obvious to folks running `oc ....`.  I haven't Title Cased, because I'm not listing a particular product/implementation; it's possible that the customer has pointed their cluster at a custom update service like [a raw GitHub file][3].  I've kept "Upstream" to make it easier for folks to associate with spec.upstream.  And I've left the GA `oc adm upgrade` alone on this, because it's been using "Upstream:" for years now, and this seems minor enough that I don't think it's worth disrupting things there.

[1]: https://docs.openshift.com/container-platform/4.17/updating/understanding_updates/intro-to-updates.html
[3]: https://issues.redhat.com/browse/OTA-520