### PR TITLE
OCPBUGS-61311: Introduce auto-open-browser flag for external OIDC issuer login

### DIFF
--- a/pkg/cli/login/login.go
+++ b/pkg/cli/login/login.go
@@ -98,6 +98,7 @@ func NewCmdLogin(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.
 	cmds.Flags().StringSliceVar(&o.OIDCExtraScopes, "extra-scopes", o.OIDCExtraScopes, "Experimental: Extra scopes for external OIDC issuer. Optional.")
 	cmds.Flags().StringVar(&o.OIDCIssuerURL, "issuer-url", o.OIDCIssuerURL, "Experimental: Issuer url for external issuer. Required.")
 	cmds.Flags().StringVar(&o.OIDCCAFile, "oidc-certificate-authority", o.OIDCCAFile, "Experimental: The path to a certificate authority bundle to use when communicating with external OIDC issuer.")
+	cmds.Flags().BoolVar(&o.OIDCAutoOpenBrowser, "auto-open-browser", o.OIDCAutoOpenBrowser, "Experimental: Specify browser is automatically opened or not for external OIDC issuer. Disabled by default.")
 	return cmds
 }
 
@@ -190,7 +191,7 @@ func (o LoginOptions) Validate(cmd *cobra.Command, serverFlag string, args []str
 		return errors.New("currently only oc-oidc is supported")
 	}
 
-	oidcOptionsSet := o.OIDCClientID != "" || o.OIDCClientSecret != "" || len(o.OIDCExtraScopes) > 0 || o.OIDCIssuerURL != ""
+	oidcOptionsSet := o.OIDCClientID != "" || o.OIDCClientSecret != "" || len(o.OIDCExtraScopes) > 0 || o.OIDCIssuerURL != "" || o.OIDCAutoOpenBrowser
 
 	if o.OIDCExecPluginType == "" && oidcOptionsSet {
 		return errors.New("please specify --exec-plugin type. Currently only oc-oidc is supported")

--- a/pkg/cli/login/loginoptions.go
+++ b/pkg/cli/login/loginoptions.go
@@ -80,12 +80,13 @@ type LoginOptions struct {
 	CertFile string
 	KeyFile  string
 
-	OIDCExecPluginType string
-	OIDCClientID       string
-	OIDCClientSecret   string
-	OIDCExtraScopes    []string
-	OIDCIssuerURL      string
-	OIDCCAFile         string
+	OIDCExecPluginType  string
+	OIDCClientID        string
+	OIDCClientSecret    string
+	OIDCExtraScopes     []string
+	OIDCIssuerURL       string
+	OIDCCAFile          string
+	OIDCAutoOpenBrowser bool
 
 	Token string
 
@@ -370,6 +371,10 @@ func (o *LoginOptions) prepareBuiltinExecPlugin() (*kclientcmdapi.ExecConfig, er
 
 	if len(o.OIDCCAFile) > 0 {
 		execProvider.Args = append(execProvider.Args, fmt.Sprintf("--certificate-authority=%s", o.OIDCCAFile))
+	}
+
+	if o.OIDCAutoOpenBrowser {
+		execProvider.Args = append(execProvider.Args, "--auto-open-browser")
 	}
 
 	return execProvider, nil


### PR DESCRIPTION
`oc get-token` supports automatically opening browser during the process of logging to external OIDC issuer. However, `oc login` does not expose any flag to wire it from `oc login`.

This PR introduces a new flag, namely `--auto-open-browser` in oc login command to wire it to `oc get-token` in order to automatically open browsers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an experimental --auto-open-browser flag to the login command to automatically launch your system browser for OIDC authentication.
  * Disabled by default; enable per-invocation for a smoother sign-in flow.
  * Supported in the built-in OIDC exec-plugin path to reduce manual steps during authentication.
  * Validation now prevents using the flag unless a supported OIDC exec-plugin is selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->