### PR TITLE
NO-ISSUE: pkg/cli/admin/upgrade/recommend: Configureable version for test fixtures

### DIFF
--- a/pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring.version-4.16.32-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring.version-4.16.32-output
@@ -20,4 +20,6 @@ recommended/PodDisruptionBudgetAlerts/PodDisruptionBudgetAtLimit/1=False:
 Upstream update service: https://api.integration.openshift.com/api/upgrades_info/graph
 Channel: candidate-4.16 (available channels: candidate-4.16, candidate-4.17, candidate-4.18, eus-4.16, fast-4.16, fast-4.17, stable-4.16, stable-4.17)
 
-error: no updates to 4.12 available, so cannot display context for the requested release 4.12.51
+Update to 4.16.32 has no known issues relevant to this cluster.
+Image: quay.io/openshift-release-dev/ocp-release@sha256:0e71cb61694473b40e8d95f530eaf250a62616debb98199f31b4034808687dae
+Release URL: https://access.redhat.com/errata/RHSA-2025:0650

--- a/pkg/cli/admin/upgrade/recommend/examples/README.md
+++ b/pkg/cli/admin/upgrade/recommend/examples/README.md
@@ -5,7 +5,7 @@ Each example consists of inputs and outputs, matched by a common substring:
 * `TESTCASE-cv.yaml` (input): ClusterVersion object (created by `oc get clusterversion version -o yaml`).  Lists are also supported.
 * `TESTCASE.output` (output): expected output of `oc adm upgrade recommend`.
 * `TESTCASE.show-outdated-releases-output` (output): expected output of `oc adm upgrade recommend --show-outdated-releases`.
-* `TESTCASE.version-4.12.51-output` (output): expected output of `oc adm upgrade recommend --to 4.12.51`.
+* `TESTCASE.version-<VERSION>-output` (output): expected output of `oc adm upgrade recommend --to <VERSION>`.
 
 The `TestExamples` test in [`examples_test.go`](../examples_test.go) file above validates all examples.
 When the testcase is executed with a non-empty `UPDATE` environmental variable, it will update the `TESTCASE.out` fixture:

--- a/pkg/cli/admin/upgrade/recommend/examples/README.md
+++ b/pkg/cli/admin/upgrade/recommend/examples/README.md
@@ -4,7 +4,8 @@ Each example consists of inputs and outputs, matched by a common substring:
 
 * `TESTCASE-cv.yaml` (input): ClusterVersion object (created by `oc get clusterversion version -o yaml`).  Lists are also supported.
 * `TESTCASE.output` (output): expected output of `oc adm upgrade recommend`.
-* `TESTCASE.include-not-recommended-output` (output): expected output of `oc adm upgrade recommend --include-not-recommended`.
+* `TESTCASE.show-outdated-releases-output` (output): expected output of `oc adm upgrade recommend --show-outdated-releases`.
+* `TESTCASE.version-4.12.51-output` (output): expected output of `oc adm upgrade recommend --to 4.12.51`.
 
 The `TestExamples` test in [`examples_test.go`](../examples_test.go) file above validates all examples.
 When the testcase is executed with a non-empty `UPDATE` environmental variable, it will update the `TESTCASE.out` fixture:
@@ -16,5 +17,5 @@ $ UPDATE=yes go test -v ./pkg/cli/admin/upgrade/recommend/...
 You can also pass the inputs to the `oc adm upgrade recommend` directly:
 
 ```console
-$ oc adm upgrade recommend --mock-clusterversion=4.14.1-both-available-and-conditional-cv.yaml
+$ oc adm upgrade recommend --mock-clusterversion=4.14.1-all-recommended-cv.yaml
 ```

--- a/pkg/cli/admin/upgrade/recommend/examples_test.go
+++ b/pkg/cli/admin/upgrade/recommend/examples_test.go
@@ -46,8 +46,9 @@ func TestExamples(t *testing.T) {
 	variants := []struct {
 		name                 string
 		showOutdatedReleases bool
-		version              string
+		versions             map[string]string
 		outputSuffix         string
+		outputSuffixPattern  string
 	}{
 		{
 			name:                 "normal output",
@@ -60,9 +61,14 @@ func TestExamples(t *testing.T) {
 			outputSuffix:         ".show-outdated-releases-output",
 		},
 		{
-			name:         "specific version",
-			version:      "4.12.51",
-			outputSuffix: ".version-4.12.51-output",
+			name: "specific version",
+			versions: map[string]string{
+				"examples/4.12.16-longest-not-recommended-cv.yaml": "4.12.51",
+				"examples/4.12.16-longest-recommended-cv.yaml":     "4.12.51",
+				"examples/4.14.1-all-recommended-cv.yaml":          "4.12.51",
+				"examples/4.16.27-degraded-monitoring-cv.yaml":     "4.16.32",
+			},
+			outputSuffixPattern: ".version-%s-output",
 		},
 	}
 
@@ -70,12 +76,16 @@ func TestExamples(t *testing.T) {
 		cv := cv
 		for _, variant := range variants {
 			variant := variant
+			var version string
+			if version = variant.versions[cv]; version != "" {
+				variant.outputSuffix = fmt.Sprintf(variant.outputSuffixPattern, version)
+			}
 			t.Run(fmt.Sprintf("%s-%s", cv, variant.name), func(t *testing.T) {
 				t.Parallel()
 				opts := &options{
 					mockData:             mockData{cvPath: cv},
 					showOutdatedReleases: variant.showOutdatedReleases,
-					rawVersion:           variant.version,
+					rawVersion:           version,
 				}
 				if err := opts.Complete(nil, nil, nil); err != nil {
 					t.Fatalf("Error when completing options: %v", err)


### PR DESCRIPTION
Always testing 4.12.51 was easy, but is less interesting once we have one `no updates to 4.12 available` example.  Make the target version for each ClusterVersion dump configurable, so we can see what `--version <VERSION>` with working versions expands too on more recent dumps as well.
