### PR TITLE
OCPBUGS-59951: oc adm must-gather: Wrap gather in a session

### DIFF
--- a/pkg/cli/admin/mustgather/mustgather.go
+++ b/pkg/cli/admin/mustgather/mustgather.go
@@ -87,9 +87,6 @@ var (
 		  oc adm must-gather --image=my/image:tag --source-dir=/pod/directory -- myspecial-command.sh
 	`)
 
-	// According to https://github.com/openshift/enhancements/blob/master/enhancements/oc/must-gather.md#proposal
-	// we can assume /usr/bin/gather* is always run in the end, even when a custom command is specified.
-	// That's why we always kill all processes matching gather, even though a custom command can be specified.
 	volumeUsageCheckerScript = `
 echo "[disk usage checker] Started"
 target_dir="%s"
@@ -101,7 +98,10 @@ usage_percentage=$(( (disk_usage * 100) / disk_space ))
 echo "[disk usage checker] Volume usage percentage: current = ${usage_percentage} ; allowed = ${usage_percentage_limit}"
 if [ "$usage_percentage" -gt "$usage_percentage_limit" ]; then
 	echo "[disk usage checker] Disk usage exceeds the volume percentage of ${usage_percentage_limit} for mounted directory, terminating..."
-	pkill --signal SIGKILL gather
+	ps -o sess --no-headers | sort -u | while read sid; do
+		[[ "$sid" -eq "${$}" ]] && continue
+		pkill --signal SIGKILL --session "$sid"
+	done
 	exit 1
 fi
 sleep 5
@@ -1266,8 +1266,18 @@ func buildPodCommand(
 	volumeCheckerScript string,
 	gatherCommand string,
 ) string {
-	// Start the checker in the background,
-	// run the gather command and wait for it to complete/exit.
-	// Make sure all changes are written to disk at the end.
-	return fmt.Sprintf("%s & %s; sync && echo 'Caches written to disk'", volumeCheckerScript, gatherCommand)
+	var cmd strings.Builder
+
+	// Start the checker in the background.
+	cmd.WriteString(volumeCheckerScript)
+	cmd.WriteString(` & `)
+
+	// Start the gather command in a separate session.
+	cmd.WriteString("setsid -w bash <<-MUSTGATHER_EOF\n")
+	cmd.WriteString(gatherCommand)
+	cmd.WriteString("\nMUSTGATHER_EOF\n")
+
+	// Make sure all changes are written to disk.
+	cmd.WriteString(`sync && echo 'Caches written to disk'`)
+	return cmd.String()
 }

--- a/pkg/cli/admin/mustgather/mustgather_test.go
+++ b/pkg/cli/admin/mustgather/mustgather_test.go
@@ -453,13 +453,19 @@ func TestBuildPodCommand(t *testing.T) {
 			name:                     "default gather command",
 			volumeUsageCheckerScript: "sleep infinity",
 			gatherCommand:            "/usr/bin/gather",
-			expectedCommand:          `sleep infinity & /usr/bin/gather; sync && echo 'Caches written to disk'`,
+			expectedCommand: `sleep infinity & setsid -w bash <<-MUSTGATHER_EOF
+/usr/bin/gather
+MUSTGATHER_EOF
+sync && echo 'Caches written to disk'`,
 		},
 		{
 			name:                     "custom gather command",
 			volumeUsageCheckerScript: "sleep infinity",
 			gatherCommand:            "sed -i 's#--rotated-pod-logs# #g' /usr/bin/*gather* && /usr/bin/gather",
-			expectedCommand:          `sleep infinity & sed -i 's#--rotated-pod-logs# #g' /usr/bin/*gather* && /usr/bin/gather; sync && echo 'Caches written to disk'`,
+			expectedCommand: `sleep infinity & setsid -w bash <<-MUSTGATHER_EOF
+sed -i 's#--rotated-pod-logs# #g' /usr/bin/*gather* && /usr/bin/gather
+MUSTGATHER_EOF
+sync && echo 'Caches written to disk'`,
 		},
 	}
 


### PR DESCRIPTION
Wrap the gather command in the pod in a session so that it can be killed in a robust.

### Testing

I changed the script to use #2084 , then I tested it:

```
[must-gather-xgq5w] POD 2025-09-03T14:42:53.288635083Z [disk usage checker] Started
[must-gather-xgq5w] POD 2025-09-03T14:42:53.292175382Z [disk usage checker] Volume usage percentage: current = 84 ; allowed = 30
[must-gather-xgq5w] POD 2025-09-03T14:42:53.292195419Z [disk usage checker] Disk usage exceeds the volume percentage of 30 for mounted directory, terminating...
[must-gather-xgq5w] POD 2025-09-03T14:42:53.297763443Z /bin/bash: line 19:     3 Killed                  setsid -w bash <<-MUSTGATHER_EOF
[must-gather-xgq5w] POD 2025-09-03T14:42:53.297763443Z /usr/bin/gather
[must-gather-xgq5w] POD 2025-09-03T14:42:53.297763443Z MUSTGATHER_EOF
[must-gather-xgq5w] POD 2025-09-03T14:42:53.297763443Z 
[must-gather-xgq5w] POD 2025-09-03T14:42:53.545057394Z Caches written to disk
```

With a custom command:

```
[must-gather-j2hqg] POD 2025-09-03T14:53:00.395951667Z [disk usage checker] Started
[must-gather-j2hqg] POD 2025-09-03T14:53:00.398359655Z [disk usage checker] Volume usage percentage: current = 83 ; allowed = 30
[must-gather-j2hqg] POD 2025-09-03T14:53:00.398359655Z [disk usage checker] Disk usage exceeds the volume percentage of 30 for mounted directory, terminating...
[must-gather-j2hqg] POD 2025-09-03T14:53:00.401604549Z /bin/bash: line 19:     3 Killed                  setsid -w bash <<-MUSTGATHER_EOF
[must-gather-j2hqg] POD 2025-09-03T14:53:00.401604549Z sed -i 's#--rotated-pod-logs# #g' /usr/bin/*gather* && /usr/bin/gather
[must-gather-j2hqg] POD 2025-09-03T14:53:00.401604549Z MUSTGATHER_EOF
[must-gather-j2hqg] POD 2025-09-03T14:53:00.401604549Z 
[must-gather-j2hqg] POD 2025-09-03T14:53:00.570840175Z Caches written to disk
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Must-gather now runs the collection in a separate session to improve reliability.
  * Disk-usage guard targets other sessions and avoids terminating the initiator’s shell.
  * Ensures a final disk sync and a “Caches written to disk” log after completion for safer writes under pressure.

* **Tests**
  * Updated tests to reflect the new session-based command structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->