### PR TITLE
OCPBUGS-56691: Rely on overall available disk space of the mounted volume

### DIFF
--- a/pkg/cli/admin/mustgather/mustgather.go
+++ b/pkg/cli/admin/mustgather/mustgather.go
@@ -141,7 +141,7 @@ func NewMustGatherOptions(streams genericiooptions.IOStreams) *MustGatherOptions
 		SourceDir:        "/must-gather/",
 		IOStreams:        streams,
 		Timeout:          10 * time.Minute,
-		VolumePercentage: 30,
+		VolumePercentage: 50,
 	}
 	opts.LogOut = opts.newPrefixWriter(streams.Out, "[must-gather      ] OUT", false, true)
 	opts.RawOut = opts.newPrefixWriter(streams.Out, "", false, false)


### PR DESCRIPTION
Previously volume size checker script in must-gather compares the usage of the given directory (`du -s`) against the full mounted disk size (`df -P`). This was correct assumption iff mounted volume is empty. 

However, in reality, all of the mounted volumes from a Node contains some data. So that `du -s` returns the size of collected must-gather output (e.g. 1KB). If we compare this value against the total volume size, this calculates the usage percentage to a very low value. However, EmptyDir's volume capacity might even be full.

This PR relies on the Capacity field of executed `df -P` command.

In second commit, there is also a minor change by using `node-role.kubernetes.io/control-plane` node selected instead of deprecated `node-role.kubernetes.io/master`.

In third commit, this PR increases the default value of volume-percentage to 50%. Because it is likely that nodes may suffer the relatively lower default value (i.e. 30%)