### PR TITLE
OCPBUGS-60877: pkg/cli/admin/inspectalerts: Pass through --certificate-authority, etc.

### DIFF
--- a/pkg/cli/admin/upgrade/recommend/recommend.go
+++ b/pkg/cli/admin/upgrade/recommend/recommend.go
@@ -105,6 +105,8 @@ func (o *options) Complete(f kcmdutil.Factory, cmd *cobra.Command, args []string
 		if err != nil {
 			return err
 		}
+		o.RESTConfig.UserAgent = rest.DefaultKubernetesUserAgent() + "(upgrade-recommend)"
+
 		o.Client, err = configv1client.NewForConfig(o.RESTConfig)
 		if err != nil {
 			return err


### PR DESCRIPTION
Instead of passing tidbits from the `rest.Config` through to `transport.HTTPWrappersForConfig` by hand, use `rest.TransportFor`.  That picks up all the goodies, like `TLSClientConfig`'s `CAFile` (which is fed by `--certificate-authority`) and `Insecure` (which is fed by `--insecure-skip-tls-verify`).  Which makes it possible to invoke both inspect-alerts and also other Go consumers like `oc adm upgrade recommend` and `oc adm upgrade status` with options to trust a Thanos-fronting Ingress that they wouldn't otherwise trust.  That can be helpful when running against test clusters, where the Thanos-fronting Ingress is less likely to have an X.509 certificate signed by a broadly-trusted Certificate Authority.

We still want the clear message about the token requirement though, so there's a new `ValidateRESTConfig` that callers can wash their `rest.Config` by before converting it to a `RoundTripper`.  Otherwise the you-didn't-use-a-bearer-token error messages look fairly opaque:

    ... failed to get alerts from Thanos: unable to get /api/v1/alerts from URI in the openshift-monitoring/thanos-querier Route: thanos-querier-openshift-monitoring.apps...->GET status code=401

I'm also shifting user-agent configuration earlier (to right after the `rest.Config`'s creation) and pushing it out to each of the three commands, now that I'm no longer getting down into the transport weeds within the `getWith...` helper function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability when fetching alerts across inspect-alerts, upgrade recommend, and upgrade status.
  - Better handling of multi-host routes with consolidated errors when all attempts fail.

- Chores
  - Standardized user-agent strings for related commands to improve observability.
  - Added stricter REST configuration validation before making requests for safer operation.

- Refactor
  - Alert retrieval now uses a more flexible transport mechanism for improved compatibility and reduced coupling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->