### PR TITLE
OCPBUGS-54168: Use ProxyFromEnvironment when creating HTTP transport

### DIFF
--- a/pkg/cli/admin/toppvc/persistentvolumeclaims.go
+++ b/pkg/cli/admin/toppvc/persistentvolumeclaims.go
@@ -252,6 +252,7 @@ func getWithBearer(ctx context.Context, getRoute RouteGetter, namespace, name st
 	}
 
 	httpTransport := &http.Transport{
+		Proxy:           http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: InsecureTLS},
 	}
 


### PR DESCRIPTION
### Add proxy support for pvc filesystem usage percentage CLI
- Go’s net/http client resolves DNS before proxying the request — proxies are only used after DNS resolution. So we'd better init Go HTTP Client with Standard HTTP Proxy if the proxy environment variables set.

**Local test wroked**

```console
# before the fix patch after export proxy
$ export http_proxy=http://XXXX
$ export https_proxy=http://XXXX

$ oc adm top pvc --insecure-skip-tls-verify=true --v=8
I0324 22:52:59.943468   40954 loader.go:402] Config loaded from file:  /Users/wangpenghao/hc.kubeconfig
I0324 22:52:59.943835   40954 envvar.go:172] "Feature gate default state" feature="InformerResourceVersion" enabled=false
I0324 22:52:59.943855   40954 envvar.go:172] "Feature gate default state" feature="WatchListClient" enabled=false
I0324 22:52:59.943860   40954 envvar.go:172] "Feature gate default state" feature="ClientsAllowCBOR" enabled=false
I0324 22:52:59.943865   40954 envvar.go:172] "Feature gate default state" feature="ClientsPreferCBOR" enabled=false
I0324 22:52:59.944331   40954 type.go:168] "Request Body" body=""
I0324 22:52:59.944429   40954 round_trippers.go:470] GET https://api.ropatil-324aws1.qe.devcluster.openshift.com:6443/apis/route.openshift.io/v1/namespaces/openshift-monitoring/routes/prometheus-k8s
I0324 22:52:59.944435   40954 round_trippers.go:476] Request Headers:
I0324 22:52:59.944443   40954 round_trippers.go:480]     Accept: application/json, */*
I0324 22:52:59.944447   40954 round_trippers.go:480]     User-Agent: oc/4.19.0 (darwin/amd64) kubernetes/e7e738c
I0324 22:52:59.944452   40954 round_trippers.go:480]     Authorization: Bearer <masked>
I0324 22:53:01.000163   40954 round_trippers.go:581] Response Status: 200 OK in 1055 milliseconds
I0324 22:53:01.000252   40954 round_trippers.go:584] Response Headers:
I0324 22:53:01.000270   40954 round_trippers.go:587]     Cache-Control: no-cache, private
I0324 22:53:01.000280   40954 round_trippers.go:587]     Cache-Control: no-store
I0324 22:53:01.000291   40954 round_trippers.go:587]     Date: Mon, 24 Mar 2025 14:53:00 GMT
I0324 22:53:01.000301   40954 round_trippers.go:587]     X-Kubernetes-Pf-Flowschema-Uid: 5af774f2-4560-49d4-a68e-414d1eac5fa4
I0324 22:53:01.000312   40954 round_trippers.go:587]     Content-Length: 1707
I0324 22:53:01.000320   40954 round_trippers.go:587]     Audit-Id: e7f9cf7a-0e2a-46f3-94b4-bbfbcc50c422
I0324 22:53:01.000330   40954 round_trippers.go:587]     Audit-Id: e7f9cf7a-0e2a-46f3-94b4-bbfbcc50c422
I0324 22:53:01.000341   40954 round_trippers.go:587]     Content-Type: application/json
I0324 22:53:01.000351   40954 round_trippers.go:587]     Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
I0324 22:53:01.000364   40954 round_trippers.go:587]     X-Kubernetes-Pf-Prioritylevel-Uid: 0a76752a-7742-4c20-8588-a5d863f93cd1
I0324 22:53:01.000700   40954 type.go:168] "Response Body" body="{\"kind\":\"Route\",\"apiVersion\":\"route.openshift.io/v1\",\"metadata\":{\"name\":\"prometheus-k8s\",\"namespace\":\"openshift-monitoring\",\"uid\":\"44db6991-09ed-45c4-9b75-f4eb77a70b71\",\"resourceVersion\":\"29427\",\"creationTimestamp\":\"2025-03-24T06:36:58Z\",\"labels\":{\"app.kubernetes.io/managed-by\":\"cluster-monitoring-operator\",\"app.kubernetes.io/part-of\":\"openshift-monitoring\"},\"annotations\":{\"openshift.io/description\":\"Expose the `/api` endpoints of the `prometheus-k8s` service via a router.\",\"openshift.io/host.generated\":\"true\"},\"managedFields\":[{\"manager\":\"operator\",\"operation\":\"Update\",\"apiVersion\":\"route.openshift.io/v1\",\"time\":\"2025-03-24T06:36:58Z\",\"fieldsType\":\"FieldsV1\",\"fieldsV1\":{\"f:metadata\":{\"f:annotations\":{\".\":{},\"f:openshift.io/description\":{}},\"f:labels\":{\".\":{},\"f:app.kubernetes.io/managed-by\":{},\"f:app.kubernetes.io/part-of\":{}}},\"f:spec\":{\"f:path\":{},\"f:port\":{\".\":{},\"f:targetPort\":{}},\"f:tls\":{\".\":{},\"f:insecureEdgeTerminationPolicy\":{},\"f:termination\":{}},\"f:to\":{\"f:kind\":{},\"f:name\":{},\"f:weight\":{}},\"f:wi [truncated 683 chars]"
I0324 22:53:01.002184   40954 round_trippers.go:470] GET https://prometheus-k8s-openshift-monitoring.apps.ropatil-324aws1.qe.devcluster.openshift.com/api/v1/query?query=100%2Akubelet_volume_stats_used_bytes%7Bpersistentvolumeclaim%3D~%22.%2A%22%2C+namespace%3D%22default%22%7D%2Fkubelet_volume_stats_capacity_bytes%7Bpersistentvolumeclaim%3D~%22.%2A%22%2C+namespace%3D%22default%22%7D
I0324 22:53:01.002278   40954 round_trippers.go:476] Request Headers:
I0324 22:53:01.002327   40954 round_trippers.go:480]     User-Agent: oc/4.19.0 (darwin/amd64) kubernetes/e7e738c(top persistentvolumeclaims)
I0324 22:53:01.002345   40954 round_trippers.go:480]     Authorization: Bearer <masked>
I0324 22:53:01.458489   40954 round_trippers.go:581] Response Status:  in 456 milliseconds
I0324 22:53:01.458526   40954 round_trippers.go:584] Response Headers:
error: failed to get persistentvolumeclaims from Prometheus: unable to get /api/v1/query from URI in the openshift-monitoring/prometheus-k8s Route: prometheus-k8s-openshift-monitoring.apps.ropatil-324aws1.qe.devcluster.openshift.com, Get "https://prometheus-k8s-openshift-monitoring.apps.ropatil-324aws1.qe.devcluster.openshift.com/api/v1/query?query=100%2Akubelet_volume_stats_used_bytes%7Bpersistentvolumeclaim%3D~%22.%2A%22%2C+namespace%3D%22default%22%7D%2Fkubelet_volume_stats_capacity_bytes%7Bpersistentvolumeclaim%3D~%22.%2A%22%2C+namespace%3D%22default%22%7D": dial tcp: lookup prometheus-k8s-openshift-monitoring.apps.ropatil-324aws1.qe.devcluster.openshift.com: no such host
 
# After the fix patch
$ make oc
go build -mod=vendor -tags 'include_gcs include_oss containers_image_openpgp gssapi' -ldflags "-X github.com/openshift/oc/pkg/version.versionFromGit="v4.2.0-alpha.0-2624-g33cbfe1" -X github.com/openshift/oc/pkg/version.commitFromGit="33cbfe154" -X github.com/openshift/oc/pkg/version.gitTreeState="dirty" -X github.com/openshift/oc/pkg/version.buildDate="2025-03-24T14:39:37Z" -X k8s.io/component-base/version.gitMajor="1" -X k8s.io/component-base/version.gitMinor="32" -X k8s.io/component-base/version.gitVersion="v1.32.1" -X k8s.io/component-base/version.gitCommit="33cbfe154" -X k8s.io/component-base/version.buildDate="2025-03-24T14:39:34Z" -X k8s.io/component-base/version.gitTreeState="clean" -X k8s.io/client-go/pkg/version.gitVersion="v4.2.0-alpha.0-2624-g33cbfe1" -X k8s.io/client-go/pkg/version.gitCommit="33cbfe154" -X k8s.io/client-go/pkg/version.buildDate="2025-03-24T14:39:34Z" -X k8s.io/client-go/pkg/version.gitTreeState="dirty"" github.com/openshift/oc/cmd/oc
 $./oc version
Client Version: v4.2.0-alpha.0-2624-g33cbfe1
Kustomize Version: v5.5.0

$ ./oc adm top pvc --insecure-skip-tls-verify=true      
NAMESPACE NAME  USAGE(%) 
default   mypvc 0.00%    
```