### PR TITLE
OCPBUGS-62875: Pass dry-run option to all create API calls

### DIFF
--- a/pkg/cli/create/build.go
+++ b/pkg/cli/create/build.go
@@ -219,7 +219,7 @@ func (o *CreateBuildOptions) Run() error {
 
 	if o.CreateSubcommandOptions.DryRunStrategy != cmdutil.DryRunClient {
 		var err error
-		build, err = o.Client.Builds(o.CreateSubcommandOptions.Namespace).Create(context.TODO(), build, metav1.CreateOptions{})
+		build, err = o.Client.Builds(o.CreateSubcommandOptions.Namespace).Create(context.TODO(), build, o.CreateSubcommandOptions.toCreateOptions())
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/create/clusterquota.go
+++ b/pkg/cli/create/clusterquota.go
@@ -137,7 +137,7 @@ func (o *CreateClusterQuotaOptions) Run() error {
 
 	if o.CreateSubcommandOptions.DryRunStrategy != cmdutil.DryRunClient {
 		var err error
-		clusterQuota, err = o.Client.ClusterResourceQuotas().Create(context.TODO(), clusterQuota, metav1.CreateOptions{})
+		clusterQuota, err = o.Client.ClusterResourceQuotas().Create(context.TODO(), clusterQuota, o.CreateSubcommandOptions.toCreateOptions())
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/create/create.go
+++ b/pkg/cli/create/create.go
@@ -3,6 +3,7 @@ package create
 import (
 	"github.com/spf13/cobra"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
@@ -62,6 +63,15 @@ func (o *CreateSubcommandOptions) Complete(f genericclioptions.RESTClientGetter,
 	}
 
 	return nil
+}
+
+func (o *CreateSubcommandOptions) toCreateOptions() metav1.CreateOptions {
+	createOptions := metav1.CreateOptions{}
+	if o.DryRunStrategy == cmdutil.DryRunServer {
+		createOptions.DryRun = []string{metav1.DryRunAll}
+	}
+
+	return createOptions
 }
 
 // NameFromCommandArgs is a utility function for commands that assume the first argument is a resource name

--- a/pkg/cli/create/deploymentconfig.go
+++ b/pkg/cli/create/deploymentconfig.go
@@ -111,7 +111,7 @@ func (o *CreateDeploymentConfigOptions) Run() error {
 
 	if o.CreateSubcommandOptions.DryRunStrategy != cmdutil.DryRunClient {
 		var err error
-		deploymentConfig, err = o.Client.DeploymentConfigs(o.CreateSubcommandOptions.Namespace).Create(context.TODO(), deploymentConfig, metav1.CreateOptions{})
+		deploymentConfig, err = o.Client.DeploymentConfigs(o.CreateSubcommandOptions.Namespace).Create(context.TODO(), deploymentConfig, o.CreateSubcommandOptions.toCreateOptions())
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/create/identity.go
+++ b/pkg/cli/create/identity.go
@@ -112,7 +112,7 @@ func (o *CreateIdentityOptions) Run() error {
 
 	if o.CreateSubcommandOptions.DryRunStrategy != cmdutil.DryRunClient {
 		var err error
-		identity, err = o.IdentityClient.Identities().Create(context.TODO(), identity, metav1.CreateOptions{})
+		identity, err = o.IdentityClient.Identities().Create(context.TODO(), identity, o.CreateSubcommandOptions.toCreateOptions())
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/create/imagestream.go
+++ b/pkg/cli/create/imagestream.go
@@ -99,7 +99,7 @@ func (o *CreateImageStreamOptions) Run() error {
 
 	if o.CreateSubcommandOptions.DryRunStrategy != cmdutil.DryRunClient {
 		var err error
-		imageStream, err = o.Client.ImageStreams(o.CreateSubcommandOptions.Namespace).Create(context.TODO(), imageStream, metav1.CreateOptions{})
+		imageStream, err = o.Client.ImageStreams(o.CreateSubcommandOptions.Namespace).Create(context.TODO(), imageStream, o.CreateSubcommandOptions.toCreateOptions())
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/create/imagestreamtag.go
+++ b/pkg/cli/create/imagestreamtag.go
@@ -181,7 +181,7 @@ func (o *CreateImageStreamTagOptions) Run() error {
 	}
 
 	if o.CreateSubcommandOptions.DryRunStrategy != cmdutil.DryRunClient {
-		isTag, err = o.Client.ImageStreamTags(o.CreateSubcommandOptions.Namespace).Create(context.TODO(), isTag, metav1.CreateOptions{})
+		isTag, err = o.Client.ImageStreamTags(o.CreateSubcommandOptions.Namespace).Create(context.TODO(), isTag, o.CreateSubcommandOptions.toCreateOptions())
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/create/route.go
+++ b/pkg/cli/create/route.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
@@ -120,6 +121,15 @@ func (o *CreateRouteSubcommandOptions) Complete(f kcmdutil.Factory, cmd *cobra.C
 	}
 
 	return nil
+}
+
+func (o *CreateRouteSubcommandOptions) toCreateOptions() metav1.CreateOptions {
+	createOptions := metav1.CreateOptions{}
+	if o.DryRunStrategy == cmdutil.DryRunServer {
+		createOptions.DryRun = []string{metav1.DryRunAll}
+	}
+
+	return createOptions
 }
 
 func resolveRouteName(args []string) (string, error) {

--- a/pkg/cli/create/routeedge.go
+++ b/pkg/cli/create/routeedge.go
@@ -8,7 +8,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util"
@@ -137,7 +136,7 @@ func (o *CreateEdgeRouteOptions) Run() error {
 	}
 
 	if o.CreateRouteSubcommandOptions.DryRunStrategy != kcmdutil.DryRunClient {
-		route, err = o.CreateRouteSubcommandOptions.Client.Routes(o.CreateRouteSubcommandOptions.Namespace).Create(context.TODO(), route, metav1.CreateOptions{})
+		route, err = o.CreateRouteSubcommandOptions.Client.Routes(o.CreateRouteSubcommandOptions.Namespace).Create(context.TODO(), route, o.CreateRouteSubcommandOptions.toCreateOptions())
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/create/routepassthrough.go
+++ b/pkg/cli/create/routepassthrough.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util"
@@ -103,7 +102,7 @@ func (o *CreatePassthroughRouteOptions) Run() error {
 	}
 
 	if o.CreateRouteSubcommandOptions.DryRunStrategy != kcmdutil.DryRunClient {
-		route, err = o.CreateRouteSubcommandOptions.Client.Routes(o.CreateRouteSubcommandOptions.Namespace).Create(context.TODO(), route, metav1.CreateOptions{})
+		route, err = o.CreateRouteSubcommandOptions.Client.Routes(o.CreateRouteSubcommandOptions.Namespace).Create(context.TODO(), route, o.CreateRouteSubcommandOptions.toCreateOptions())
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/create/routereenecrypt.go
+++ b/pkg/cli/create/routereenecrypt.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util"
@@ -152,7 +151,7 @@ func (o *CreateReencryptRouteOptions) Run() error {
 	}
 
 	if o.CreateRouteSubcommandOptions.DryRunStrategy != kcmdutil.DryRunClient {
-		route, err = o.CreateRouteSubcommandOptions.Client.Routes(o.CreateRouteSubcommandOptions.Namespace).Create(context.TODO(), route, metav1.CreateOptions{})
+		route, err = o.CreateRouteSubcommandOptions.Client.Routes(o.CreateRouteSubcommandOptions.Namespace).Create(context.TODO(), route, o.CreateRouteSubcommandOptions.toCreateOptions())
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/create/user.go
+++ b/pkg/cli/create/user.go
@@ -107,7 +107,7 @@ func (o *CreateUserOptions) Run() error {
 
 	var err error
 	if o.CreateSubcommandOptions.DryRunStrategy != cmdutil.DryRunClient {
-		user, err = o.UserClient.Users().Create(context.TODO(), user, metav1.CreateOptions{})
+		user, err = o.UserClient.Users().Create(context.TODO(), user, o.CreateSubcommandOptions.toCreateOptions())
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/create/user_identity_mapping.go
+++ b/pkg/cli/create/user_identity_mapping.go
@@ -131,7 +131,7 @@ func (o *CreateUserIdentityMappingOptions) Run() error {
 
 	var err error
 	if o.CreateSubcommandOptions.DryRunStrategy != cmdutil.DryRunClient {
-		mapping, err = o.UserIdentityMappingClient.UserIdentityMappings().Create(context.TODO(), mapping, metav1.CreateOptions{})
+		mapping, err = o.UserIdentityMappingClient.UserIdentityMappings().Create(context.TODO(), mapping, o.CreateSubcommandOptions.toCreateOptions())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The `create` subcommands of `oc` do not pass along the `--dry-run` option when used on the command-line. Therefore, the server-side dry run is ignored, and the resources get created.

The fix provided in https://github.com/openshift/openshift-apiserver/pull/511 was necessary for image streams, but we also need wiring on the `oc` side.