### PR TITLE
NO-JIRA: Remove mentioning about IRC channel in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,8 @@ OpenShift cluster.
 
 All contributions are welcome - oc uses the Apache 2 license and does not require
 any contributor agreement to submit patches.  Please open issues for any bugs
-or problems you encounter, ask questions on the OpenShift IRC channel
-(#openshift-dev on freenode), or get involved in the [kubectl](https://github.com/kubernetes/kubectl)
-and [kubernetes project](https://github.com/kubernetes/kubernetes) at the container
-runtime layer.
+or problems you encounter. You can also get involved with the [kubectl](https://github.com/kubernetes/kubectl)
+and the [Kubernetes project](https://github.com/kubernetes/kubernetes).
 
 ## Building
 


### PR DESCRIPTION
IRC Channel is not  used anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contributing guidance to remove an outdated OpenShift IRC reference.
  * Consolidated contribution/contact instructions, directing contributors to the kubectl repository.
  * Added a link to the Kubernetes project for clearer ecosystem context.
  * Improved wording and capitalization for clarity.
  * No functional or behavioral changes to the product.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->