### PR TITLE
[BUG] Fix scale and autoscale oc completion

### DIFF
--- a/pkg/cli/kubectlwrappers/wrappers.go
+++ b/pkg/cli/kubectlwrappers/wrappers.go
@@ -143,7 +143,8 @@ func NewCmdProxy(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.
 // NewCmdScale is a wrapper for the Kubernetes cli scale command
 func NewCmdScale(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	cmd := cmdutil.ReplaceCommandName("kubectl", "oc", templates.Normalize(scale.NewCmdScale(f, streams)))
-	cmd.ValidArgs = append(cmd.ValidArgs, "deploymentconfig")
+	validArgs := []string{"deployment", "replicaset", "replicationcontroller", "statefulset", "deploymentconfig"}
+	cmd.ValidArgsFunction = utilcomp.SpecifiedResourceTypeAndNameCompletionFunc(f, validArgs)
 	return cmd
 }
 
@@ -151,7 +152,8 @@ func NewCmdScale(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.
 func NewCmdAutoscale(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	cmd := cmdutil.ReplaceCommandName("kubectl", "oc", templates.Normalize(autoscale.NewCmdAutoscale(f, streams)))
 	cmd.Short = "Autoscale a deployment config, deployment, replica set, stateful set, or replication controller"
-	cmd.ValidArgs = append(cmd.ValidArgs, "deploymentconfig")
+	validArgs := []string{"deployment", "replicaset", "replicationcontroller", "statefulset", "deploymentconfig"}
+	cmd.ValidArgsFunction = utilcomp.SpecifiedResourceTypeAndNameCompletionFunc(f, validArgs)
 	return cmd
 }
 


### PR DESCRIPTION
This PR fixes #1993.

I've added the relevant resources to the validArgs array and set the ValidArgsFunction in oc's scale and autoscale commands - the existing ValidArgs wasn't appropriate and also didn't work because it's not set in the original commands.
I'm not sure whether machineSet should be included in this array as well since it may not be relevant for all openshift clusters.