### PR TITLE
OCPBUGS-62445: prevent crash when rootDeviceHints format is invalid

### DIFF
--- a/pkg/cli/admin/nodeimage/create.go
+++ b/pkg/cli/admin/nodeimage/create.go
@@ -635,6 +635,9 @@ func (o *CreateOptions) createConfigFileFromFlags() ([]byte, error) {
 	}
 	if o.SingleNodeOpts.RootDeviceHints != "" {
 		parts := strings.SplitN(o.SingleNodeOpts.RootDeviceHints, ":", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("incorrect rootDeviceHints format provided: %s. Expected format: <hint name>:<value>, for example: deviceName:/dev/sda", o.SingleNodeOpts.RootDeviceHints)
+		}
 		host["rootDeviceHints"] = map[string]interface{}{
 			parts[0]: parts[1],
 		}

--- a/pkg/cli/admin/nodeimage/create_test.go
+++ b/pkg/cli/admin/nodeimage/create_test.go
@@ -663,6 +663,13 @@ func TestCreateConfigFileFromFlags(t *testing.T) {
 			expectedConfigFile: expectedConfigFile,
 		},
 		{
+			name: "root device hints incorrect",
+			singleNodeCreateOptions: &singleNodeCreateOptions{
+				RootDeviceHints: "/dev/sda",
+			},
+			expectedError: "incorrect rootDeviceHints format provided: /dev/sda. Expected format: <hint name>:<value>, for example: deviceName:/dev/sda",
+		},
+		{
 			name: "ssh-key-path missing or incorrect",
 			singleNodeCreateOptions: &singleNodeCreateOptions{
 				SSHKeyPath: "wrong-ssh-key-file-name",


### PR DESCRIPTION
This PR adds validation for the --root-device-hint flag in the Create Node Image command.
Previously, providing an invalid format would cause the command to crash with a stack trace.