### PR TITLE
OTA-1576: pkg/cli/admin/upgrade/recommend: Add a blank line after --version conditional risk

### DIFF
--- a/pkg/cli/admin/upgrade/recommend/recommend.go
+++ b/pkg/cli/admin/upgrade/recommend/recommend.go
@@ -343,9 +343,12 @@ func (o *options) Run(ctx context.Context) error {
 					}
 					unaccepted := issues.Difference(accept)
 					if unaccepted.Len() > 0 {
+						if !o.quiet {
+							fmt.Println(o.Out)
+						}
 						return fmt.Errorf("issues that apply to this cluster but which were not included in --accept: %s", strings.Join(sets.List(unaccepted), ","))
 					} else if issues.Len() > 0 && !o.quiet {
-						fmt.Fprintf(o.Out, "Update to %s has no known issues relevant to this cluster other than the accepted %s.\n", update.Release.Version, strings.Join(sets.List(issues), ","))
+						fmt.Fprintf(o.Out, "\nUpdate to %s has no known issues relevant to this cluster other than the accepted %s.\n", update.Release.Version, strings.Join(sets.List(issues), ","))
 					}
 					return nil
 				}


### PR DESCRIPTION
When I added the:

```
Update to 4.18.6 Recommended=False:
...
```

block in c1ef32845c (#1897), there was no subsequent output in this "`--version` has conditional risks" case, so the earlier lack-of-blank-line made sense.

But then 2d7e00420c (#2023) gave the option for a subsequent:

    error: issues that apply to this cluster but which were not included in --accept: ...

or:

    Update to %s has no known issues relevant...

This commit adds a new line to standard output, to offset those summaries from the possibly-long Message:

```
...
Update to 4.18.6 Recommended=False:
Image: quay.io/openshift-release-dev/ocp-release@sha256:61fdad894f035a8b192647c224faf565279518255bdbf60a91db4ee0479adaa6
Release URL: https://access.redhat.com/errata/RHSA-2025:3066
Reason: CRIOLayerCompressionPulls
Message: The CRI-O container runtime may fail to pull images with certain layer compression characteristics https://issues.redhat.com/browse/OCPNODE-3074

error: issues that apply to this cluster but which were not included in --accept: ConditionalUpdateRisk,KubeContainerWaiting
```

instead of cramming that `error: ...` or `... has no known issues...` right onto the end of the output.  Although the error is getting written to standard error instead of the standard output, so in that case, the newline will only matter for terminal users and others who are flattening those two streams together.