### PR TITLE
OCPBUGS-60989: pkg/cli/admin/release/info: Mention elided first-parent, non-merge commits

### DIFF
--- a/pkg/cli/admin/release/git_test.go
+++ b/pkg/cli/admin/release/git_test.go
@@ -22,14 +22,15 @@ func (g fakeGit) exec(commands ...string) (string, error) {
 
 func Test_mergeLogForRepo(t *testing.T) {
 	tests := []struct {
-		name    string
-		input   string
-		repo    string
-		from    string
-		to      string
-		squash  bool
-		want    []MergeCommit
-		wantErr bool
+		name              string
+		input             string
+		repo              string
+		from              string
+		to                string
+		squash            bool
+		want              []MergeCommit
+		wantElidedCommits int
+		wantErr           bool
 	}{
 		{
 			input: "abc\x1e1\x1eMerge pull request #145 from\x1eBug 1743564: test",
@@ -291,13 +292,16 @@ func Test_mergeLogForRepo(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := fakeGit{input: tt.input, squash: tt.squash}
-			got, err := mergeLogForRepo(g, tt.repo, "a", "b")
+			got, elidedCommits, err := mergeLogForRepo(g, tt.repo, "a", "b")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("mergeLogForRepo() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("mergeLogForRepo(): %s", diff.ObjectReflectDiff(tt.want, got))
+			}
+			if elidedCommits != tt.wantElidedCommits {
+				t.Errorf("mergeLogForRepo(): %d elided commits report differs from expected %d", elidedCommits, tt.wantElidedCommits)
 			}
 		})
 	}


### PR DESCRIPTION
Originally, the change-log generation focused on merge commits, which are common in many repositories.  For example, in this `oc` repository:

```console
$ git log --graph --oneline -10
*   559c67e11 (HEAD -> main, origin/main) Merge pull request #2083 from wking/oc-adm-upgrade-recommend-certificate-authority
|\
| * b98b2e157 pkg/cli/admin/inspectalerts: Pass through --certificate-authority, etc.
* |   e7900febd Merge pull request #2082 from ardaguclu/code-rabbit-test
|\ \
| |/
|/|
| * ffe752e7c Remove mentioning about IRC channel from README
* | f114b178f OTA-1581: Promote `oc adm upgrade status` to general availability (#2063)
* |   1c54ec072 Merge pull request #2077 from hongkailiu/OTA-1601
|\ \
| * | 5f1dbb8b1 Move not-lines-related table.Write out of the loop
| * | a35266244 Truncate long reasons
| * | 11f9f47e1 Reproduce the long reason issue
| * | 970f883d2 status: improve line break handling for CO Message
```

4299014c82 (#1116), and mentioned the insights operator:

```console
$ git clone --depth 10 --branch master https://github.com/openshift/insights-operator
$ cd insights-operator
$ git log --graph --oneline -5
* da45333 (HEAD -> master, origin/master, origin/HEAD) OCPBUGS-60611: virt launcher logs gatherer (#1110)
* 737b59b fix: incorrect anonymization of domains (#1111)
* b5185da feat: add permissions to gather clusterrole (#1106)
* 3099eb0 feat: Allow on-demand gathering during initial periodic run (#1109)
* 7f8b40d RFE-4152: Add missing readonlyRootFilesystem (#1104)
```

But some repositories also use a mixture of real merges and squash or rebase merges:

```console
$ git clone --depth 20 --branch main https://github.com/openshift/operator-framework-operator-controller
$ cd operator-framework-operator-controller
$ git log --graph --oneline -11
* 9319f22a (HEAD -> main, origin/main, origin/HEAD) UPSTREAM: <carry>: Ensure unique name for bad-catalog tests
* 9b50498a UPSTREAM: <carry>: Adds ResourceVersion checks to the tls secret deletion test, mirroring the logic used in the certificate rotation test. This makes the test more robust by ensuring a new secret is created, not just that an existing one is still present.
* 2ed1a5c8 UPSTREAM: <carry>: Migrate single/own namespace tests
* 0c4f4303 UPSTREAM: <carry>: [OTE] add catalog tests from openshift/origin
* 28299f38 UPSTREAM: <carry>: remove obsolete owners
* 5aa7897f UPSTREAM: <carry>: [OTE] - Readme:Add info to help use payload-aggregate with new tests
* 0bb19537 UPSTREAM: <carry>: Adds ResourceVersion checks to the tls secret deletion test, mirroring the logic used in the certificate rotation test. This makes the test more robust by ensuring a new secret is created, not just that an existing one is still present.
* e9e3220f UPSTREAM: <carry>: [OTE] Add webhook to validate openshift-service-ca certificate rotation
*   a7d35272 Merge pull request #453 from openshift-bot/synchronize-upstream
|\
| * d93f9d16 UPSTREAM: <drop>: configure the commit-checker
| * 9a69e8ed UPSTREAM: <drop>: remove upstream GitHub configuration
```

Before this commit, the logic would find the merge commits, assume that all content came in via merge commits, and not mention the other changes:

```console
$ git log --first-parent --merges --oneline
a7d3527 Merge pull request #453 from openshift-bot/synchronize-upstream
4cae159 Merge pull request #449 from openshift-bot/synchronize-upstream
82f63dc Merge pull request #444 from openshift-bot/synchronize-upstream
6f91d84 Merge pull request #435 from openshift-bot/synchronize-upstream
```

With this commit, we'll continue to include a line for each of those merges.  But we'll also include the count of any elided, non-merge, first-parent commits:

```console
$ git log --first-parent --no-merges --oneline | wc -l
16
```

Folks interested in what exactly was elided will have to click through to `Full changelog` or otherwise go digging.  But at least they'll get the count of elided commits to know that there is more information there to see behind that click.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Changelogs and bug reports now report the number of commits elided by squash/rebase merges.
  * JSON changelog output adds an elidedCommits field for consumers.
  * Human-readable and Markdown outputs include a line for elided commits when present.
  * Summaries prefer first‑parent merge history when mixed merge strategies exist to reduce noise.

* **Tests**
  * Tests updated to validate the reported elided commits value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->