### PR TITLE
OCPBUGS-52936: oc adm policy: Only initialize UserClient if built-in OAuth is enabled

### DIFF
--- a/pkg/cli/admin/policy/modify_roles.go
+++ b/pkg/cli/admin/policy/modify_roles.go
@@ -355,7 +355,7 @@ func (o *RoleModificationOptions) innerComplete(f kcmdutil.Factory, cmd *cobra.C
 		return err
 	}
 
-	found := false
+	userAPIAvailable := false
 	groupList, err := o.DiscoveryClient.ServerGroups()
 	if discovery.IsGroupDiscoveryFailedError(err) {
 		// proceed with partial results; treat missing groups as "not found"
@@ -369,11 +369,11 @@ func (o *RoleModificationOptions) innerComplete(f kcmdutil.Factory, cmd *cobra.C
 		// Because we don't need UserClient, if external OIDC is used.
 		// Simply checking the existence of userv1 in the discovery can signal us whether built-in OAuth is functioning or not.
 		if group.PreferredVersion.GroupVersion == userv1.GroupVersion.String() {
-			found = true
+			userAPIAvailable = true
 			break
 		}
 	}
-	if found {
+	if userAPIAvailable {
 		o.UserClient, err = userv1client.NewForConfig(clientConfig)
 		if err != nil {
 			return err


### PR DESCRIPTION
`UserClient` is strictly tied to `User` object in OpenShift clusters. However, `User` resource is not served, if the external OIDC is configured instead. 

That causes improper HTTP calls to the server against a resource that already does not exist. 

This PR uses discovery client to decide whether external OIDC is configured or not in the cluster by checking the existence of `user.openshift.io/v1` GroupVersion. And only initializes `UserClient`, if discovery client serves `user.openshift.io/v1`