### PR TITLE
OCPBUGS-56598: pkg/cli/admin/mustgather: Include ClusterVersion in fallback inspect

### DIFF
--- a/pkg/cli/admin/mustgather/mustgather.go
+++ b/pkg/cli/admin/mustgather/mustgather.go
@@ -1061,27 +1061,47 @@ func (o *MustGatherOptions) newPod(node, image string, hasMaster bool) *corev1.P
 // BackupGathering is called if the full must-gather has an error.  This is useful for making sure we get *something*
 // no matter what has failed.  It should be focused on universal openshift failures.
 func (o *MustGatherOptions) BackupGathering(ctx context.Context, errs []error) {
+	typeTargets := strings.Join([]string{
+		"clusterversion.v1.config.openshift.io",
+		"clusteroperators.v1.config.openshift.io",
+	}, ",")
+	namedTargets := []string{
+		"namespace/openshift-cluster-version",
+	}
+
 	fmt.Fprintf(o.ErrOut, "\n\n") // Space out the output
 	fmt.Fprintf(o.ErrOut, "Error running must-gather collection:\n    %v\n\n", errors.NewAggregate(errs))
-	fmt.Fprintf(o.ErrOut, "Falling back to `oc adm inspect clusteroperators.v1.config.openshift.io` to collect basic cluster information.\n")
+	fmt.Fprintf(o.ErrOut, "Falling back to `oc adm inspect %s` to collect basic cluster types.\n", typeTargets)
 
 	streams := o.IOStreams
 	streams.Out = o.newPrefixWriter(streams.Out, fmt.Sprintf("[must-gather      ] OUT"), false, true)
+	destDir := path.Join(o.DestDir, fmt.Sprintf("inspect.local.%06d", rand.Int63()))
 
+	if err := runInspect(streams, rest.CopyConfig(o.Config), destDir, []string{typeTargets}); err != nil {
+		fmt.Fprintf(o.ErrOut, "error completing cluster type inspection: %v\n", err)
+	}
+
+	fmt.Fprintf(o.ErrOut, "Falling back to `oc adm inspect %s` to collect basic cluster named resources.\n", strings.Join(namedTargets, " "))
+
+	if err := runInspect(streams, rest.CopyConfig(o.Config), destDir, namedTargets); err != nil {
+		fmt.Fprintf(o.ErrOut, "error completing cluster named resource inspection: %v\n", err)
+	}
+	return
+}
+
+func runInspect(streams genericiooptions.IOStreams, config *rest.Config, destDir string, arguments []string) error {
 	inspectOptions := inspect.NewInspectOptions(streams)
-	inspectOptions.RESTConfig = rest.CopyConfig(o.Config)
-	inspectOptions.DestDir = path.Join(o.DestDir, fmt.Sprintf("inspect.local.%06d", rand.Int63()))
+	inspectOptions.RESTConfig = config
+	inspectOptions.DestDir = destDir
 
-	if err := inspectOptions.Complete([]string{"clusteroperators.v1.config.openshift.io"}); err != nil {
-		fmt.Fprintf(o.ErrOut, "error completing backup collection: %v\n", err)
-		return
+	if err := inspectOptions.Complete(arguments); err != nil {
+		return fmt.Errorf("error completing backup collection: %w", err)
 	}
 	if err := inspectOptions.Validate(); err != nil {
-		fmt.Fprintf(o.ErrOut, "error validating backup collection: %v\n", err)
-		return
+		return fmt.Errorf("error validating backup collection: %w", err)
 	}
 	if err := inspectOptions.Run(); err != nil {
-		fmt.Fprintf(o.ErrOut, "error running backup collection: %v\n", err)
-		return
+		return fmt.Errorf("error running backup collection: %w", err)
 	}
+	return nil
 }


### PR DESCRIPTION
These are unlikely to be helpful in debugging why a must-gather attempt failed (for that, you'd need to capture the must-gather namespace before deleting it), but they do make the fallback inspect artifacts more useful for folks trying to understand the issue that caused them to want to must-gather (e.g. "why is my cluster stuck mid-update?").

I'm hard-coding the `openshift-cluster-version` namespace for now, but future ClusterVersion may grow a `status.relatedObjects` (as ClusterOperator already have), and at some point in the future that might make the hard-coded namespace redundant and drop-able.