### PR TITLE
pkg/cli/admin/upgrade/recommend: Populate RESTConfig

### DIFF
--- a/pkg/cli/admin/upgrade/recommend/recommend.go
+++ b/pkg/cli/admin/upgrade/recommend/recommend.go
@@ -89,15 +89,15 @@ func (o *options) Complete(f kcmdutil.Factory, cmd *cobra.Command, args []string
 	kcmdutil.RequireNoArguments(cmd, args)
 
 	if o.mockData.cvPath == "" {
-		cfg, err := f.ToRESTConfig()
+		var err error
+		o.RESTConfig, err = f.ToRESTConfig()
 		if err != nil {
 			return err
 		}
-		client, err := configv1client.NewForConfig(cfg)
+		o.Client, err = configv1client.NewForConfig(o.RESTConfig)
 		if err != nil {
 			return err
 		}
-		o.Client = client
 	} else {
 		cvSuffix := "-cv.yaml"
 		o.mockData.alertsPath = strings.Replace(o.mockData.cvPath, cvSuffix, "-alerts.json", 1)


### PR DESCRIPTION
Avoid crashing with pre-checks enabled:

```console
$ export OC_ENABLE_CMD_UPGRADE_RECOMMEND=true  # overall 'recommend' command still tech-preview
$ export OC_ENABLE_CMD_UPGRADE_RECOMMEND_PRECHECK=true  # pre-check functionality even more tech-preview
$ ./oc adm upgrade recommend --version 4.17.18
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x3bd3cdd]

goroutine 1 [running]:
github.com/openshift/client-go/route/clientset/versioned/typed/route/v1.NewForConfig(0x24ec35c?)
	/go/src/github.com/openshift/oc/vendor/github.com/openshift/client-go/route/clientset/versioned/typed/route/v1/route_client.go:31 +0x1d
github.com/openshift/oc/pkg/cli/admin/upgrade/recommend.(*options).alerts(0xc000663130, {0x5ed4828, 0x8350a80})
	/go/src/github.com/openshift/oc/pkg/cli/admin/upgrade/recommend/alerts.go:34 +0x170
github.com/openshift/oc/pkg/cli/admin/upgrade/recommend.(*options).precheck(0x0?, {0x5ed4828, 0x8350a80})
...
```

I'd added the `RESTConfig` option to feed the Route lookup in e11b84dab2 (#1970), but forgotten to populate it, and the bugged path is outside of what the unit test fixtures excercise.