### PR TITLE
OCPBUGS-59311: pkg/.../inspect: Add support for context.Context

### DIFF
--- a/pkg/cli/admin/inspect/admission_webhooks.go
+++ b/pkg/cli/admin/inspect/admission_webhooks.go
@@ -1,6 +1,7 @@
 package inspect
 
 import (
+	"context"
 	"fmt"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/util/errors"
@@ -20,41 +21,41 @@ func (c *mutatingWebhookConfigList) addItem(obj interface{}) error {
 	return nil
 }
 
-func gatherMutatingAdmissionWebhook(context *resourceContext, info *resource.Info, o *InspectOptions) error {
+func gatherMutatingAdmissionWebhook(ctx context.Context, resourceCtx *resourceContext, info *resource.Info, o *InspectOptions) error {
 	structuredObj, err := toStructuredObject[admissionregistrationv1.MutatingWebhookConfiguration, admissionregistrationv1.MutatingWebhookConfigurationList](info.Object)
 	if err != nil {
-		return gatherGenericObject(context, info, o)
+		return gatherGenericObject(ctx, resourceCtx, info, o)
 	}
 
 	errs := []error{}
 	switch castObj := structuredObj.(type) {
 	case *admissionregistrationv1.MutatingWebhookConfiguration:
-		if err := gatherMutatingAdmissionWebhookRelated(context, o, castObj); err != nil {
+		if err := gatherMutatingAdmissionWebhookRelated(ctx, resourceCtx, o, castObj); err != nil {
 			errs = append(errs, err)
 		}
 
 	case *admissionregistrationv1.MutatingWebhookConfigurationList:
 		for _, webhook := range castObj.Items {
-			if err := gatherMutatingAdmissionWebhookRelated(context, o, &webhook); err != nil {
+			if err := gatherMutatingAdmissionWebhookRelated(ctx, resourceCtx, o, &webhook); err != nil {
 				errs = append(errs, err)
 			}
 		}
 
 	}
 
-	if err := gatherGenericObject(context, info, o); err != nil {
+	if err := gatherGenericObject(ctx, resourceCtx, info, o); err != nil {
 		errs = append(errs, err)
 	}
 	return errors.NewAggregate(errs)
 }
 
-func gatherMutatingAdmissionWebhookRelated(context *resourceContext, o *InspectOptions, webhookConfig *admissionregistrationv1.MutatingWebhookConfiguration) error {
+func gatherMutatingAdmissionWebhookRelated(ctx context.Context, resourceCtx *resourceContext, o *InspectOptions, webhookConfig *admissionregistrationv1.MutatingWebhookConfiguration) error {
 	errs := []error{}
 	for _, webhook := range webhookConfig.Webhooks {
 		if webhook.ClientConfig.Service == nil {
 			continue
 		}
-		if err := gatherNamespaces(context, o, webhook.ClientConfig.Service.Namespace); err != nil {
+		if err := gatherNamespaces(ctx, resourceCtx, o, webhook.ClientConfig.Service.Namespace); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -75,41 +76,41 @@ func (c *validatingWebhookConfigList) addItem(obj interface{}) error {
 	return nil
 }
 
-func gatherValidatingAdmissionWebhook(context *resourceContext, info *resource.Info, o *InspectOptions) error {
+func gatherValidatingAdmissionWebhook(ctx context.Context, resourceCtx *resourceContext, info *resource.Info, o *InspectOptions) error {
 	structuredObj, err := toStructuredObject[admissionregistrationv1.ValidatingWebhookConfiguration, admissionregistrationv1.ValidatingWebhookConfigurationList](info.Object)
 	if err != nil {
-		return gatherGenericObject(context, info, o)
+		return gatherGenericObject(ctx, resourceCtx, info, o)
 	}
 
 	errs := []error{}
 	switch castObj := structuredObj.(type) {
 	case *admissionregistrationv1.ValidatingWebhookConfiguration:
-		if err := gatherValidatingAdmissionWebhookRelated(context, o, castObj); err != nil {
+		if err := gatherValidatingAdmissionWebhookRelated(ctx, resourceCtx, o, castObj); err != nil {
 			errs = append(errs, err)
 		}
 
 	case *admissionregistrationv1.ValidatingWebhookConfigurationList:
 		for _, webhook := range castObj.Items {
-			if err := gatherValidatingAdmissionWebhookRelated(context, o, &webhook); err != nil {
+			if err := gatherValidatingAdmissionWebhookRelated(ctx, resourceCtx, o, &webhook); err != nil {
 				errs = append(errs, err)
 			}
 		}
 
 	}
 
-	if err := gatherGenericObject(context, info, o); err != nil {
+	if err := gatherGenericObject(ctx, resourceCtx, info, o); err != nil {
 		errs = append(errs, err)
 	}
 	return errors.NewAggregate(errs)
 }
 
-func gatherValidatingAdmissionWebhookRelated(context *resourceContext, o *InspectOptions, webhookConfig *admissionregistrationv1.ValidatingWebhookConfiguration) error {
+func gatherValidatingAdmissionWebhookRelated(ctx context.Context, resourceCtx *resourceContext, o *InspectOptions, webhookConfig *admissionregistrationv1.ValidatingWebhookConfiguration) error {
 	errs := []error{}
 	for _, webhook := range webhookConfig.Webhooks {
 		if webhook.ClientConfig.Service == nil {
 			continue
 		}
-		if err := gatherNamespaces(context, o, webhook.ClientConfig.Service.Namespace); err != nil {
+		if err := gatherNamespaces(ctx, resourceCtx, o, webhook.ClientConfig.Service.Namespace); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/pkg/cli/admin/inspect/proxy.go
+++ b/pkg/cli/admin/inspect/proxy.go
@@ -1,6 +1,7 @@
 package inspect
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path"
@@ -28,7 +29,7 @@ func (c *proxyList) addItem(obj interface{}) error {
 	return nil
 }
 
-func inspectProxyInfo(info *resource.Info, o *InspectOptions) error {
+func inspectProxyInfo(ctx context.Context, info *resource.Info, o *InspectOptions) error {
 	structuredObj, err := toStructuredObject[configv1.Proxy, configv1.ProxyList](info.Object)
 	if err != nil {
 		return err
@@ -51,7 +52,7 @@ func inspectProxyInfo(info *resource.Info, o *InspectOptions) error {
 	if err := os.MkdirAll(dirPath, os.ModePerm); err != nil {
 		return err
 	}
-	return o.fileWriter.WriteFromResource(path.Join(dirPath, filename), structuredObj)
+	return o.fileWriter.WriteFromResource(ctx, path.Join(dirPath, filename), structuredObj)
 }
 
 // elideProxy obfuscates the sensitive information from proxy object.

--- a/pkg/cli/admin/inspect/route.go
+++ b/pkg/cli/admin/inspect/route.go
@@ -1,6 +1,7 @@
 package inspect
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path"
@@ -24,7 +25,7 @@ func (c *routeList) addItem(obj interface{}) error {
 	return nil
 }
 
-func inspectRouteInfo(info *resource.Info, o *InspectOptions) error {
+func inspectRouteInfo(ctx context.Context, info *resource.Info, o *InspectOptions) error {
 	structuredObj, err := toStructuredObject[routev1.Route, routev1.RouteList](info.Object)
 	if err != nil {
 		return err
@@ -47,7 +48,7 @@ func inspectRouteInfo(info *resource.Info, o *InspectOptions) error {
 	if err := os.MkdirAll(dirPath, os.ModePerm); err != nil {
 		return err
 	}
-	return o.fileWriter.WriteFromResource(path.Join(dirPath, filename), structuredObj)
+	return o.fileWriter.WriteFromResource(ctx, path.Join(dirPath, filename), structuredObj)
 }
 
 func elideRoute(route *routev1.Route) {

--- a/pkg/cli/admin/inspect/secret.go
+++ b/pkg/cli/admin/inspect/secret.go
@@ -1,6 +1,7 @@
 package inspect
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path"
@@ -25,7 +26,7 @@ func (c *secretList) addItem(obj interface{}) error {
 	return nil
 }
 
-func inspectSecretInfo(info *resource.Info, o *InspectOptions) error {
+func inspectSecretInfo(ctx context.Context, info *resource.Info, o *InspectOptions) error {
 	structuredObj, err := toStructuredObject[corev1.Secret, corev1.SecretList](info.Object)
 	if err != nil {
 		return err
@@ -49,7 +50,7 @@ func inspectSecretInfo(info *resource.Info, o *InspectOptions) error {
 	if err := os.MkdirAll(dirPath, os.ModePerm); err != nil {
 		return err
 	}
-	return o.fileWriter.WriteFromResource(path.Join(dirPath, filename), structuredObj)
+	return o.fileWriter.WriteFromResource(ctx, path.Join(dirPath, filename), structuredObj)
 }
 
 var publicSecretKeys = sets.NewString(

--- a/pkg/cli/admin/inspect/writer.go
+++ b/pkg/cli/admin/inspect/writer.go
@@ -50,14 +50,14 @@ func (r *resourceWriterReadCloser) Close() error {
 
 type simpleFileWriter struct{}
 
-func (f *simpleFileWriter) Write(filepath string, src fileWriterSource) error {
+func (f *simpleFileWriter) Write(ctx context.Context, filepath string, src fileWriterSource) error {
 	dest, err := os.OpenFile(filepath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
 	if err != nil {
 		return err
 	}
 	defer dest.Close()
 
-	readCloser, err := src.Stream(context.TODO())
+	readCloser, err := src.Stream(ctx)
 	if err != nil {
 		return err
 	}
@@ -71,19 +71,19 @@ type MultiSourceFileWriter struct {
 	printer printers.ResourcePrinter
 }
 
-func (f *MultiSourceFileWriter) WriteFromSource(filepath string, source fileWriterSource) error {
+func (f *MultiSourceFileWriter) WriteFromSource(ctx context.Context, filepath string, source fileWriterSource) error {
 	writer := &simpleFileWriter{}
-	return writer.Write(filepath, source)
+	return writer.Write(ctx, filepath, source)
 }
 
-func (f *MultiSourceFileWriter) WriteFromResource(filepath string, obj runtime.Object) error {
+func (f *MultiSourceFileWriter) WriteFromResource(ctx context.Context, filepath string, obj runtime.Object) error {
 	source := &resourceWriterSource{
 		obj:     obj,
 		printer: f.printer,
 	}
 
 	writer := &simpleFileWriter{}
-	return writer.Write(filepath, source)
+	return writer.Write(ctx, filepath, source)
 }
 
 func NewMultiSourceWriter(printer printers.ResourcePrinter) *MultiSourceFileWriter {


### PR DESCRIPTION
`context.Context` is now being passed around to support interrupting the whole inspection process.
`RunContext` method is the entry point.

There is no functional change.

Split from https://github.com/openshift/oc/pull/2062