### PR TITLE
Do not verify TLS if cluster is configured as insecure

### DIFF
--- a/pkg/cli/login/loginoptions.go
+++ b/pkg/cli/login/loginoptions.go
@@ -160,7 +160,7 @@ func (o *LoginOptions) getClientConfig() (*restclient.Config, error) {
 	}
 	o.Server = serverNormalized
 	clientConfig.Host = o.Server
-	clientConfig.Insecure = o.InsecureTLS
+	clientConfig.Insecure = o.InsecureTLS || hasExistingInsecureCluster(*clientConfig, *o.StartingKubeConfig)
 
 	if !o.InsecureTLS {
 		// use specified CA or find existing CA
@@ -188,9 +188,7 @@ func (o *LoginOptions) getClientConfig() (*restclient.Config, error) {
 		// connection or if we already have a cluster stanza that tells us to
 		// connect to this particular server insecurely
 		case x509.UnknownAuthorityError, x509.HostnameError, x509.CertificateInvalidError:
-			if o.InsecureTLS ||
-				hasExistingInsecureCluster(*clientConfig, *o.StartingKubeConfig) ||
-				promptForInsecureTLS(o.In, o.Out, err) {
+			if promptForInsecureTLS(o.In, o.Out, err) {
 				clientConfig.Insecure = true
 				clientConfig.CAFile = ""
 				clientConfig.CAData = nil


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/OCPBUGS-64619