### PR TITLE
OCPBUGS-53106: Get installer image from configMap for node-image command

### DIFF
--- a/pkg/cli/admin/nodeimage/mirrorbuilder.go
+++ b/pkg/cli/admin/nodeimage/mirrorbuilder.go
@@ -1,0 +1,75 @@
+package nodeimage
+
+import (
+	"fmt"
+	"io"
+
+	ocpv1 "github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+)
+
+func getIdmsContents(writer io.Writer, idmsMirrorSetList *ocpv1.ImageDigestMirrorSetList, icspMirrorSetList *ocpv1.ImageContentPolicyList) ([]byte, error) {
+	imageDigestSet := ocpv1.ImageDigestMirrorSet{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: ocpv1.GroupVersion.String(),
+			Kind:       "ImageDigestMirrorSet",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "image-digest",
+			// not namespaced
+		},
+	}
+
+	// Add mirrors from IDMS
+	if idmsMirrorSetList != nil {
+		log(writer, "Adding mirrors from ImageDigestMirrors")
+		for _, idms := range idmsMirrorSetList.Items {
+			for _, digestMirror := range idms.Spec.ImageDigestMirrors {
+				imageDigestSet.Spec.ImageDigestMirrors = append(imageDigestSet.Spec.ImageDigestMirrors, digestMirror)
+			}
+		}
+	}
+
+	// Add mirrors from ICSP
+	if icspMirrorSetList != nil {
+		log(writer, "Adding mirrors from ImageContentPolicies")
+		for _, icsp := range icspMirrorSetList.Items {
+			for _, digestMirror := range icsp.Spec.RepositoryDigestMirrors {
+				// Skip adding the mirror if the source already exists
+				if digestSourceExists(imageDigestSet.Spec.ImageDigestMirrors, digestMirror.Source) {
+					continue
+				}
+				mirror := ocpv1.ImageDigestMirrors{
+					Source: digestMirror.Source,
+				}
+				for _, m := range digestMirror.Mirrors {
+					mirror.Mirrors = append(mirror.Mirrors, ocpv1.ImageMirror(m))
+				}
+				imageDigestSet.Spec.ImageDigestMirrors = append(imageDigestSet.Spec.ImageDigestMirrors, mirror)
+			}
+		}
+	}
+
+	contents, err := yaml.Marshal(imageDigestSet)
+	if err != nil {
+		return nil, err
+	}
+
+	return contents, nil
+}
+
+func digestSourceExists(mirrors []ocpv1.ImageDigestMirrors, source string) bool {
+	for _, mirror := range mirrors {
+		if mirror.Source == source {
+			return true
+		}
+	}
+	return false
+}
+
+func log(writer io.Writer, format string, a ...interface{}) {
+	if writer != nil {
+		fmt.Fprintf(writer, format+"\n", a...)
+	}
+}

--- a/pkg/cli/admin/nodeimage/mirrorbuilder_test.go
+++ b/pkg/cli/admin/nodeimage/mirrorbuilder_test.go
@@ -1,0 +1,187 @@
+package nodeimage
+
+import (
+	"reflect"
+	"testing"
+
+	ocpv1 "github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var defaultIdmsSetList = ocpv1.ImageDigestMirrorSetList{
+	TypeMeta: metav1.TypeMeta{},
+	ListMeta: metav1.ListMeta{
+		ResourceVersion: "15",
+	},
+	Items: []ocpv1.ImageDigestMirrorSet{
+		{
+			TypeMeta:   metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{Name: "image-digest-mirror", Namespace: "test"},
+			Spec: ocpv1.ImageDigestMirrorSetSpec{
+				ImageDigestMirrors: []ocpv1.ImageDigestMirrors{
+					{
+						Source: "quay.io/openshift-release-dev/ocp-v4.0-art-dev",
+						Mirrors: []ocpv1.ImageMirror{
+							"virthost.test:5000/localimages/local-release-image",
+						},
+					},
+					{
+						Source: "registry.ci.openshift.org/ocp/release",
+						Mirrors: []ocpv1.ImageMirror{
+							"virthost.test:5000/localimages/local-dev",
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+var defaultIdms = `apiVersion: config.openshift.io/v1
+kind: ImageDigestMirrorSet
+metadata:
+  creationTimestamp: null
+  name: image-digest
+spec:
+  imageDigestMirrors:
+  - mirrors:
+    - virthost.test:5000/localimages/local-release-image
+    source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+  - mirrors:
+    - virthost.test:5000/localimages/local-dev
+    source: registry.ci.openshift.org/ocp/release
+status: {}
+`
+
+var defaultIcspList = ocpv1.ImageContentPolicyList{
+	TypeMeta: metav1.TypeMeta{},
+	ListMeta: metav1.ListMeta{
+		ResourceVersion: "15",
+	},
+	Items: []ocpv1.ImageContentPolicy{
+		{
+			TypeMeta:   metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{Name: "image-policy", Namespace: "test"},
+			Spec: ocpv1.ImageContentPolicySpec{
+				RepositoryDigestMirrors: []ocpv1.RepositoryDigestMirrors{
+					{
+						Source: "quay.io/openshift-release-dev/ocp-v4.0-art-dev",
+						Mirrors: []ocpv1.Mirror{
+							"virthost.test:5000/localimages/local-release-image",
+						},
+					},
+					{
+						Source: "registry.ci.openshift.org/ocp/release",
+						Mirrors: []ocpv1.Mirror{
+							"virthost.test:5000/localimages/local-dev",
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+var icspListDifferentThanIdms = ocpv1.ImageContentPolicyList{
+	TypeMeta: metav1.TypeMeta{},
+	ListMeta: metav1.ListMeta{
+		ResourceVersion: "15",
+	},
+	Items: []ocpv1.ImageContentPolicy{
+		{
+			TypeMeta:   metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{Name: "image-policy", Namespace: "test"},
+			Spec: ocpv1.ImageContentPolicySpec{
+				RepositoryDigestMirrors: []ocpv1.RepositoryDigestMirrors{
+					{
+						Source: "example.com/ocp-v4.0-art-dev",
+						Mirrors: []ocpv1.Mirror{
+							"localimages/local-release-image",
+						},
+					},
+					{
+						Source: "example.com/ocp/release",
+						Mirrors: []ocpv1.Mirror{
+							"localimages/local-dev",
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+var icspPlusIdms = `apiVersion: config.openshift.io/v1
+kind: ImageDigestMirrorSet
+metadata:
+  creationTimestamp: null
+  name: image-digest
+spec:
+  imageDigestMirrors:
+  - mirrors:
+    - virthost.test:5000/localimages/local-release-image
+    source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+  - mirrors:
+    - virthost.test:5000/localimages/local-dev
+    source: registry.ci.openshift.org/ocp/release
+  - mirrors:
+    - localimages/local-release-image
+    source: example.com/ocp-v4.0-art-dev
+  - mirrors:
+    - localimages/local-dev
+    source: example.com/ocp/release
+status: {}
+`
+
+func TestGetIdmsContents(t *testing.T) {
+	testCases := []struct {
+		name          string
+		idmsSetList   *ocpv1.ImageDigestMirrorSetList
+		icspSetList   *ocpv1.ImageContentPolicyList
+		expectedIdms  []byte
+		expectedError string
+	}{
+		{
+			name:         "IDMS Only mirrors",
+			idmsSetList:  &defaultIdmsSetList,
+			icspSetList:  nil,
+			expectedIdms: []byte(defaultIdms),
+		},
+		{
+			name:         "ICSP Only mirrors",
+			idmsSetList:  nil,
+			icspSetList:  &defaultIcspList,
+			expectedIdms: []byte(defaultIdms),
+		},
+		{
+			name:         "IDMS and ICSP mirrors the same",
+			idmsSetList:  &defaultIdmsSetList,
+			icspSetList:  &defaultIcspList,
+			expectedIdms: []byte(defaultIdms),
+		},
+		{
+			name:         "IDMS and ICSP mirrors are different",
+			idmsSetList:  &defaultIdmsSetList,
+			icspSetList:  &icspListDifferentThanIdms,
+			expectedIdms: []byte(icspPlusIdms),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			idmsContents, err := getIdmsContents(nil, tc.idmsSetList, tc.icspSetList)
+
+			if tc.expectedError == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if !reflect.DeepEqual(tc.expectedIdms, idmsContents) {
+					t.Errorf("Expected:\n%s\ngot:\n%s", tc.expectedIdms, idmsContents)
+				}
+			} else {
+				if err == nil {
+					t.Fatalf("expected error not received: %s", tc.expectedError)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
In order to handle disconnected environments for the node-image command, get the installer image from the configMap created by the installer instead of extracting it from the releaseImage.