### PR TITLE
OCPBUGS-61063: pkg/cli/admin/upgrade/recommend: Enable precheck and accept gates

### DIFF
--- a/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-not-recommended.version-4.12.51-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-not-recommended.version-4.12.51-output
@@ -15,3 +15,5 @@ Reason: MultipleReasons
 Message: An unintended reversion to the default kubelet nodeStatusReportFrequency can cause significant load on the control plane. https://issues.redhat.com/browse/MCO-1094
   
   After rebooting into kernel-4.18.0-372.88.1.el8_6 or later, kernel nodes experience high load average and io_wait times. The nodes might fail to start or stop pods and probes may fail. Workload and host processes may become unresponsive and workload may be disrupted. https://issues.redhat.com/browse/COS-2705
+
+error: issues that apply to this cluster but which were not included in --accept: AlertNoTestData,ConditionalUpdateRisk

--- a/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-recommended.version-4.12.51-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.12.16-longest-recommended.version-4.12.51-output
@@ -15,3 +15,5 @@ Reason: MultipleReasons
 Message: An unintended reversion to the default kubelet nodeStatusReportFrequency can cause significant load on the control plane. https://issues.redhat.com/browse/MCO-1094
   
   After rebooting into kernel-4.18.0-372.88.1.el8_6 or later, kernel nodes experience high load average and io_wait times. The nodes might fail to start or stop pods and probes may fail. Workload and host processes may become unresponsive and workload may be disrupted. https://issues.redhat.com/browse/COS-2705
+
+error: issues that apply to this cluster but which were not included in --accept: AlertNoTestData,ConditionalUpdateRisk

--- a/pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring.version-4.16.32-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.16.27-degraded-monitoring.version-4.16.32-output
@@ -23,3 +23,5 @@ Channel: candidate-4.16 (available channels: candidate-4.16, candidate-4.17, can
 Update to 4.16.32 has no known issues relevant to this cluster.
 Image: quay.io/openshift-release-dev/ocp-release@sha256:0e71cb61694473b40e8d95f530eaf250a62616debb98199f31b4034808687dae
 Release URL: https://access.redhat.com/errata/RHSA-2025:0650
+
+error: issues that apply to this cluster but which were not included in --accept: ClusterOperatorDown,Failing,PodDisruptionBudgetAtLimit


### PR DESCRIPTION
To make that functionality generally available.  This could be a more thorough overhaul, e.g. I could drop the `precheckEnabled` knob entirely.  But I'm doing the smallest possible pivot now, in case folks want to backport to older 4.y.  And I can do the dev-branch polishing later on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The upgrade recommendation command now always exposes the quiet and accept options without extra enablement.
  * Prechecks run by default to surface potential issues before proceeding.
  * Acceptance is consistently enforced: the command errors if any issues remain unaccepted; if all issues are accepted, a confirmation is shown (suppressed in quiet mode).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->