### PR TITLE
CNTRLPLANE-371: oc idle: Use endpointslice instead of deprecated endpoints

### DIFF
--- a/pkg/cli/idle/idle_test.go
+++ b/pkg/cli/idle/idle_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"testing"
 
+	v1 "k8s.io/api/discovery/v1"
+
 	unidlingapi "github.com/openshift/api/unidling/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
@@ -58,49 +60,35 @@ func makeRCRef(name string) *metav1.OwnerReference {
 }
 
 func TestFindIdlablesForEndpoints(t *testing.T) {
-	endpoints := &corev1.Endpoints{
-		Subsets: []corev1.EndpointSubset{
+	endpoints := &v1.EndpointSlice{
+		Endpoints: []v1.Endpoint{
 			{
-				Addresses: []corev1.EndpointAddress{
-					{
-						TargetRef: makePodRef("somepod1", "somens1"),
-					},
-					{
-						TargetRef: makePodRef("somepod2", "somens1"),
-					},
-					{
-						TargetRef: &corev1.ObjectReference{
-							Kind:      "Cheese",
-							Name:      "cheddar",
-							Namespace: "somens",
-						},
-					},
+				TargetRef: makePodRef("somepod1", "somens1"),
+			},
+			{
+				TargetRef: makePodRef("somepod2", "somens1"),
+			},
+			{
+				TargetRef: &corev1.ObjectReference{
+					Kind:      "Cheese",
+					Name:      "cheddar",
+					Namespace: "somens",
 				},
 			},
 			{
-				Addresses: []corev1.EndpointAddress{
-					{},
-					{
-						TargetRef: makePodRef("somepod3", "somens1"),
-					},
-					{
-						TargetRef: makePodRef("somepod4", "somens1"),
-					},
-					{
-						TargetRef: makePodRef("somepod5", "somens1"),
-					},
-					{
-						TargetRef: makePodRef("missingpod", "somens1"),
-					},
-				},
+				TargetRef: makePodRef("somepod3", "somens1"),
 			},
 			{
-				Addresses: []corev1.EndpointAddress{
-					{},
-					{
-						TargetRef: makePodRef("somepod1", "somens2"),
-					},
-				},
+				TargetRef: makePodRef("somepod4", "somens1"),
+			},
+			{
+				TargetRef: makePodRef("somepod5", "somens1"),
+			},
+			{
+				TargetRef: makePodRef("missingpod", "somens1"),
+			},
+			{
+				TargetRef: makePodRef("somepod1", "somens2"),
 			},
 		},
 	}


### PR DESCRIPTION
`endpoints` resource has been deprecated and `endpointslices` is the recommended resource instead. `oc idle` command heavily relies on endpoints and this PR switches it to endpointslices to unblock 1.33 rebasing process.

This PR should not have any functional changes.