### PR TITLE
OCPBUGS-60903: oc adm release extract: add oc-mirror to the tools list

### DIFF
--- a/pkg/cli/admin/release/extract_tools.go
+++ b/pkg/cli/admin/release/extract_tools.go
@@ -209,6 +209,27 @@ var (
 	program is [located on github](https://github.com/openshift/cloud-credential-operator).
 	`)
 
+	readmeOCMirror = heredoc.Doc(`
+	# OC Mirror Utility
+
+	The oc-mirror tool assists with mirroring Openshift release content from a target
+	registry to another for disconnected install scenarios.
+
+	To learn more about OpenShift, visit [docs.openshift.com](https://docs.openshift.com)
+	and select the version of OpenShift you are using.
+
+	# Installing the tools
+
+	After extracting this archive, move the \u0060oc-mirror\u0060 binary to a location on your
+	PATH such as \u0060/usr/local/bin\u0060, or keep it in a temporary directory and
+	reference it via \u0060./oc-mirror\u0060.
+
+	## License
+
+	OpenShift is licensed under the Apache Public License 2.0. The source code for this
+	program is [located on github](https://github.com/openshift/oc-mirror).
+	`)
+
 	// indicates that the architecture of the binary matches the release payload
 	targetReleaseArch = "release-arch"
 )
@@ -525,6 +546,36 @@ func (o *ExtractOptions) extractCommand(command string) error {
 			Readme:            readmeCCOUnix,
 			ArchiveFormat:     "ccoctl-linux-rhel9-%s.tar.gz",
 			TargetCommandName: "ccoctl",
+		},
+		{
+			OS:                   "linux",
+			Arch:                 targetReleaseArch,
+			Command:              "oc-mirror.rhel9",
+			InjectReleaseVersion: true,
+			Mapping:              extract.Mapping{Image: "oc-mirror", From: "usr/bin/oc-mirror.rhel9"},
+			Readme:               readmeOCMirror,
+			ArchiveFormat:        "oc-mirror.rhel9-%s.tar.gz",
+			TargetCommandName:    "oc-mirror",
+		},
+		{
+			OS:                   "linux",
+			Arch:                 targetReleaseArch,
+			Command:              "oc-mirror.rhel8",
+			InjectReleaseVersion: true,
+			Mapping:              extract.Mapping{Image: "oc-mirror", From: "usr/bin/oc-mirror.rhel8"},
+			Readme:               readmeOCMirror,
+			ArchiveFormat:        "oc-mirror.rhel8-%s.tar.gz",
+			TargetCommandName:    "oc-mirror",
+		},
+		{
+			OS:                   "linux",
+			Arch:                 targetReleaseArch,
+			Command:              "oc-mirror",
+			InjectReleaseVersion: true,
+			Mapping:              extract.Mapping{Image: "oc-mirror", From: "usr/bin/oc-mirror"},
+			Readme:               readmeOCMirror,
+			ArchiveFormat:        "oc-mirror-%s.tar.gz",
+			TargetCommandName:    "oc-mirror",
 		},
 	}
 


### PR DESCRIPTION
This will allow oc-mirror to be injected with the OCP release version it's a part of.