### PR TITLE
OCPBUGS-64619: oc login: Respect insecure flag from kubeconfig

### DIFF
--- a/pkg/cli/login/error_translation.go
+++ b/pkg/cli/login/error_translation.go
@@ -24,6 +24,8 @@ You can also run this command again providing the path to a config file directly
 Ensure the specified server supports HTTPS.`
 	invalidServerURLMsg = `Seems you passed an HTML page (console?) instead of server URL.
 Verify provided address and try again.`
+
+	insecureTransportCertificateAuthorityConflictMsg = "certificate-authority, certificate-authority-data are mutually exclusive with insecure-skip-tls-verify"
 )
 
 type errInvalidServerURL struct{}

--- a/pkg/cli/login/helpers.go
+++ b/pkg/cli/login/helpers.go
@@ -30,20 +30,14 @@ func getMatchingClusters(clientConfig restclient.Config, kubeconfig clientcmdapi
 	return ret
 }
 
-// findExistingClientCA returns *either* the existing client CA file name as a string,
-// *or* data in a []byte for a given host, and true if it exists in the given config
-func findExistingClientCA(host string, kubeconfig clientcmdapi.Config) (string, []byte, bool) {
+// findClusters returns the first cluster matching the host.
+func findCluster(host string, kubeconfig clientcmdapi.Config) *clientcmdapi.Cluster {
 	for _, cluster := range kubeconfig.Clusters {
 		if cluster.Server == host {
-			if len(cluster.CertificateAuthority) > 0 {
-				return cluster.CertificateAuthority, nil, true
-			}
-			if len(cluster.CertificateAuthorityData) > 0 {
-				return "", cluster.CertificateAuthorityData, true
-			}
+			return cluster
 		}
 	}
-	return "", nil, false
+	return nil
 }
 
 // dialToServer takes the Server URL from the given clientConfig and dials to

--- a/pkg/cli/login/loginoptions.go
+++ b/pkg/cli/login/loginoptions.go
@@ -163,13 +163,20 @@ func (o *LoginOptions) getClientConfig() (*restclient.Config, error) {
 	clientConfig.Insecure = o.InsecureTLS
 
 	if !o.InsecureTLS {
-		// use specified CA or find existing CA
+		// Try to use the specified CA. Then fall back into searching kubeconfig.
 		if len(o.CAFile) > 0 {
 			clientConfig.CAFile = o.CAFile
 			clientConfig.CAData = nil
-		} else if caFile, caData, ok := findExistingClientCA(clientConfig.Host, *o.StartingKubeConfig); ok {
-			clientConfig.CAFile = caFile
-			clientConfig.CAData = caData
+		} else if cluster := findCluster(clientConfig.Host, *o.StartingKubeConfig); cluster != nil {
+			clientConfig.Insecure = cluster.InsecureSkipTLSVerify
+			clientConfig.CAFile = cluster.CertificateAuthority
+			clientConfig.CAData = cluster.CertificateAuthorityData
+
+			// It's not allowed to specify both the insecure flag and a CA.
+			// k8s transport init machinery returns an error in that case.
+			if clientConfig.Insecure && (clientConfig.CAFile != "" || clientConfig.CAData != nil) {
+				return nil, errors.New(insecureTransportCertificateAuthorityConflictMsg)
+			}
 		}
 	}
 
@@ -188,7 +195,7 @@ func (o *LoginOptions) getClientConfig() (*restclient.Config, error) {
 		// connection or if we already have a cluster stanza that tells us to
 		// connect to this particular server insecurely
 		case x509.UnknownAuthorityError, x509.HostnameError, x509.CertificateInvalidError:
-			if o.InsecureTLS ||
+			if clientConfig.Insecure ||
 				hasExistingInsecureCluster(*clientConfig, *o.StartingKubeConfig) ||
 				promptForInsecureTLS(o.In, o.Out, err) {
 				clientConfig.Insecure = true


### PR DESCRIPTION
When running oc login, the insecure flag from kubeconfig is not consulted properly when calling `getClientConfig`.
This is now fixed.