### PR TITLE
COS-3023: Fixing rpmdiff permissions when running in container

### DIFF
--- a/pkg/cli/image/extract/extract.go
+++ b/pkg/cli/image/extract/extract.go
@@ -642,6 +642,8 @@ func (_ removePermissions) Alter(hdr *tar.Header) (bool, error) {
 	default:
 		hdr.Mode = int64(os.FileMode(0755))
 	}
+	hdr.Xattrs = map[string]string{}
+	hdr.PAXRecords = map[string]string{}
 	return true, nil
 }
 


### PR DESCRIPTION
When the original PR (#1966) merged, we started to get the following error:
```
I0407 12:45:14.563409       1 release_info.go:369] Failed to generate RPM diff: exit status 1
$ /usr/bin/oc adm release info --rpmdb-cache=/tmp/rpmdb/ --output=json --rpmdb-diff quay.io/openshift-release-dev/ocp-release@sha256:3c7decd8e09329d5206a96bcc19838d25bdc3af9c9565f249aa91494c7beb7db quay.io/openshift-release-dev/ocp-release@sha256:1e9baecce90105b4c0aa695dadc2fac7e4b9fd54e0d2ede90e143e57df8e424a
error: fetching rpmdb for from image: downloading quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:8fac1110def727105bd11bbf49fef58072b970d40e9e55e5a645fcc54e00610a: unable to extract layer sha256:92aa75b30536c7a6425569a089281f13e3a280359eca40c2ed0cfa33c5a24134 from quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:8fac1110def727105bd11bbf49fef58072b970d40e9e55e5a645fcc54e00610a: lsetxattr security.capability /tmp/rpmdb/sha256_8fac1110def727105bd11bbf49fef58072b970d40e9e55e5a645fcc54e00610a.work/sysroot/ostree/repo/objects/11/cc090cce85c1508d0f575003cba646f3eea42638697f3b79c6a00910d3c3f6.file: operation not permitted
```
@jlebon recommended a potential fix for the problem.  I was able to make the changes, build, and verify that they work in the exact same environment that produced the failure above.
Output from my updated container:
```
sh-5.2# /usr/bin/oc adm release info --rpmdb-cache=/tmp/rpmdb/ --output=json --rpmdb-diff quay.io/openshift-release-dev/ocp-release:4.19.0-ec.4-x86_64 quay.io/openshift-release-dev/ocp-release:4.19.0-ec.3-x86_64                         
{
  "changed": {
    "NetworkManager": {
      "old": "1:1.52.0-1.el9_6",
      "new": "1:1.51.90-2.el9"
    },
    "NetworkManager-cloud-setup": {
      "old": "1:1.52.0-1.el9_6",
      "new": "1:1.51.90-2.el9"
    },
    "NetworkManager-libnm": {
      "old": "1:1.52.0-1.el9_6",
      "new": "1:1.51.90-2.el9"
    },
    "NetworkManager-ovs": {
      "old": "1:1.52.0-1.el9_6",
      "new": "1:1.51.90-2.el9"
    },
    "NetworkManager-team": {
      "old": "1:1.52.0-1.el9_6",
      "new": "1:1.51.90-2.el9"
    },
    "NetworkManager-tui": {
      "old": "1:1.52.0-1.el9_6",
      "new": "1:1.51.90-2.el9"
    },
    "binutils": {
      "old": "2.35.2-63.el9",
      "new": "2.35.2-60.el9"
    },
    "binutils-gold": {
      "old": "2.35.2-63.el9",
      "new": "2.35.2-60.el9"
    },
    "bootc": {
      "old": "1.1.6-3.el9_6",
      "new": "1.1.5-1.el9"
    },
    "containers-common": {
      "old": "2:1-117.el9_6",
      "new": "2:1-114.el9"
    },
    "cri-o": {
      "old": "1.32.2-6.rhaos4.19.gitf7c1f5b.el9",
      "new": "1.32.2-2.rhaos4.19.git318db72.el9"
    },
    "dracut": {
      "old": "057-87.git20250311.el9_6",
      "new": "057-86.git20250217.el9"
    },
    "dracut-network": {
      "old": "057-87.git20250311.el9_6",
      "new": "057-86.git20250217.el9"
    },
    "dracut-squash": {
      "old": "057-87.git20250311.el9_6",
      "new": "057-86.git20250217.el9"
    },
    "grub2-common": {
      "old": "1:2.06-101.el9_6",
      "new": "1:2.06-94.el9"
    },
    "grub2-efi-x64": {
      "old": "1:2.06-101.el9_6",
      "new": "1:2.06-94.el9"
    },
    "grub2-pc": {
      "old": "1:2.06-101.el9_6",
      "new": "1:2.06-94.el9"
    },
    "grub2-pc-modules": {
      "old": "1:2.06-101.el9_6",
      "new": "1:2.06-94.el9"
    },
    "grub2-tools": {
      "old": "1:2.06-101.el9_6",
      "new": "1:2.06-94.el9"
    },
    "grub2-tools-minimal": {
      "old": "1:2.06-101.el9_6",
      "new": "1:2.06-94.el9"
    },
    "kernel": {
      "old": "5.14.0-570.9.1.el9_6",
      "new": "5.14.0-570.el9"
    },
    "kernel-core": {
      "old": "5.14.0-570.9.1.el9_6",
      "new": "5.14.0-570.el9"
    },
    "kernel-modules": {
      "old": "5.14.0-570.9.1.el9_6",
      "new": "5.14.0-570.el9"
    },
    "kernel-modules-core": {
      "old": "5.14.0-570.9.1.el9_6",
      "new": "5.14.0-570.el9"
    },
    "kernel-modules-extra": {
      "old": "5.14.0-570.9.1.el9_6",
      "new": "5.14.0-570.el9"
    },
    "libxslt": {
      "old": "1.1.34-10.el9_6",
      "new": "1.1.34-9.el9"
    },
    "linux-firmware": {
      "old": "20250314-151.el9_6",
      "new": "20250212-150.el9"
    },
    "linux-firmware-whence": {
      "old": "20250314-151.el9_6",
      "new": "20250212-150.el9"
    },
    "nmstate": {
      "old": "2.2.41-1.el9_6",
      "new": "2.2.40-1.el9"
    },
    "openshift-clients": {
      "old": "4.19.0-202503211410.p0.g33cbfe1.assembly.stream.el9",
      "new": "4.19.0-202503032209.p0.ge7e738c.assembly.stream.el9"
    },
    "openshift-kubelet": {
      "old": "4.19.0-202503250607.p0.gd365efd.assembly.stream.el9",
      "new": "4.19.0-202502280209.p0.gc3a6a36.assembly.stream.el9"
    },
    "ose-aws-ecr-image-credential-provider": {
      "old": "4.19.0-202503041513.p0.g425c1c5.assembly.stream.el9",
      "new": "4.19.0-202502260909.p0.g425c1c5.assembly.stream.el9"
    },
    "ose-azure-acr-image-credential-provider": {
      "old": "4.19.0-202503051509.p0.gcc04736.assembly.stream.el9",
      "new": "4.19.0-202502261109.p0.g2e732f8.assembly.stream.el9"
    },
    "ose-gcp-gcr-image-credential-provider": {
      "old": "4.19.0-202503041513.p0.gd8d3aeb.assembly.stream.el9",
      "new": "4.19.0-202502260909.p0.gd8d3aeb.assembly.stream.el9"
    },
    "redhat-release": {
      "old": "9.6-0.1.el9",
      "new": "9.6-0.0.el9"
    },
    "redhat-release-eula": {
      "old": "9.6-0.1.el9",
      "new": "9.6-0.0.el9"
    },
    "selinux-policy": {
      "old": "38.1.53-4.el9_6",
      "new": "38.1.53-2.el9"
    },
    "selinux-policy-targeted": {
      "old": "38.1.53-4.el9_6",
      "new": "38.1.53-2.el9"
    }
  }
}
```
This PR contains the recommended changes