### PR TITLE
OCPBUGS-52164: Add the generation of initrd.addrsize and generic.ins file for ABI Day2 Artifacts

### DIFF
--- a/pkg/cli/admin/nodeimage/create.go
+++ b/pkg/cli/admin/nodeimage/create.go
@@ -381,7 +381,7 @@ func (o *CreateOptions) copyArtifactsFromNodeJoinerPod() error {
 	}
 	if o.GeneratePXEFiles {
 		rsyncOptions.Source.Path = "/assets/boot-artifacts/"
-		rsyncOptions.RsyncInclude = []string{"*.img", "*.*vmlinuz", "*.ipxe"}
+		rsyncOptions.RsyncInclude = []string{"*.img", "*.*vmlinuz", "*.ipxe", "*.ins", "*.addrsize"}
 		logMessage = "Saving PXE artifacts to %s"
 	}
 	rsyncOptions.Strategy = o.copyStrategy(rsyncOptions)


### PR DESCRIPTION
This PR introduces a conditional filter to include .ins and .addrsize PXE artifacts only when the target CPU architecture is s390x during ABI-based Day-2 node image creation using oc adm node-image create.

Changes:

Updated the create.go logic to check for s390x CPU architecture before including:
*.ins
*.addrsize

Testing
Tested by:
Running the oc adm node-image create for s390x and verified only s390x-relevant PXE files are generated.
Ensured no regression on other platforms — .ins and .addrsize are excluded when architecture is not s390x.