### PR TITLE
OCPSTRAT-2147: Upgrade to go 1.24 and OCP 4.20

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.23-openshift-4.19
+  tag: rhel-9-release-golang-1.24-openshift-4.20

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/oc
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/AaronO/go-git-http v0.0.0-20161214145340-1d9485b3a98f

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0
 	github.com/openshift/api v0.0.0-20250130025500-d9e1a2e1fe6b
-	github.com/openshift/build-machinery-go v0.0.0-20250102153059-e85a1a7ecb5c
+	github.com/openshift/build-machinery-go v0.0.0-20250602125535-1b6d00b8c37c
 	github.com/openshift/client-go v0.0.0-20250125113824-8e1f0b8fa9a7
 	github.com/openshift/library-go v0.0.0-20250218150059-017e5b6cf27c
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8

--- a/go.sum
+++ b/go.sum
@@ -491,8 +491,8 @@ github.com/opencontainers/selinux v1.11.0 h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaL
 github.com/opencontainers/selinux v1.11.0/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
 github.com/openshift/api v0.0.0-20250130025500-d9e1a2e1fe6b h1:6OdSvfIgEGZ4Oc4zmhcaCRGWeJHVvHc3fkoRckWYajQ=
 github.com/openshift/api v0.0.0-20250130025500-d9e1a2e1fe6b/go.mod h1:yk60tHAmHhtVpJQo3TwVYq2zpuP70iJIFDCmeKMIzPw=
-github.com/openshift/build-machinery-go v0.0.0-20250102153059-e85a1a7ecb5c h1:6XcszPFZpan4qll5XbdLll7n1So3IsPn28aw2j1obMo=
-github.com/openshift/build-machinery-go v0.0.0-20250102153059-e85a1a7ecb5c/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
+github.com/openshift/build-machinery-go v0.0.0-20250602125535-1b6d00b8c37c h1:gJvhduWIrpzoUTwrJjjeul+hGETKkhRhEZosBg/X3Hg=
+github.com/openshift/build-machinery-go v0.0.0-20250602125535-1b6d00b8c37c/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/openshift/client-go v0.0.0-20250125113824-8e1f0b8fa9a7 h1:4iliLcvr1P9EUMZgIaSNEKNQQzBn+L6PSequlFOuB6Q=
 github.com/openshift/client-go v0.0.0-20250125113824-8e1f0b8fa9a7/go.mod h1:2tcufBE4Cu6RNgDCxcUJepa530kGo5GFVfR9BSnndhI=
 github.com/openshift/gssapi v0.0.0-20161010215902-5fb4217df13b h1:it0YPE/evO6/m8t8wxis9KFI2F/aleOKsI6d9uz0cEk=

--- a/images/cli-artifacts/Dockerfile.rhel
+++ b/images/cli-artifacts/Dockerfile.rhel
@@ -1,16 +1,16 @@
 # This Dockerfile builds an image containing the Mac and Windows version of oc
 # layered on top of the Linux cli image.
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.23-openshift-4.19 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.24-openshift-4.20 AS builder
 WORKDIR /go/src/github.com/openshift/oc
 COPY . .
 RUN make cross-build --warn-undefined-variables
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder-rhel-9
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20 AS builder-rhel-9
 WORKDIR /go/src/github.com/openshift/oc
 COPY . .
 RUN make cross-build --warn-undefined-variables
 
-FROM registry.ci.openshift.org/ocp/4.19:cli
+FROM registry.ci.openshift.org/ocp/4.20:cli
 
 COPY --from=builder-rhel-9 /go/src/github.com/openshift/oc/_output/bin/ /usr/share/openshift/
 

--- a/images/cli/Dockerfile.rhel
+++ b/images/cli/Dockerfile.rhel
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20 AS builder
 WORKDIR /go/src/github.com/openshift/oc
 COPY . .
 RUN make build --warn-undefined-variables
 
-FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.20:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/oc/oc /usr/bin/
 RUN for i in kubectl openshift-deploy openshift-docker-build openshift-sti-build openshift-git-clone openshift-manage-dockerfile openshift-extract-image-content openshift-recycle; do ln -sf /usr/bin/oc /usr/bin/$i; done
 LABEL io.k8s.display-name="OpenShift Client" \

--- a/images/deployer/Dockerfile.rhel
+++ b/images/deployer/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/4.19:cli
+FROM registry.ci.openshift.org/ocp/4.20:cli
 
 LABEL io.k8s.display-name="OpenShift Deployer" \
       io.k8s.description="This is a component of OpenShift and executes the user deployment process to roll out new containers. It may be used as a base image for building your own custom deployer image." \

--- a/images/tools/Dockerfile
+++ b/images/tools/Dockerfile
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20 AS builder
 WORKDIR /go/src/github.com/openshift/oc
 COPY . .
 RUN make build --warn-undefined-variables
 
-FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.20:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/oc/oc /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/oc/images/tools/sos.conf /etc/sos/
 RUN for i in kubectl openshift-deploy openshift-docker-build openshift-sti-build openshift-git-clone openshift-manage-dockerfile openshift-extract-image-content openshift-recycle; do ln -sf /usr/bin/oc /usr/bin/$i; done

--- a/pkg/cli/admin/admin.go
+++ b/pkg/cli/admin/admin.go
@@ -1,8 +1,6 @@
 package admin
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	"k8s.io/cli-runtime/pkg/genericiooptions"
@@ -57,7 +55,7 @@ func NewCommandAdmin(f kcmdutil.Factory, streams genericiooptions.IOStreams) *co
 	cmds := &cobra.Command{
 		Use:   "adm",
 		Short: "Tools for managing a cluster",
-		Long:  fmt.Sprintf(adminLong),
+		Long:  adminLong,
 		Run:   kcmdutil.DefaultSubCommandRun(streams.ErrOut),
 	}
 

--- a/pkg/cli/admin/mustgather/summary.go
+++ b/pkg/cli/admin/mustgather/summary.go
@@ -25,7 +25,7 @@ import (
 // to one of those three spots.  Doing so improves the self-diagnosis capabilities of our platform and lets *every*
 // client benefit.
 func (o *MustGatherOptions) PrintBasicClusterState(ctx context.Context) {
-	fmt.Fprintf(o.RawOut, "When opening a support case, bugzilla, or issue please include the following summary data along with any other requested information:\n")
+	fmt.Fprint(o.RawOut, "When opening a support case, bugzilla, or issue please include the following summary data along with any other requested information:\n")
 
 	clusterVersion, err := o.ConfigClient.ConfigV1().ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
 	if err != nil {
@@ -44,11 +44,11 @@ func (o *MustGatherOptions) PrintBasicClusterState(ctx context.Context) {
 	if err != nil {
 		fmt.Fprintf(o.RawOut, "error getting cluster operators: %v\n", err)
 	}
-	fmt.Fprintf(o.RawOut, "ClusterOperators:\n")
-	fmt.Fprintf(o.RawOut, humanSummaryForInterestingClusterOperators(clusterOperators)+"\n")
+	fmt.Fprint(o.RawOut, "ClusterOperators:\n")
+	fmt.Fprint(o.RawOut, humanSummaryForInterestingClusterOperators(clusterOperators)+"\n")
 
 	// TODO gather and display firing alerts
-	fmt.Fprintf(o.RawOut, "\n\n")
+	fmt.Fprint(o.RawOut, "\n\n")
 }
 
 // longExistingOperators is a list of operators that should be present on every variant of every platform and have

--- a/pkg/cli/admin/ocpcertificates/ocp_certificates.go
+++ b/pkg/cli/admin/ocpcertificates/ocp_certificates.go
@@ -1,8 +1,6 @@
 package ocpcertificates
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	"k8s.io/cli-runtime/pkg/genericiooptions"
@@ -25,7 +23,7 @@ func NewCommandOCPCertificates(f kcmdutil.Factory, streams genericiooptions.IOSt
 	cmds := &cobra.Command{
 		Use:   "ocp-certificates",
 		Short: "Tools for managing a cluster's certificates",
-		Long:  fmt.Sprintf(ocpCertificatesLong),
+		Long:  ocpCertificatesLong,
 		Run:   kcmdutil.DefaultSubCommandRun(streams.ErrOut),
 	}
 

--- a/pkg/cli/admin/prune/auth/bindings.go
+++ b/pkg/cli/admin/prune/auth/bindings.go
@@ -36,7 +36,7 @@ func reapClusterBindings(removedSubject corev1.ObjectReference, c authv1client.A
 			if _, err := c.ClusterRoleBindings().Update(context.TODO(), &updatedBinding, metav1.UpdateOptions{}); err != nil && !kerrors.IsNotFound(err) {
 				errors = append(errors, err)
 			} else {
-				fmt.Fprintf(out, "clusterrolebinding.rbac.authorization.k8s.io/"+updatedBinding.Name+" updated\n")
+				fmt.Fprintf(out, "clusterrolebinding.rbac.authorization.k8s.io/%s updated\n", updatedBinding.Name)
 			}
 		}
 	}
@@ -65,7 +65,7 @@ func reapNamespacedBindings(removedSubject corev1.ObjectReference, c authv1clien
 			if _, err := c.RoleBindings(binding.Namespace).Update(context.TODO(), &updatedBinding, metav1.UpdateOptions{}); err != nil && !kerrors.IsNotFound(err) {
 				errors = append(errors, err)
 			} else {
-				fmt.Fprintf(out, "rolebinding.rbac.authorization.k8s.io/"+updatedBinding.Name+" updated\n")
+				fmt.Fprintf(out, "rolebinding.rbac.authorization.k8s.io/%s updated\n", updatedBinding.Name)
 			}
 		}
 	}

--- a/pkg/cli/admin/prune/auth/cluster_role.go
+++ b/pkg/cli/admin/prune/auth/cluster_role.go
@@ -23,7 +23,7 @@ func reapForClusterRole(clusterBindingClient rbacv1client.ClusterRoleBindingsGet
 			if err := clusterBindingClient.ClusterRoleBindings().Delete(context.TODO(), clusterBinding.Name, metav1.DeleteOptions{}); err != nil && !kerrors.IsNotFound(err) {
 				errors = append(errors, err)
 			} else {
-				fmt.Fprintf(out, "clusterrolebinding.rbac.authorization.k8s.io/"+clusterBinding.Name+" deleted\n")
+				fmt.Fprintf(out, "clusterrolebinding.rbac.authorization.k8s.io/%s deleted\n", clusterBinding.Name)
 			}
 		}
 	}
@@ -37,7 +37,7 @@ func reapForClusterRole(clusterBindingClient rbacv1client.ClusterRoleBindingsGet
 			if err := bindingClient.RoleBindings(namespacedBinding.Namespace).Delete(context.TODO(), namespacedBinding.Name, metav1.DeleteOptions{}); err != nil && !kerrors.IsNotFound(err) {
 				errors = append(errors, err)
 			} else {
-				fmt.Fprintf(out, "rolebinding.rbac.authorization.k8s.io/"+namespacedBinding.Name+" deleted\n")
+				fmt.Fprintf(out, "rolebinding.rbac.authorization.k8s.io/%s deleted\n", namespacedBinding.Name)
 			}
 		}
 	}

--- a/pkg/cli/admin/prune/auth/group.go
+++ b/pkg/cli/admin/prune/auth/group.go
@@ -44,7 +44,7 @@ func reapForGroup(
 			if _, err := securityClient.Update(context.TODO(), &updatedSCC, metav1.UpdateOptions{}); err != nil && !kerrors.IsNotFound(err) {
 				errors = append(errors, err)
 			} else {
-				fmt.Fprintf(out, "securitycontextconstraints.security.openshift.io/"+updatedSCC.Name+" updated\n")
+				fmt.Fprintf(out, "securitycontextconstraints.security.openshift.io/%s updated\n", updatedSCC.Name)
 			}
 		}
 	}

--- a/pkg/cli/admin/prune/auth/role.go
+++ b/pkg/cli/admin/prune/auth/role.go
@@ -24,7 +24,7 @@ func reapForRole(bindingClient rbacv1client.RoleBindingsGetter, namespace, name 
 			if err := bindingClient.RoleBindings(namespace).Delete(context.TODO(), binding.Name, metav1.DeleteOptions{PropagationPolicy: &foreground}); err != nil && !kerrors.IsNotFound(err) {
 				errors = append(errors, err)
 			} else {
-				fmt.Fprintf(out, "rolebinding.rbac.authorization.k8s.io/"+binding.Name+" deleted\n")
+				fmt.Fprintf(out, "rolebinding.rbac.authorization.k8s.io/%s deleted\n", binding.Name)
 			}
 		}
 	}

--- a/pkg/cli/admin/prune/auth/user.go
+++ b/pkg/cli/admin/prune/auth/user.go
@@ -48,7 +48,7 @@ func reapForUser(
 			if _, err := securityClient.Update(context.TODO(), &updatedSCC, metav1.UpdateOptions{}); err != nil && !kerrors.IsNotFound(err) {
 				errors = append(errors, err)
 			} else {
-				fmt.Fprintf(out, "securitycontextconstraints.security.openshift.io/"+updatedSCC.Name+" updated\n")
+				fmt.Fprintf(out, "securitycontextconstraints.security.openshift.io/%s updated\n", updatedSCC.Name)
 			}
 		}
 	}
@@ -71,7 +71,7 @@ func reapForUser(
 			if _, err := userClient.Groups().Update(context.TODO(), &updatedGroup, metav1.UpdateOptions{}); err != nil && !kerrors.IsNotFound(err) {
 				errors = append(errors, err)
 			} else {
-				fmt.Fprintf(out, "group.user.openshift.io/"+updatedGroup.Name+" updated\n")
+				fmt.Fprintf(out, "group.user.openshift.io/%s updated\n", updatedGroup.Name)
 			}
 		}
 	}
@@ -88,7 +88,7 @@ func reapForUser(
 			if err := oauthClient.OAuthClientAuthorizations().Delete(context.TODO(), authorization.Name, metav1.DeleteOptions{}); err != nil && !kerrors.IsNotFound(err) {
 				errors = append(errors, err)
 			} else {
-				fmt.Fprintf(out, "oauthclientauthorization.oauth.openshift.io/"+authorization.Name+" updated\n")
+				fmt.Fprintf(out, "oauthclientauthorization.oauth.openshift.io/%s updated\n", authorization.Name)
 			}
 		}
 	}

--- a/pkg/cli/admin/prune/imageprune/prune.go
+++ b/pkg/cli/admin/prune/imageprune/prune.go
@@ -3,6 +3,7 @@ package imageprune
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -1368,7 +1369,7 @@ func deleteFromRegistry(registryClient *http.Client, url string) error {
 	// non-2xx/3xx response doesn't cause an error, so we need to check for it
 	// manually and return it to caller
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusBadRequest {
-		return fmt.Errorf(resp.Status)
+		return errors.New(resp.Status)
 	}
 
 	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusAccepted {

--- a/pkg/cli/admin/release/extract_tools.go
+++ b/pkg/cli/admin/release/extract_tools.go
@@ -804,7 +804,7 @@ func (o *ExtractOptions) extractCommand(command string) error {
 					if err != nil {
 						return false, err
 					}
-					if _, err := fmt.Fprintf(fw, text); err != nil {
+					if _, err := fmt.Fprint(fw, text); err != nil {
 						return false, err
 					}
 				}
@@ -843,7 +843,7 @@ func (o *ExtractOptions) extractCommand(command string) error {
 					}); err != nil {
 						return false, err
 					}
-					if _, err := fmt.Fprintf(tw, text); err != nil {
+					if _, err := fmt.Fprint(tw, text); err != nil {
 						return false, err
 					}
 				}
@@ -964,7 +964,7 @@ func (o *ExtractOptions) extractCommand(command string) error {
 
 	if willArchive {
 		buf := &bytes.Buffer{}
-		fmt.Fprintf(buf, heredoc.Doc(`
+		fmt.Fprint(buf, heredoc.Doc(`
 			Client tools for OpenShift
 			--------------------------
 

--- a/pkg/cli/admin/release/git.go
+++ b/pkg/cli/admin/release/git.go
@@ -206,7 +206,7 @@ func gitOutputToError(err error, out string) error {
 	if len(out) == 0 {
 		return err
 	}
-	return fmt.Errorf(out)
+	return errors.New(out)
 }
 
 var (

--- a/pkg/cli/admin/release/info.go
+++ b/pkg/cli/admin/release/info.go
@@ -6,7 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	stderrors "errors"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -33,7 +33,7 @@ import (
 	"k8s.io/client-go/transport"
 	"k8s.io/klog/v2"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	kapierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/duration"
@@ -335,7 +335,7 @@ func replaceClusterSemanticArgs(f kcmdutil.Factory, args []string, semanticArgs 
 	}
 	cv, err := client.ConfigV1().ClusterVersions().Get(context.TODO(), "version", metav1.GetOptions{})
 	if err != nil {
-		if errors.IsNotFound(err) || errors.ReasonForError(err) == metav1.StatusReasonUnknown {
+		if kapierrors.IsNotFound(err) || kapierrors.ReasonForError(err) == metav1.StatusReasonUnknown {
 			klog.V(2).Infof("Unable to find cluster version object from cluster: %v", err)
 			return args, fmt.Errorf("info expects one argument, or a connection to an OpenShift 4.x server")
 		}
@@ -1840,7 +1840,7 @@ func describeChangelog(out, errOut io.Writer, releaseInfo *ReleaseInfo, diff *Re
 		fmt.Fprintln(out, string(data))
 
 	default:
-		fmt.Fprintf(out, heredoc.Docf(`
+		fmt.Fprint(out, heredoc.Docf(`
 		# %s
 
 		Created: %s
@@ -2297,7 +2297,7 @@ func (o *InfoOptions) downloadRpmdb(image imagereference.DockerImageReference, d
 	defer func() {
 		if tmperr := os.RemoveAll(tmpDir); tmperr != nil {
 			tmperr = fmt.Errorf("nuking %s: %v", tmpDir, tmperr)
-			err = stderrors.Join(err, tmperr)
+			err = errors.Join(err, tmperr)
 			return
 		}
 	}()
@@ -2386,7 +2386,7 @@ func rpmdbToMetalayerMetadata(dir string, outfile string) error {
 	}
 
 	if rpmdbPath == "" {
-		return stderrors.New("no rpmdb found in image")
+		return errors.New("no rpmdb found in image")
 	}
 
 	var out bytes.Buffer

--- a/pkg/cli/config/refreshcabundle/refresh_ca_bundle.go
+++ b/pkg/cli/config/refreshcabundle/refresh_ca_bundle.go
@@ -139,7 +139,7 @@ func (r *RefreshCABundleRuntime) Run(ctx context.Context) error {
 	}
 
 	if r.DryRun {
-		fmt.Fprintf(r.Out, caBundle)
+		fmt.Fprint(r.Out, caBundle)
 		return nil
 	}
 

--- a/pkg/cli/debug/debug.go
+++ b/pkg/cli/debug/debug.go
@@ -2,6 +2,7 @@ package debug
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -610,7 +611,7 @@ func (o *DebugOptions) RunDebug() error {
 			if len(o.NodeName) > 0 {
 				msg += fmt.Sprintf(" on node %q", o.NodeName)
 			}
-			return fmt.Errorf(msg)
+			return errors.New(msg)
 			// switch to logging output
 		case err == krun.ErrPodCompleted, err == conditions.ErrContainerTerminated:
 			resultPod, ok := containerRunningEvent.Object.(*corev1.Pod)
@@ -624,7 +625,7 @@ func (o *DebugOptions) RunDebug() error {
 						if len(o.NodeName) > 0 {
 							msg += fmt.Sprintf(" on node %q", o.NodeName)
 						}
-						return fmt.Errorf(msg)
+						return errors.New(msg)
 					}
 				}
 			}

--- a/pkg/cli/deployer/strategy/support/lifecycle.go
+++ b/pkg/cli/deployer/strategy/support/lifecycle.go
@@ -2,6 +2,7 @@ package support
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -325,7 +326,7 @@ func (e *hookExecutor) executeExecNewPod(hook *appsv1.LifecycleHook, rc *corev1.
 	wg.Wait()
 	if updatedPod.Status.Phase == corev1.PodFailed {
 		fmt.Fprintf(e.out, "--> %s: Failed\n", label)
-		return fmt.Errorf(updatedPod.Status.Message)
+		return errors.New(updatedPod.Status.Message)
 	}
 	// Only show this message if we created the pod ourselves, or we saw
 	// the pod in a running or pending state.

--- a/pkg/cli/extract/extract.go
+++ b/pkg/cli/extract/extract.go
@@ -186,7 +186,7 @@ func (o *ExtractOptions) Run() error {
 			}
 		}
 		if len(errs) > 0 {
-			return fmt.Errorf(kcmdutil.MultipleErrors("error: ", errs))
+			return errors.New(kcmdutil.MultipleErrors("error: ", errs))
 		}
 		return nil
 	})

--- a/pkg/cli/login/loginoptions.go
+++ b/pkg/cli/login/loginoptions.go
@@ -134,9 +134,8 @@ func (o *LoginOptions) getClientConfig() (*restclient.Config, error) {
 		// we need to have a server to talk to
 		if printers.IsTerminal(o.In) {
 			for !o.serverProvided() {
-				defaultServer := defaultClusterURL
-				promptMsg := fmt.Sprintf("Server [%s]: ", defaultServer)
-				o.Server = term.PromptForStringWithDefault(o.In, o.Out, defaultServer, promptMsg)
+				o.Server = term.PromptForStringWithDefault(
+					o.In, o.Out, defaultClusterURL, "Server [%s]: ", defaultClusterURL)
 			}
 		}
 	}
@@ -452,7 +451,7 @@ func (o *LoginOptions) gatherProjectInfo() error {
 			return err
 		}
 		msg := ocerrors.NoProjectsExistMessage(canRequest)
-		fmt.Fprintf(o.Out, msg)
+		fmt.Fprint(o.Out, msg)
 		o.Project = ""
 
 	case 1:
@@ -554,7 +553,7 @@ func (o *LoginOptions) SaveConfig() (bool, error) {
 		}
 
 		out := &bytes.Buffer{}
-		fmt.Fprintf(out, ocerrors.ErrKubeConfigNotWriteable(o.PathOptions.GetDefaultFilename(), o.PathOptions.IsExplicitFile(), err).Error())
+		fmt.Fprint(out, ocerrors.ErrKubeConfigNotWriteable(o.PathOptions.GetDefaultFilename(), o.PathOptions.IsExplicitFile(), err).Error())
 		return false, fmt.Errorf("%v", out)
 	}
 

--- a/pkg/cli/login/loginoptions_test.go
+++ b/pkg/cli/login/loginoptions_test.go
@@ -103,7 +103,7 @@ func TestTLSWithCertificateNotMatchingHostname(t *testing.T) {
 
 	server, err := newTLSServer(invalidHostCert, invalidHostKey)
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 	server.StartTLS()
 	defer server.Close()
@@ -182,7 +182,7 @@ func TestTLSWithExpiredCertificate(t *testing.T) {
 
 	server, err := newTLSServer(expiredCert, expiredKey)
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 	server.StartTLS()
 	defer server.Close()

--- a/pkg/cli/newapp/newapp.go
+++ b/pkg/cli/newapp/newapp.go
@@ -3,6 +3,7 @@ package newapp
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -23,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/errors"
+	kutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -724,23 +725,23 @@ func CompleteAppConfig(config *newcmd.AppConfig, f kcmdutil.Factory, c *cobra.Co
 			fmt.Fprintf(buf, "%s:\n", argName)
 			for _, classErr := range config.EnvironmentClassificationErrors {
 				if classErr.Value != nil {
-					fmt.Fprintf(buf, fmt.Sprintf("%s:  %v\n", classErr.Key, classErr.Value))
+					fmt.Fprintf(buf, "%s:  %v\n", classErr.Key, classErr.Value)
 				} else {
-					fmt.Fprintf(buf, fmt.Sprintf("%s\n", classErr.Key))
+					fmt.Fprintf(buf, "%s\n", classErr.Key)
 				}
 			}
 			for _, classErr := range config.SourceClassificationErrors {
-				fmt.Fprintf(buf, fmt.Sprintf("%s:  %v\n", classErr.Key, classErr.Value))
+				fmt.Fprintf(buf, "%s:  %v\n", classErr.Key, classErr.Value)
 			}
 			for _, classErr := range config.TemplateClassificationErrors {
-				fmt.Fprintf(buf, fmt.Sprintf("%s:  %v\n", classErr.Key, classErr.Value))
+				fmt.Fprintf(buf, "%s:  %v\n", classErr.Key, classErr.Value)
 			}
 			for _, classErr := range config.ComponentClassificationErrors {
-				fmt.Fprintf(buf, fmt.Sprintf("%s:  %v\n", classErr.Key, classErr.Value))
+				fmt.Fprintf(buf, "%s:  %v\n", classErr.Key, classErr.Value)
 			}
 			fmt.Fprintln(buf)
 		}
-		return kcmdutil.UsageErrorf(c, heredoc.Docf(buf.String()))
+		return kcmdutil.UsageErrorf(c, "%s", heredoc.Doc(buf.String()))
 	}
 
 	if config.AllowMissingImages && config.AsSearch {
@@ -891,7 +892,7 @@ func HandleError(err error, commandPath string, config *newcmd.AppConfig, transf
 		return nil
 	}
 	errs := []error{err}
-	if agg, ok := err.(errors.Aggregate); ok {
+	if agg, ok := err.(kutilerrors.Aggregate); ok {
 		errs = agg.Errors()
 	}
 	groups := ErrorGroups{}
@@ -904,7 +905,7 @@ func HandleError(err error, commandPath string, config *newcmd.AppConfig, transf
 		if len(group.classification) > 0 {
 			fmt.Fprintln(buf)
 		}
-		fmt.Fprintf(buf, group.classification)
+		fmt.Fprint(buf, group.classification)
 		if len(group.suggestion) > 0 {
 			if len(group.classification) > 0 {
 				fmt.Fprintln(buf)
@@ -913,7 +914,7 @@ func HandleError(err error, commandPath string, config *newcmd.AppConfig, transf
 		}
 		fmt.Fprint(buf, group.suggestion)
 	}
-	return fmt.Errorf(buf.String())
+	return errors.New(buf.String())
 }
 
 type ErrorGroup struct {
@@ -1068,13 +1069,14 @@ func TransformRunError(err error, commandPath string, groups ErrorGroups, config
 	switch err {
 	case errNoTokenAvailable:
 		// TODO: improve by allowing token generation
-		groups.Add("", "", "", fmt.Errorf("to install components you must be logged in with an OAuth token (instead of only a certificate)"))
+		groups.Add("", "", "", errors.New("to install components you must be logged in with an OAuth token (instead of only a certificate)"))
 	case newcmd.ErrNoInputs:
 		// TODO: suggest things to the user
-		groups.Add("", "", "", UsageError(commandPath, newAppNoInput))
+		groups.Add("", "", "", UsageError(commandPath, "%s", newAppNoInput))
 	default:
 		if runtime.IsNotRegisteredError(err) {
-			groups.Add("", "", "", fmt.Errorf(fmt.Sprintf("The template contained an object type unknown to `oc new-app`.  Use `oc process -f <template> | oc create -f -` instead.  Error details: %v", err)))
+			groups.Add("", "", "", fmt.Errorf(
+				"The template contained an object type unknown to `oc new-app`.  Use `oc process -f <template> | oc create -f -` instead.  Error details: %v", err))
 		} else {
 			groups.Add("", "", "", err)
 		}

--- a/pkg/cli/newbuild/newbuild.go
+++ b/pkg/cli/newbuild/newbuild.go
@@ -279,7 +279,7 @@ func transformBuildError(err error, commandPath string, groups ocnewapp.ErrorGro
 	}
 	switch err {
 	case newcmd.ErrNoInputs:
-		groups.Add("", "", "", ocnewapp.UsageError(commandPath, newBuildNoInput))
+		groups.Add("", "", "", ocnewapp.UsageError(commandPath, "%s", newBuildNoInput))
 		return
 	}
 	ocnewapp.TransformRunError(err, commandPath, groups, config)

--- a/pkg/cli/newbuild/newbuild_test.go
+++ b/pkg/cli/newbuild/newbuild_test.go
@@ -28,7 +28,7 @@ func TestNewBuildRun(t *testing.T) {
 		{
 			name:        "no input",
 			config:      &newcmd.AppConfig{},
-			expectedErr: ocnewapp.UsageError("oc new-build", newBuildNoInput).Error(),
+			expectedErr: ocnewapp.UsageError("oc new-build", "%s", newBuildNoInput).Error(),
 		},
 		{
 			name: "no matches",

--- a/pkg/cli/observe/observe.go
+++ b/pkg/cli/observe/observe.go
@@ -727,7 +727,7 @@ func (o *ObserveOptions) dumpMetrics() {
 	w := httptest.NewRecorder()
 	promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{}).ServeHTTP(w, &http.Request{})
 	if w.Code == http.StatusOK {
-		fmt.Fprintf(o.Out, w.Body.String())
+		fmt.Fprint(o.Out, w.Body.String())
 	}
 }
 

--- a/pkg/cli/rollout/latest.go
+++ b/pkg/cli/rollout/latest.go
@@ -226,6 +226,6 @@ func (p *revisionPrinter) PrintObj(obj runtime.Object, out io.Writer) error {
 		return fmt.Errorf("%T is not a deployment config", obj)
 	}
 
-	fmt.Fprintf(out, fmt.Sprintf("%d", dc.Status.LatestVersion))
+	fmt.Fprintf(out, "%d", dc.Status.LatestVersion)
 	return nil
 }

--- a/pkg/cli/rollout/retry.go
+++ b/pkg/cli/rollout/retry.go
@@ -91,7 +91,7 @@ func NewCmdRolloutRetry(f kcmdutil.Factory, streams genericiooptions.IOStreams) 
 func (o *RetryOptions) Complete(f kcmdutil.Factory, cmd *cobra.Command, args []string) error {
 	var err error
 	if len(args) == 0 && len(o.FilenameOptions.Filenames) == 0 {
-		return kcmdutil.UsageErrorf(cmd, cmd.Use)
+		return kcmdutil.UsageErrorf(cmd, "%s", cmd.Use)
 	}
 
 	o.Resources = args

--- a/pkg/cli/serviceaccounts/create_kubeconfig.go
+++ b/pkg/cli/serviceaccounts/create_kubeconfig.go
@@ -79,7 +79,7 @@ func NewCommandCreateKubeconfig(f cmdutil.Factory, streams genericiooptions.IOSt
 
 func (o *CreateKubeconfigOptions) Complete(args []string, f cmdutil.Factory, cmd *cobra.Command) error {
 	if len(args) != 1 {
-		return cmdutil.UsageErrorf(cmd, fmt.Sprintf("expected one service account name as an argument, got %q", args))
+		return cmdutil.UsageErrorf(cmd, "expected one service account name as an argument, got %q", args)
 	}
 	context, err := cmd.Flags().GetString("context")
 	if err != nil {
@@ -182,7 +182,7 @@ func (o *CreateKubeconfigOptions) Run() error {
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(o.Out, string(out))
+			fmt.Fprint(o.Out, string(out))
 			return nil
 		}
 	}

--- a/pkg/cli/serviceaccounts/gettoken.go
+++ b/pkg/cli/serviceaccounts/gettoken.go
@@ -74,7 +74,7 @@ func NewCommandGetServiceAccountToken(f cmdutil.Factory, streams genericiooption
 
 func (o *GetServiceAccountTokenOptions) Complete(args []string, f cmdutil.Factory, cmd *cobra.Command) error {
 	if len(args) != 1 {
-		return cmdutil.UsageErrorf(cmd, fmt.Sprintf("expected one service account name as an argument, got %q", args))
+		return cmdutil.UsageErrorf(cmd, "expected one service account name as an argument, got %q", args)
 	}
 
 	o.SAName = args[0]
@@ -131,7 +131,7 @@ func (o *GetServiceAccountTokenOptions) Run() error {
 				return fmt.Errorf("service account token %q for service account %q did not contain token data", secret.Name, serviceAccount.Name)
 			}
 
-			fmt.Fprintf(o.Out, string(token))
+			fmt.Fprint(o.Out, string(token))
 			if term.IsTerminalWriter(o.Out) {
 				// pretty-print for a TTY
 				fmt.Fprintf(o.Out, "\n")

--- a/pkg/cli/serviceaccounts/newtoken.go
+++ b/pkg/cli/serviceaccounts/newtoken.go
@@ -96,7 +96,7 @@ func NewCommandNewServiceAccountToken(f cmdutil.Factory, streams genericiooption
 
 func (o *ServiceAccountTokenOptions) Complete(args []string, requestedLabels string, f cmdutil.Factory, cmd *cobra.Command) error {
 	if len(args) != 1 {
-		return cmdutil.UsageErrorf(cmd, fmt.Sprintf("expected one service account name as an argument, got %q", args))
+		return cmdutil.UsageErrorf(cmd, "expected one service account name as an argument, got %q", args)
 	}
 
 	o.SAName = args[0]
@@ -104,7 +104,7 @@ func (o *ServiceAccountTokenOptions) Complete(args []string, requestedLabels str
 	if len(requestedLabels) > 0 {
 		labels, err := generate.ParseLabels(requestedLabels)
 		if err != nil {
-			return cmdutil.UsageErrorf(cmd, err.Error())
+			return cmdutil.UsageErrorf(cmd, "%s", err.Error())
 		}
 		o.Labels = labels
 	}
@@ -184,10 +184,10 @@ func (o *ServiceAccountTokenOptions) Run() error {
 		return fmt.Errorf("service account token %q did not contain token data", tokenSecret.Name)
 	}
 
-	fmt.Fprintf(o.Out, string(token))
+	fmt.Fprint(o.Out, string(token))
 	if term.IsTerminalWriter(o.Out) {
 		// pretty-print for a TTY
-		fmt.Fprintf(o.Out, "\n")
+		fmt.Fprint(o.Out, "\n")
 	}
 	return nil
 }

--- a/pkg/cli/status/status.go
+++ b/pkg/cli/status/status.go
@@ -222,6 +222,6 @@ func (o StatusOptions) RunStatus() error {
 		return fmt.Errorf("invalid output format provided: %s", o.outputFormat)
 	}
 
-	fmt.Fprintf(o.Out, s)
+	fmt.Fprint(o.Out, s)
 	return nil
 }

--- a/pkg/helpers/bulk/cmd.go
+++ b/pkg/helpers/bulk/cmd.go
@@ -119,7 +119,7 @@ func (b *Bulk) Run(list *metainternalversion.List, namespace string) []error {
 func NewPrintNameOrErrorAfterIndent(short bool, operation string, out, errs io.Writer, dryRun bool, indent string, prefixForError PrefixForError) AfterFunc {
 	return func(obj *unstructured.Unstructured, err error) bool {
 		if err == nil {
-			fmt.Fprintf(out, indent)
+			fmt.Fprint(out, indent)
 			printSuccess(short, out, obj.GroupVersionKind(), obj.GetName(), dryRun, operation)
 		} else {
 			fmt.Fprintf(errs, "%s%s: %v\n", indent, prefixForError(err), err)

--- a/pkg/helpers/describe/describer.go
+++ b/pkg/helpers/describe/describer.go
@@ -543,7 +543,7 @@ func describeBuildTriggers(triggers []buildv1.BuildTriggerPolicy, name, namespac
 			seenHookTypes[webHookType] = true
 			fmt.Fprintf(w, "\tURL:\t%s\n", trigger.URL)
 			if webHookType == string(buildv1.GenericWebHookBuildTriggerType) && trigger.AllowEnv != nil {
-				fmt.Fprintf(w, fmt.Sprintf("\t%s:\t%v\n", "AllowEnv", *trigger.AllowEnv))
+				fmt.Fprintf(w, "\t%s:\t%v\n", "AllowEnv", *trigger.AllowEnv)
 			}
 		}
 	}
@@ -1288,7 +1288,7 @@ func (d *TemplateDescriber) describeObjects(objects []runtime.RawExtension, out 
 				groupKind = gk.String()
 			}
 		}
-		fmt.Fprintf(out, fmt.Sprintf("%s%s\t%s\n", indent, groupKind, name))
+		fmt.Fprintf(out, "%s%s\t%s\n", indent, groupKind, name)
 	}
 }
 
@@ -1400,7 +1400,7 @@ func (d *TemplateInstanceDescriber) DescribeParameters(template templatev1.Templ
 
 	indent := "    "
 	if len(template.Parameters) == 0 {
-		fmt.Fprintf(out, indent+"No parameters found.")
+		fmt.Fprint(out, indent+"No parameters found.")
 	} else {
 		for _, p := range template.Parameters {
 			if val, ok := secret.Data[p.Name]; ok {

--- a/pkg/helpers/describe/helpers.go
+++ b/pkg/helpers/describe/helpers.go
@@ -74,14 +74,14 @@ func formatEnv(env corev1.EnvVar) string {
 func formatString(out *tabwriter.Writer, label string, v interface{}) {
 	labelVals := strings.Split(toString(v), "\n")
 
-	fmt.Fprintf(out, fmt.Sprintf("%s:", label))
+	fmt.Fprintf(out, "%s:", label)
 	for _, lval := range labelVals {
-		fmt.Fprintln(out, fmt.Sprintf("\t%s", lval))
+		fmt.Fprintf(out, "\t%s\n", lval)
 	}
 }
 
 func formatTime(out *tabwriter.Writer, label string, t time.Time) {
-	fmt.Fprintf(out, fmt.Sprintf("%s:\t%s ago\n", label, FormatRelativeTime(t)))
+	fmt.Fprintf(out, "%s:\t%s ago\n", label, FormatRelativeTime(t))
 }
 
 func formatLabels(labelMap map[string]string) string {

--- a/pkg/helpers/describe/projectstatus.go
+++ b/pkg/helpers/describe/projectstatus.go
@@ -260,9 +260,9 @@ func (d *ProjectStatusDescriber) Describe(namespace, name string) (string, error
 	return tabbedString(func(out *tabwriter.Writer) error {
 		indent := "  "
 		if allNamespaces {
-			fmt.Fprintf(out, describeAllProjectsOnServer(f, d.Server))
+			fmt.Fprint(out, describeAllProjectsOnServer(f, d.Server))
 		} else {
-			fmt.Fprintf(out, describeProjectAndServer(f, project, d.Server))
+			fmt.Fprint(out, describeProjectAndServer(f, project, d.Server))
 		}
 
 		for _, service := range services {
@@ -636,7 +636,7 @@ func getMarkerScanners(logsCommandName, securityPolicyCommandFormat, setProbeCom
 
 func printLines(out io.Writer, indent string, depth int, lines ...string) {
 	for i, s := range lines {
-		fmt.Fprintf(out, strings.Repeat(indent, depth))
+		fmt.Fprint(out, strings.Repeat(indent, depth))
 		if i != 0 {
 			fmt.Fprint(out, indent)
 		}

--- a/pkg/helpers/newapp/cmd/newapp.go
+++ b/pkg/helpers/newapp/cmd/newapp.go
@@ -341,7 +341,7 @@ func (c *AppConfig) tryToAddSourceArguments(s string) bool {
 	}
 	c.SourceClassificationErrors[s] = ArgumentClassificationError{
 		Key:   "is not a Git repository",
-		Value: fmt.Errorf(errStr),
+		Value: errors.New(errStr),
 	}
 
 	return false

--- a/pkg/helpers/newapp/cmd/template.go
+++ b/pkg/helpers/newapp/cmd/template.go
@@ -39,7 +39,7 @@ func formatString(out io.Writer, tab, s string) {
 	labelVals := strings.Split(strings.TrimSuffix(s, "\n"), "\n")
 
 	for _, lval := range labelVals {
-		fmt.Fprintf(out, fmt.Sprintf("%s%s\n", tab, lval))
+		fmt.Fprintf(out, "%s%s\n", tab, lval)
 	}
 }
 

--- a/vendor/github.com/openshift/build-machinery-go/.ci-operator.yaml
+++ b/vendor/github.com/openshift/build-machinery-go/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.22-openshift-4.17
+  tag: rhel-9-release-golang-1.23-openshift-4.19

--- a/vendor/github.com/openshift/build-machinery-go/Dockerfile.commitchecker
+++ b/vendor/github.com/openshift/build-machinery-go/Dockerfile.commitchecker
@@ -1,12 +1,12 @@
 # This Dockerfile must be on the top-level of this repo, because it needs to copy
 # both commitchecker/ and make/ into the build container.
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
 WORKDIR /go/src/github.com/openshift/build-machinery-go
 COPY . .
 RUN make -C commitchecker
 
-FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/build-machinery-go/commitchecker/commitchecker /usr/bin/
 RUN dnf install --setopt=tsflags=nodocs -y git && \
     dnf clean all && rm -rf /var/cache/yum/*

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/golang/verify-update.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/golang/verify-update.mk
@@ -3,11 +3,12 @@ include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
 )
 
 go_files_count :=$(words $(GO_FILES))
+chunk_size :=1000
 
 verify-gofmt:
 	$(info Running `$(GOFMT) $(GOFMT_FLAGS)` on $(go_files_count) file(s).)
 	@TMP=$$( mktemp ); \
-	$(GOFMT) $(GOFMT_FLAGS) $(GO_FILES) | tee $${TMP}; \
+	find . -name '*.go' -not -path '*/vendor/*' -not -path '*/_output/*' -print | xargs -n $(chunk_size) $(GOFMT) $(GOFMT_FLAGS) | tee $${TMP}; \
 	if [ -s $${TMP} ]; then \
 		echo "$@ failed - please run \`make update-gofmt\`"; \
 		exit 1; \
@@ -16,7 +17,7 @@ verify-gofmt:
 
 update-gofmt:
 	$(info Running `$(GOFMT) $(GOFMT_FLAGS) -w` on $(go_files_count) file(s).)
-	@$(GOFMT) $(GOFMT_FLAGS) -w $(GO_FILES)
+	@find . -name '*.go' -not -path '*/vendor/*' -not -path '*/_output/*' -print | xargs -n $(chunk_size) $(GOFMT) $(GOFMT_FLAGS) -w
 .PHONY: update-gofmt
 
 

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/controller-gen.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/controller-gen.mk
@@ -3,6 +3,26 @@ include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
 	../../lib/tmp.mk \
 )
 
+##############
+# DEPRECATED #
+##############
+# This utility is hard to maintain due to the need to continuously build and release binaries for
+# multiple platforms and versions. Instead it is recommended that you:
+# - Vendor the sigs.k8s.io/controller-tools repository.
+# - Write a local rule to (lazily) build the controller-gen binary from the vendored repo.
+# For example:
+#
+# CONTROLLER_GEN_SRC := $(shell realpath vendor/sigs.k8s.io/controller-tools/cmd/controller-gen)
+# CONTROLLER_GEN := $(shell go list -f '{{.Target}}' $(CONTROLLER_GEN_SRC))
+# $(CONTROLLER_GEN): $(CONTROLLER_GEN_SRC)
+# 	go install $(CONTROLLER_GEN_SRC)
+#
+# This allows you to upgrade versions simply by revendoring controller-tools:
+# - Bump the semver in your go.mod
+# - go mod tidy
+# - go mod vendor
+##############
+
 # NOTE: The release binary specified here needs to be built properly so that
 # `--version` works correctly. Just using `go build` will result in it
 # reporting `(devel)`. To build for a given platform:

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/yq.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/yq.mk
@@ -8,8 +8,7 @@ include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
 
 YQ_VERSION ?=2.4.0
 YQ ?=$(PERMANENT_TMP_GOPATH)/bin/yq-$(YQ_VERSION)
-yq_dir :=$(dir $(YQ))
-
+yq_dir =$(dir $(YQ))
 
 ensure-yq:
 ifeq "" "$(wildcard $(YQ))"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -653,7 +653,7 @@ github.com/openshift/api/template/v1
 github.com/openshift/api/unidling/v1alpha1
 github.com/openshift/api/user
 github.com/openshift/api/user/v1
-# github.com/openshift/build-machinery-go v0.0.0-20250102153059-e85a1a7ecb5c
+# github.com/openshift/build-machinery-go v0.0.0-20250602125535-1b6d00b8c37c
 ## explicit; go 1.22.0
 github.com/openshift/build-machinery-go
 github.com/openshift/build-machinery-go/make


### PR DESCRIPTION
Update go.mod and base images in all Dockerfiles.

This potentially supersedes:

- https://github.com/openshift/oc/pull/2041
- https://github.com/openshift/oc/pull/2044
