### PR TITLE
OCPBUGS-60989: adm release info: Print commit url if no associated PR number

### DIFF
--- a/pkg/cli/admin/release/git.go
+++ b/pkg/cli/admin/release/git.go
@@ -298,13 +298,13 @@ func mergeLogForRepo(g gitInterface, repo string, from, to string) ([]MergeCommi
 			m = squashRePR.FindStringSubmatch(mergeMsg)
 		}
 
-		if m == nil || len(m) < 2 {
+		if len(m) >= 2 {
+			mergeCommit.PullRequest, err = strconv.Atoi(m[1])
+			if err != nil {
+				return nil, fmt.Errorf("could not extract PR number from %q: %v", mergeMsg, err)
+			}
+		} else {
 			klog.V(2).Infof("Omitted commit %s which has no pull-request", mergeCommit.Commit)
-			continue
-		}
-		mergeCommit.PullRequest, err = strconv.Atoi(m[1])
-		if err != nil {
-			return nil, fmt.Errorf("could not extract PR number from %q: %v", mergeMsg, err)
 		}
 		if len(msg) == 0 {
 			msg = "Merge"


### PR DESCRIPTION
`oc adm release info --changelog` discards the commits, if no associated pull request number is found. This is problematic because discarded commits makes it difficult to find the regression in the changelogs to investigate.

So that this PR prints commit message (with commit url) to at least show the change in the output. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release generation now correctly handles merge commits without an associated pull request. Such commits are included in the output and no longer cause parsing errors or get skipped, resulting in more complete release notes and smoother runs when direct merges or backports occur. Commits with valid PR references continue to be processed as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->