### PR TITLE
NO-JIRA: Improve must-gather image handling and annotation checks- #2071

### DIFF
--- a/pkg/cli/admin/mustgather/mustgather.go
+++ b/pkg/cli/admin/mustgather/mustgather.go
@@ -341,7 +341,7 @@ func (o *MustGatherOptions) completeImages(ctx context.Context) error {
 	}
 	if o.AllImages {
 		// find all csvs and clusteroperators with the annotation "operators.openshift.io/must-gather-image"
-		pluginImages, err := o.annotatedCSVs(ctx)
+		pluginImages, missingCSVs, err := o.annotatedCSVs(ctx)
 		if err != nil {
 			return err
 		}
@@ -350,17 +350,20 @@ func (o *MustGatherOptions) completeImages(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		var missingAnnotation []string
+		var missingCOs []string
 		for _, item := range cos.Items {
 			ann := item.GetAnnotations()
 			if v, ok := ann[mgAnnotation]; ok {
 				pluginImages[v] = struct{}{}
 			} else {
-				missingAnnotation = append(missingAnnotation, item.GetName())
+				missingCOs = append(missingCOs, item.GetName())
 			}
 		}
-		if len(missingAnnotation) > 0 {
-			o.log("WARNING: ClusterOperators without %s annotation: %s", mgAnnotation, strings.Join(missingAnnotation, ", "))
+		if len(missingCOs) > 0 {
+			o.log("ClusterOperators without %s annotation: %s", mgAnnotation, strings.Join(missingCOs, ", "))
+		}
+		if len(missingCSVs) > 0 {
+			o.log("CSVs without %s annotation: %s", mgAnnotation, strings.Join(missingCSVs, ", "))
 		}
 		// delete the default image to avoid duplication in case an Operator had it in its annotation
 		delete(pluginImages, o.Images[0])
@@ -373,7 +376,7 @@ func (o *MustGatherOptions) completeImages(ctx context.Context) error {
 	return nil
 }
 
-func (o *MustGatherOptions) annotatedCSVs(ctx context.Context) (map[string]struct{}, error) {
+func (o *MustGatherOptions) annotatedCSVs(ctx context.Context) (map[string]struct{}, []string, error) {
 	csvGVR := schema.GroupVersionResource{
 		Group:    "operators.coreos.com",
 		Version:  "v1alpha1",
@@ -383,7 +386,7 @@ func (o *MustGatherOptions) annotatedCSVs(ctx context.Context) (map[string]struc
 
 	csvs, err := o.DynamicClient.Resource(csvGVR).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var missingAnnotation []string
@@ -395,10 +398,7 @@ func (o *MustGatherOptions) annotatedCSVs(ctx context.Context) (map[string]struc
 			missingAnnotation = append(missingAnnotation, item.GetName())
 		}
 	}
-	if len(missingAnnotation) > 0 {
-		o.log("WARNING: CSVs without %s annotation: %s", mgAnnotation, strings.Join(missingAnnotation, ", "))
-	}
-	return pluginImages, nil
+	return pluginImages, missingAnnotation, nil
 }
 
 func (o *MustGatherOptions) resolveImageStreamTagString(ctx context.Context, s string) (string, error) {

--- a/pkg/cli/admin/mustgather/mustgather.go
+++ b/pkg/cli/admin/mustgather/mustgather.go
@@ -389,16 +389,16 @@ func (o *MustGatherOptions) annotatedCSVs(ctx context.Context) (map[string]struc
 		return nil, nil, err
 	}
 
-	var missingAnnotation []string
+	var annotationMissingImages []string
 	for _, item := range csvs.Items {
 		ann := item.GetAnnotations()
 		if v, ok := ann[mgAnnotation]; ok {
 			pluginImages[v] = struct{}{}
 		} else {
-			missingAnnotation = append(missingAnnotation, item.GetName())
+			annotationMissingImages = append(annotationMissingImages, item.GetName())
 		}
 	}
-	return pluginImages, missingAnnotation, nil
+	return pluginImages, annotationMissingImages, nil
 }
 
 func (o *MustGatherOptions) resolveImageStreamTagString(ctx context.Context, s string) (string, error) {

--- a/pkg/cli/admin/mustgather/mustgather.go
+++ b/pkg/cli/admin/mustgather/mustgather.go
@@ -6,11 +6,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"math/rand"
 	"os"
 	"os/signal"
 	"path"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -350,17 +352,11 @@ func (o *MustGatherOptions) completeImages(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		var annotationMissingCOs []string
 		for _, item := range cos.Items {
 			ann := item.GetAnnotations()
 			if v, ok := ann[mgAnnotation]; ok {
 				pluginImages[v] = struct{}{}
-			} else {
-				annotationMissingCOs = append(annotationMissingCOs, item.GetName())
 			}
-		}
-		if len(annotationMissingCOs) > 0 {
-			o.log("ClusterOperators without %s annotation: %s", mgAnnotation, strings.Join(annotationMissingCOs, ", "))
 		}
 		if len(annotationMissingCSVs) > 0 {
 			o.log("CSVs without %s annotation: %s", mgAnnotation, strings.Join(annotationMissingCSVs, ", "))
@@ -389,16 +385,16 @@ func (o *MustGatherOptions) annotatedCSVs(ctx context.Context) (map[string]struc
 		return nil, nil, err
 	}
 
-	var annotationMissingImages []string
+	annotationMissingImages := make(map[string]struct{})
 	for _, item := range csvs.Items {
 		ann := item.GetAnnotations()
 		if v, ok := ann[mgAnnotation]; ok {
 			pluginImages[v] = struct{}{}
 		} else {
-			annotationMissingImages = append(annotationMissingImages, item.GetName())
+			annotationMissingImages[item.GetName()] = struct{}{}
 		}
 	}
-	return pluginImages, annotationMissingImages, nil
+	return pluginImages, slices.Sorted(maps.Keys(annotationMissingImages)), nil
 }
 
 func (o *MustGatherOptions) resolveImageStreamTagString(ctx context.Context, s string) (string, error) {

--- a/pkg/cli/admin/mustgather/mustgather.go
+++ b/pkg/cli/admin/mustgather/mustgather.go
@@ -341,7 +341,7 @@ func (o *MustGatherOptions) completeImages(ctx context.Context) error {
 	}
 	if o.AllImages {
 		// find all csvs and clusteroperators with the annotation "operators.openshift.io/must-gather-image"
-		pluginImages, missingCSVs, err := o.annotatedCSVs(ctx)
+		pluginImages, annotationMissingCSVs, err := o.annotatedCSVs(ctx)
 		if err != nil {
 			return err
 		}
@@ -350,20 +350,20 @@ func (o *MustGatherOptions) completeImages(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		var missingCOs []string
+		var annotationMissingCOs []string
 		for _, item := range cos.Items {
 			ann := item.GetAnnotations()
 			if v, ok := ann[mgAnnotation]; ok {
 				pluginImages[v] = struct{}{}
 			} else {
-				missingCOs = append(missingCOs, item.GetName())
+				annotationMissingCOs = append(annotationMissingCOs, item.GetName())
 			}
 		}
-		if len(missingCOs) > 0 {
-			o.log("ClusterOperators without %s annotation: %s", mgAnnotation, strings.Join(missingCOs, ", "))
+		if len(annotationMissingCOs) > 0 {
+			o.log("ClusterOperators without %s annotation: %s", mgAnnotation, strings.Join(annotationMissingCOs, ", "))
 		}
-		if len(missingCSVs) > 0 {
-			o.log("CSVs without %s annotation: %s", mgAnnotation, strings.Join(missingCSVs, ", "))
+		if len(annotationMissingCSVs) > 0 {
+			o.log("CSVs without %s annotation: %s", mgAnnotation, strings.Join(annotationMissingCSVs, ", "))
 		}
 		// delete the default image to avoid duplication in case an Operator had it in its annotation
 		delete(pluginImages, o.Images[0])

--- a/pkg/cli/admin/mustgather/mustgather.go
+++ b/pkg/cli/admin/mustgather/mustgather.go
@@ -6,13 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"maps"
 	"math/rand"
 	"os"
 	"os/signal"
 	"path"
 	"regexp"
-	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -28,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	kutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
@@ -385,16 +384,16 @@ func (o *MustGatherOptions) annotatedCSVs(ctx context.Context) (map[string]struc
 		return nil, nil, err
 	}
 
-	annotationMissingImages := make(map[string]struct{})
+	annotationMissingImages := sets.New[string]()
 	for _, item := range csvs.Items {
 		ann := item.GetAnnotations()
 		if v, ok := ann[mgAnnotation]; ok {
 			pluginImages[v] = struct{}{}
 		} else {
-			annotationMissingImages[item.GetName()] = struct{}{}
+			annotationMissingImages.Insert(item.GetName())
 		}
 	}
-	return pluginImages, slices.Sorted(maps.Keys(annotationMissingImages)), nil
+	return pluginImages, sets.List(annotationMissingImages), nil
 }
 
 func (o *MustGatherOptions) resolveImageStreamTagString(ctx context.Context, s string) (string, error) {

--- a/pkg/cli/admin/mustgather/mustgather.go
+++ b/pkg/cli/admin/mustgather/mustgather.go
@@ -350,11 +350,17 @@ func (o *MustGatherOptions) completeImages(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+		var missingAnnotation []string
 		for _, item := range cos.Items {
 			ann := item.GetAnnotations()
 			if v, ok := ann[mgAnnotation]; ok {
 				pluginImages[v] = struct{}{}
+			} else {
+				missingAnnotation = append(missingAnnotation, item.GetName())
 			}
+		}
+		if len(missingAnnotation) > 0 {
+			o.log("WARNING: ClusterOperators without %s annotation: %s", mgAnnotation, strings.Join(missingAnnotation, ", "))
 		}
 		// delete the default image to avoid duplication in case an Operator had it in its annotation
 		delete(pluginImages, o.Images[0])
@@ -380,11 +386,17 @@ func (o *MustGatherOptions) annotatedCSVs(ctx context.Context) (map[string]struc
 		return nil, err
 	}
 
+	var missingAnnotation []string
 	for _, item := range csvs.Items {
 		ann := item.GetAnnotations()
 		if v, ok := ann[mgAnnotation]; ok {
 			pluginImages[v] = struct{}{}
+		} else {
+			missingAnnotation = append(missingAnnotation, item.GetName())
 		}
+	}
+	if len(missingAnnotation) > 0 {
+		o.log("WARNING: CSVs without %s annotation: %s", mgAnnotation, strings.Join(missingAnnotation, ", "))
 	}
 	return pluginImages, nil
 }


### PR DESCRIPTION
## Pull Request: Improve must-gather image handling and annotation checks

###  Summary

This PR enhances the `MustGatherOptions.completeImages()` method by:

* **Logging warnings** for CSVs that are missing the required `must-gather-image` annotation.
* Improving robustness and readability of the image collection logic.
* Ensuring deduplication of default must-gather image when collecting plug-in images.


### Changes

* Moved CSV annotation scanning inline to allow per-CSV warning messages.
* Added warning log in the format:

  ```
  WARNING: CSV operator <name> doesn't have the must-gather-image annotation.
  ```
* Enhanced image resolution logic to:

  * Fallback to hardcoded must-gather image if the image stream tag cannot be resolved.
  * Log warnings for such fallbacks.
* Maintained support for `--all` (aka `AllImages`) by collecting images from both:

  * CSVs (ClusterServiceVersions)
  * ClusterOperators
* Ensured duplicate images (especially the default one) are not added to the final list.


### Testing

* Verified that missing annotations on CSVs produce proper warning output.
* Confirmed image collection and deduplication works as expected.
* Manually validated fallback logic for missing default image stream tag.


### Related

* Annotation key used: `operators.openshift.io/must-gather-image`
* Fulfills a need for better diagnostics and operator plug-in visibility in `oc adm must-gather --all-images`.

---

### Notes

* Future enhancement may consider moving CSV image collection into a separate method again, but returning both:

  * `pluginImages`
  * `[]string` of CSVs missing the annotation for external logging.

