### PR TITLE
NO-JIRA: debug: suggest nsenter instead of chroot

### DIFF
--- a/pkg/cli/debug/debug.go
+++ b/pkg/cli/debug/debug.go
@@ -548,7 +548,7 @@ func (o *DebugOptions) RunDebug() error {
 			}
 			if o.IsNode {
 				if !(template.Spec.OS != nil && template.Spec.OS.Name == corev1.Windows) {
-					fmt.Fprintf(o.ErrOut, "To use host binaries, run `chroot /host`\n")
+					fmt.Fprintf(o.ErrOut, "To use host binaries, run `chroot /host`. Instead, if you need to access host namespaces, run `nsenter -a -t 1`.\n")
 				}
 			}
 		}


### PR DESCRIPTION
`chroot /host` does not change the namespaces for the current process. In particular not joining the mount namespace is a continuous source of confusion for mounts not being propagated to the containers.

Suggest `nsenter` as a better alternative.