### PR TITLE
OCPNODE-3426: Introduce a dedicated Pod label for the purpose of identifying debug pods

### DIFF
--- a/pkg/cli/debug/debug.go
+++ b/pkg/cli/debug/debug.go
@@ -1053,6 +1053,11 @@ func (o *DebugOptions) approximatePodTemplateForObject(object runtime.Object) (*
 		isTrue := true
 		hostPathType := corev1.HostPathDirectory
 		template := &corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"debug.openshift.io/managed-by": "oc-debug",
+				},
+			},
 			Spec: corev1.PodSpec{
 				NodeName:    t.Name,
 				HostNetwork: true,


### PR DESCRIPTION
User Requirement: https://issues.redhat.com/browse/OCPSTRAT-846
Issue: https://issues.redhat.com/browse/OCPNODE-3426

As part of developing a user activity auditing feature for openshift nodes, we need a reliable way to identify the user who initiated a debug pod. Our current solution, leveraging the Security Profiles Operator, relies on injecting the request.UID into the debug pod's environment variables via a mutating admission webhook.

However, a fundamental challenge exists in identifying these "debug pods" within the webhook. While OpenShift's `oc debug node/<nodename>` command already injects an annotation (debug.openshift.io/source-container and debug.openshift.io/source-resource) to mark debug pods, Kubernetes webhooks, by design, only support label selectors (not annotation selectors) in their objectSelector configuration. This prevents our webhook from reliably targeting oc debug pods based on their existing annotations.

This PR introduces a new, consistent Pod label to explicitly mark pods created by the "oc debug node/nodename" command. This label will be:

debug.openshift.io/managed-by: "oc-debug"

By adding this label, our webhook can then be configured with an objectSelector to precisely target these debug pods. This enables the webhook to effectively inject the necessary request.UID environment variable, making our user activity auditing feature viable and robust for oc debug workflows.

A similar effort is ongoing with kubectl: https://github.com/kubernetes/kubernetes/pull/131791 . To keep the distinction with kubectl debug and oc debug I made sure not to use the same label as used in the open source PR

Currently we plan to have this feature in 4.20. But it may change based on user requirements.

**Testing**
Tested by compiling locally:
```
oc describe po ip-10-0-76-184ec2internal-debug-bpp99                                            ✔  admin 󱃾  21:34:04
Name:                 ip-10-0-76-184ec2internal-debug-bpp99
Namespace:            default
Priority:             1000000000
Priority Class Name:  openshift-user-critical
Service Account:      default
Node:                 ip-10-0-76-184.ec2.internal/10.0.76.184
Start Time:           Wed, 02 Jul 2025 21:33:54 +0530
Labels:               debug.openshift.io/managed-by=oc-debug
Annotations:          debug.openshift.io/source-container: container-00
                      debug.openshift.io/source-resource: /v1, Resource=nodes/ip-10-0-76-184.ec2.internal
```