### PR TITLE
OCPBUGS-59951: must-gather: Fix usage checker for custom commands

### DIFF
--- a/pkg/cli/admin/mustgather/mustgather_test.go
+++ b/pkg/cli/admin/mustgather/mustgather_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+
 	corev1 "k8s.io/api/core/v1"
 	k8sapierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -435,6 +437,37 @@ func TestGetCandidateNodeNames(t *testing.T) {
 			names := getCandidateNodeNames(test.nodeList, test.hasMaster)
 			if !reflect.DeepEqual(test.nodeNames, names) {
 				t.Fatalf("Expected and computed list of node names differ. Expected %#v. Got %#v.", test.nodeNames, names)
+			}
+		})
+	}
+}
+
+func TestBuildPodCommand(t *testing.T) {
+	tests := []struct {
+		name                     string
+		volumeUsageCheckerScript string
+		gatherCommand            string
+		expectedCommand          string
+	}{
+		{
+			name:                     "default gather command",
+			volumeUsageCheckerScript: "sleep infinity",
+			gatherCommand:            "/usr/bin/gather",
+			expectedCommand:          `sleep infinity & /usr/bin/gather; sync && echo 'Caches written to disk'`,
+		},
+		{
+			name:                     "custom gather command",
+			volumeUsageCheckerScript: "sleep infinity",
+			gatherCommand:            "sed -i 's#--rotated-pod-logs# #g' /usr/bin/*gather* && /usr/bin/gather",
+			expectedCommand:          `sleep infinity & sed -i 's#--rotated-pod-logs# #g' /usr/bin/*gather* && /usr/bin/gather; sync && echo 'Caches written to disk'`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := buildPodCommand(test.volumeUsageCheckerScript, test.gatherCommand)
+			if cmd != test.expectedCommand {
+				t.Errorf("Unexpected pod command was generated: \n%s\n", cmp.Diff(test.expectedCommand, cmd))
 			}
 		})
 	}


### PR DESCRIPTION
When killing the gathering process, the command string is being used,
which doesn't work with custom commands. This is fixed now by actually
sending the signal to the child session, which is being used now
to wrap the command being executed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Must-gather now monitors volume usage and will terminate the gather operation if limits are exceeded.

* **Bug Fixes**
  * Prevents runaway disk consumption and reports current vs allowed usage with clearer disk-check logs and targeted termination.

* **Tests**
  * Added unit tests validating the composed command used to run must-gather.

* **Documentation**
  * Clarified end-of-gather behavior and improved disk-check logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->