### PR TITLE
OCPBUGS-63683: Replace IPv4-mapped IPv6 addresses with valid IPv6 in tests

### DIFF
--- a/pkg/helpers/source-to-image/git/url_test.go
+++ b/pkg/helpers/source-to-image/git/url_test.go
@@ -94,11 +94,11 @@ func TestParse(t *testing.T) {
 			},
 		},
 		parseTest{
-			rawurl: "http://[::ffff:1.2.3.4]:443",
+			rawurl: "http://[2001:db8::1]:443",
 			expectedGitURL: &URL{
 				URL: url.URL{
 					Scheme: "http",
-					Host:   "[::ffff:1.2.3.4]:443",
+					Host:   "[2001:db8::1]:443",
 				},
 				Type: URLTypeURL,
 			},
@@ -165,10 +165,10 @@ func TestParse(t *testing.T) {
 			},
 		},
 		parseTest{
-			rawurl: "[::ffff:1.2.3.4]:",
+			rawurl: "[2001:db8::1]:",
 			expectedGitURL: &URL{
 				URL: url.URL{
-					Host: "[::ffff:1.2.3.4]",
+					Host: "[2001:db8::1]",
 				},
 				Type: URLTypeSCP,
 			},


### PR DESCRIPTION
Replace IPv4-mapped IPv6 address format [::ffff:1.2.3.4] with a valid pure IPv6 address [2001:db8::1] in URL parsing tests.

Golang v1.24.8 and v1.25.2 introduced a security fix for CVE-2025-47912 that rejects IPv4 addresses appearing within square brackets. The IPv4-mapped IPv6 format embeds an IPv4 address within brackets, which is now considered invalid by Go's url.Parse() function.

This change maintains test coverage for IPv6 URL parsing while complying with the new security requirements in the Go standard library.

Fixes: OCPBUGS-63683

🤖 Generated with [Claude Code](https://claude.com/claude-code)