### PR TITLE
OTA-1600: pkg/cli/admin/upgrade/recommend: Don't error on unaccepted issues when the feature gate is off

### DIFF
--- a/pkg/cli/admin/upgrade/recommend/recommend.go
+++ b/pkg/cli/admin/upgrade/recommend/recommend.go
@@ -342,10 +342,12 @@ func (o *options) Run(ctx context.Context) error {
 						issues.Insert("ConditionalUpdateRisk")
 					}
 					unaccepted := issues.Difference(accept)
-					if unaccepted.Len() > 0 {
-						return fmt.Errorf("issues that apply to this cluster but which were not included in --accept: %s", strings.Join(sets.List(unaccepted), ","))
-					} else if issues.Len() > 0 && !o.quiet {
-						fmt.Fprintf(o.Out, "Update to %s has no known issues relevant to this cluster other than the accepted %s.\n", update.Release.Version, strings.Join(sets.List(issues), ","))
+					if kcmdutil.FeatureGate("OC_ENABLE_CMD_UPGRADE_RECOMMEND_ACCEPT").IsEnabled() {
+						if unaccepted.Len() > 0 {
+							return fmt.Errorf("issues that apply to this cluster but which were not included in --accept: %s", strings.Join(sets.List(unaccepted), ","))
+						} else if issues.Len() > 0 && !o.quiet {
+							fmt.Fprintf(o.Out, "Update to %s has no known issues relevant to this cluster other than the accepted %s.\n", update.Release.Version, strings.Join(sets.List(issues), ","))
+						}
 					}
 					return nil
 				}


### PR DESCRIPTION
When `OC_ENABLE_CMD_UPGRADE_RECOMMEND_ACCEPT` is not set to true, the `--accept` option does not exist.  In that case, we don't want to error [with][1]:

    error: issues that apply to this cluster but which were not included in --accept: ConditionalUpdateRisk

Instead, we just want to exit happily, because we've already mentioned the issue earlier in the message.

[1]: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/29831/pull-ci-openshift-origin-main-e2e-aws-ovn-serial-1of2/1951653929842380800