### PR TITLE
CNTRLPLANE-1538: extend --auto-open-browser to work with --web

### DIFF
--- a/pkg/cli/login/loginoptions.go
+++ b/pkg/cli/login/loginoptions.go
@@ -317,8 +317,14 @@ func (o *LoginOptions) gatherAuthInfo() error {
 	if o.WebLogin {
 		loginURLHandler := func(u *url.URL) error {
 			loginURL := u.String()
-			fmt.Fprintf(o.Out, "Opening login URL in the default browser: %s\n", loginURL)
-			return browser.OpenURL(loginURL)
+			if !o.OIDCAutoOpenBrowser {
+				fmt.Fprintf(o.Out, "Please visit the following URL in your browser: %s\n", loginURL)
+				fmt.Fprintf(o.Out, "The callback server is listening and will receive the authentication response.\n")
+				return nil
+			} else {
+				fmt.Fprintf(o.Out, "Opening login URL in the default browser: %s\n", loginURL)
+				return browser.OpenURL(loginURL)
+			}
 		}
 		token, err = tokenrequest.RequestTokenWithLocalCallback(o.Config, loginURLHandler, int(o.CallbackPort))
 	} else {


### PR DESCRIPTION
## Summary
• Extend the existing --auto-open-browser flag to support web login in addition to OIDC login
• Provides a consistent interface for controlling browser behavior across both authentication methods
• When --web is used with --auto-open-browser=false, the authorization URL is printed instead of being automatically opened
• Useful for environments where browser automation is not desired or possible (e.g., Konflux)

## Changes
• Extended --auto-open-browser flag to work with both --web and --exec-plugin
• Updated flag documentation to clarify default behavior (true for --web, false for OIDC)
• Set default to true when using --web (unless explicitly overridden)
• Removed --auto-open-browser from OIDC-only validation checks
• Updated login examples to show --auto-open-browser=false usage
• Updated test coverage to reflect new behavior

## Test plan
- [x] Test --web flag without --auto-open-browser (defaults to true, opens browser)
- [x] Test --web --auto-open-browser=false (prints URL without opening)
- [x] Test --auto-open-browser with OIDC login (existing behavior preserved)
- [x] Run all login tests to ensure no regression (all passing)
- [x] Verify successful build

Fixes: [CNTRLPLANE-1538](https://issues.redhat.com//browse/CNTRLPLANE-1538)

🤖 Generated with [Claude Code](https://claude.com/claude-code)