### PR TITLE
NO-JIRA: Add some warnings into excluded list

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,6 +5,10 @@ exclude:
   global:
     - vendor/**
     - "**/*_test.go"
+    - pkg/cli/admin/internal/codesign/machoresign.go # the paths are fed by oc
+    - pkg/cli/admin/release/new.go # we sanitize the directory
+    - pkg/cli/rsync/copy_tar.go # mostly directories are determined by oc
+    - pkg/helpers/source-to-image/tar/tar.go # we sanitize the directory
     - pkg/cli/image/archive/archive.go # this is copy of moby/moby/pkg/archive and making any changes is risky that may create uneasy to find bugs.
     - pkg/cli/admin/inspect/util.go # InsecureSkipVerify is required to show the event page which is managed by CI jobs.
     - pkg/cli/admin/release/git.go  # md5 is used to generate repo name in remoteNameForRepo func and to be compatible with git, md5 is required.


### PR DESCRIPTION
Although we fixed these failures, snyk started raising warning to fix more. However, fixing these requires some changes that are prone to regression. For now, I'll enrich excluded list for these with appropriate comments. 

Thanks to that we'll have a clear signal of snyk failures to detect any vulnerabilities. Otherwise, it is perma-failing.