### PR TITLE
OCPBUGS-49897: avoid transfering permissions when copying artifacts from node-joiner pod

### DIFF
--- a/pkg/cli/admin/nodeimage/create.go
+++ b/pkg/cli/admin/nodeimage/create.go
@@ -378,6 +378,7 @@ func (o *CreateOptions) copyArtifactsFromNodeJoinerPod() error {
 		Quiet:         true,
 		RsyncInclude:  []string{"*.iso"},
 		RsyncExclude:  []string{"*"},
+		RsyncNoPerms:  true,
 	}
 	if o.GeneratePXEFiles {
 		rsyncOptions.Source.Path = "/assets/boot-artifacts/"

--- a/pkg/cli/admin/nodeimage/create_test.go
+++ b/pkg/cli/admin/nodeimage/create_test.go
@@ -309,6 +309,9 @@ func TestRun(t *testing.T) {
 				if fakeCp.options.Destination.Path != tc.assetsDir {
 					t.Errorf("expected %v, actual %v", fakeCp.options.Destination.Path, tc.assetsDir)
 				}
+				if fakeCp.options.RsyncNoPerms == false {
+					t.Errorf("RsyncNoPerms is disabled")
+				}
 			}
 
 			for _, ext := range tc.expectedRsyncInclude {


### PR DESCRIPTION
This patch addresses the https://issues.redhat.com/browse/OCPBUGS-49897 issue by disabling explicitly the rsync permissions transfer when copying the node-joiner pod artifacts to the configured destination folder.