### PR TITLE
CORENET-5412: adm, inspect, ns: Collect UserDefinedNetwork CRs

### DIFF
--- a/pkg/cli/admin/inspect/namespace.go
+++ b/pkg/cli/admin/inspect/namespace.go
@@ -31,6 +31,7 @@ func namespaceResourcesToCollect() []schema.GroupResource {
 		{Resource: "poddisruptionbudgets"},
 		{Resource: "secrets"},
 		{Resource: "servicemonitors"},
+		{Resource: "userdefinednetworks"},
 	}
 }
 


### PR DESCRIPTION
OVN-Kubernetes (OVN-K) UserDefinedNetwork (UDN) is namespace-scope CRD that allows non-admin users create OVN-K user-defined networks w/o a cluster-admin intervention.

Collect UDN CRs to allow troubleshooting them.