### PR TITLE
OTA-1581: Promote `oc adm upgrade status` to general availability

### DIFF
--- a/pkg/cli/admin/upgrade/status/status.go
+++ b/pkg/cli/admin/upgrade/status/status.go
@@ -59,11 +59,9 @@ func New(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command 
 	}
 
 	flags := cmd.Flags()
-	// TODO: We can remove these flags once the idea about `oc adm upgrade status` stabilizes and the command
-	//       is promoted out of the OC_ENABLE_CMD_UPGRADE_STATUS feature gate
 	flags.StringVar(&o.mockData.cvPath, "mock-clusterversion", "", "Path to a YAML ClusterVersion object to use for testing (will be removed later). Files in the same directory with the same name and suffixes -co.yaml, -mcp.yaml, -mc.yaml, and -node.yaml are required.")
 	flags.StringVar(&o.detailedOutput, "details", "none", fmt.Sprintf("Show detailed output in selected section. One of: %s", strings.Join(detailedOutputAllValues, ", ")))
-
+	flags.MarkHidden("mock-clusterversion")
 	return cmd
 }
 

--- a/pkg/cli/admin/upgrade/status/status.go
+++ b/pkg/cli/admin/upgrade/status/status.go
@@ -59,7 +59,7 @@ func New(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command 
 	}
 
 	flags := cmd.Flags()
-	flags.StringVar(&o.mockData.cvPath, "mock-clusterversion", "", "Path to a YAML ClusterVersion object to use for testing (will be removed later). Files in the same directory with the same name and suffixes -co.yaml, -mcp.yaml, -mc.yaml, and -node.yaml are required.")
+	flags.StringVar(&o.mockData.cvPath, "mock-clusterversion", "", "Path to a YAML ClusterVersion object to use for testing. Files in the same directory with the same name and suffixes -co.yaml, -mcp.yaml, -mc.yaml, and -node.yaml are required.")
 	flags.StringVar(&o.detailedOutput, "details", "none", fmt.Sprintf("Show detailed output in selected section. One of: %s", strings.Join(detailedOutputAllValues, ", ")))
 	flags.MarkHidden("mock-clusterversion")
 	return cmd

--- a/pkg/cli/admin/upgrade/upgrade.go
+++ b/pkg/cli/admin/upgrade/upgrade.go
@@ -115,10 +115,8 @@ func New(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command 
 	flags.BoolVar(&o.AllowNotRecommended, "allow-not-recommended", o.AllowNotRecommended, "Allows upgrade to a version when it is supported but not recommended for updates.")
 
 	cmd.AddCommand(channel.New(f, streams))
+	cmd.AddCommand(status.New(f, streams))
 
-	if kcmdutil.FeatureGate("OC_ENABLE_CMD_UPGRADE_STATUS").IsEnabled() {
-		cmd.AddCommand(status.New(f, streams))
-	}
 	if kcmdutil.FeatureGate("OC_ENABLE_CMD_UPGRADE_ROLLBACK").IsEnabled() {
 		cmd.AddCommand(rollback.New(f, streams))
 	}


### PR DESCRIPTION
- Stop gating the command on an env variable presence
- Hide the mock input flag

The `UpgradeStatus` feature gate became eligible for promotion (https://github.com/openshift/api/pull/2418  by passing the [ci/prow/verify-feature-promotion](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_api/2418/pull-ci-openshift-api-master-verify-feature-promotion/1957733316027224064) check.

- [UpgradeStatus Feature Gate](https://sippy.dptools.openshift.org/sippy-ng/feature_gates/4.20?filters=%257B%2522items%2522%253A%255B%257B%2522columnField%2522%253A%2522feature_gate%2522%252C%2522operatorValue%2522%253A%2522equals%2522%252C%2522value%2522%253A%2522UpgradeStatus%2522%257D%255D%252C%2522linkOperator%2522%253A%2522and%2522%257D)
- [UpgradeStatus Fetature Gate Tests](https://sippy.dptools.openshift.org/sippy-ng/tests/4.20/details?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22FeatureGate%3AUpgradeStatus%5D%22%7D%5D%7D)
