### PR TITLE
OCPBUGS-30080: `adm release new`: PoC: replace version placeholders in CVO manifests

### DIFF
--- a/pkg/cli/admin/release/new.go
+++ b/pkg/cli/admin/release/new.go
@@ -1337,7 +1337,13 @@ func writePayload(w io.Writer, is *imageapi.ImageStream, cm *CincinnatiMetadata,
 
 	manifestDestinationDir := "release-manifests"
 	// ensure the directory exists in the tar bundle
-	if err := tw.WriteHeader(&tar.Header{Mode: 0777, ModTime: newest, Typeflag: tar.TypeDir, Name: manifestDestinationDir}); err != nil {
+	releaseManifestsDirHdr := tar.Header{
+		Name:     manifestDestinationDir,
+		Mode:     0777,
+		ModTime:  newest,
+		Typeflag: tar.TypeDir,
+	}
+	if err := tw.WriteHeader(&releaseManifestsDirHdr); err != nil {
 		return nil, err
 	}
 
@@ -1347,7 +1353,14 @@ func writePayload(w io.Writer, is *imageapi.ImageStream, cm *CincinnatiMetadata,
 		return nil, err
 	}
 
-	if err := tw.WriteHeader(&tar.Header{Mode: 0444, ModTime: newest, Typeflag: tar.TypeReg, Name: path.Join(manifestDestinationDir, imageReferencesImageStreamFilename), Size: int64(len(data))}); err != nil {
+	imageReferencesHdr := tar.Header{
+		Name:     path.Join(manifestDestinationDir, imageReferencesImageStreamFilename),
+		Mode:     0444,
+		ModTime:  newest,
+		Typeflag: tar.TypeReg,
+		Size:     int64(len(data)),
+	}
+	if err := tw.WriteHeader(&imageReferencesHdr); err != nil {
 		return nil, err
 	}
 	if _, err := tw.Write(data); err != nil {
@@ -1360,7 +1373,14 @@ func writePayload(w io.Writer, is *imageapi.ImageStream, cm *CincinnatiMetadata,
 		if err != nil {
 			return nil, err
 		}
-		if err := tw.WriteHeader(&tar.Header{Mode: 0444, ModTime: newest, Typeflag: tar.TypeReg, Name: path.Join(manifestDestinationDir, "release-metadata"), Size: int64(len(data))}); err != nil {
+		releaseMetadataHdr := tar.Header{
+			Name:     path.Join(manifestDestinationDir, "release-metadata"),
+			Mode:     0444,
+			ModTime:  newest,
+			Typeflag: tar.TypeReg,
+			Size:     int64(len(data)),
+		}
+		if err := tw.WriteHeader(&releaseMetadataHdr); err != nil {
 			return nil, err
 		}
 		if _, err := tw.Write(data); err != nil {
@@ -1429,7 +1449,14 @@ func writePayload(w io.Writer, is *imageapi.ImageStream, cm *CincinnatiMetadata,
 			if err != nil {
 				return err
 			}
-			if err := tw.WriteHeader(&tar.Header{Mode: 0444, ModTime: fi.ModTime(), Typeflag: tar.TypeReg, Name: dst, Size: int64(len(modified))}); err != nil {
+			dstHdr := tar.Header{
+				Name:     dst,
+				Mode:     0444,
+				ModTime:  fi.ModTime(),
+				Typeflag: tar.TypeReg,
+				Size:     int64(len(modified)),
+			}
+			if err := tw.WriteHeader(&dstHdr); err != nil {
 				return err
 			}
 			klog.V(6).Infof("Writing payload to %s\n%s", dst, string(modified))


### PR DESCRIPTION
This a proof-of-concept of a fix for OCPBUGS-30080, allowing the `0.0.0-snapshot` placeholders to be replaced in CVO manifests, just like it is in the manifests extracted from the operator images.

The CVO image, typically identified through the `--to-base-image-ref` (with a default of `cluster-version-operator`) should be processed and its manifests extracted for later inclusion in the payload image. CVO image supplied this way is always included as an input to the payload:

```golang
// the base tag should always be included in a release payload
if len(o.ToImageBaseTag) > 0 {
  o.AlwaysInclude = append(o.AlwaysInclude, o.ToImageBaseTag)
}
```

But its manifests are not extracted, because CVO image is not labeled with `io.openshift.release.operator` (if it was, its manifests would be extracted and included in `release-manifests` directory, like all other). The PoC relaxes this condition by allowing the tag specified in `o.ToImageBaseTag` to be extracted even if it is not labeled this way. The extracted manifests are later processed for release payload inclusion.

Second part of the PoC change is to recognize the CVO manifests when individual manifests are processed, transformed and considered for inclusion in the payload. The CVO manifests are recognized by passing `o.ToImageBaseTag` into the responsible function, and placing these manifests into `manifests` directory instead, but this allows them to be transformed with the simple versions mapper, which replaces the `0.0.1-snapshot` placeholder in them.

This is a tricky change because of an unknown interaction with `--to-base-image`. That image is not used as an input to the release payload, but simply as a destination, and the CVO binary and `manifests` directory contents presence is simply assumed. The PoC would change this behavior, but it is unclear what use case explicit `--to-base-image` not corresponding to the `--to-base-image-tag` has.
