### PR TITLE
NO-JIRA: `adm release new`: simplify no operator error condition

### DIFF
--- a/pkg/cli/admin/release/new.go
+++ b/pkg/cli/admin/release/new.go
@@ -782,10 +782,7 @@ func (o *NewOptions) Run(ctx context.Context) error {
 		return err
 	}
 
-	sort.Strings(operators)
-	switch {
-	case operators == nil:
-	case len(operators) == 0:
+	if len(operators) == 0 {
 		fmt.Fprintf(o.ErrOut, "warning: No operator metadata was found, no operators will be part of the release.\n")
 	}
 


### PR DESCRIPTION
The actual `operators` content is never used, so it does not need to be sorted, and treating `nil` as a silent good case and `len()==0` as an error case does not look right (`writePayload` never produces an empty non-nil `operators`).
