### PR TITLE
OCPBUGS-63809: Bump Go v1.19 to v1.24

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.19-openshift-4.12
+  tag: rhel-8-release-golang-1.24-openshift-4.12

--- a/fix_format_strings.py
+++ b/fix_format_strings.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""
+Script to fix non-constant format string issues in Go code.
+This script identifies and fixes common patterns that cause go vet errors.
+"""
+import re
+import sys
+import os
+import subprocess
+
+def get_format_string_errors():
+    """Get all format string errors from go vet"""
+    try:
+        result = subprocess.run(['go', 'vet', '-mod=vendor', './...'], 
+                              capture_output=True, text=True, cwd='/home/mbasim/Documents/components/oc')
+        errors = []
+        for line in result.stderr.split('\n'):
+            if 'non-constant format string' in line:
+                # Parse: pkg/path/file.go:line:col: non-constant format string in call to func
+                match = re.match(r'([^:]+):(\d+):\d+: non-constant format string in call to (.+)', line)
+                if match:
+                    errors.append({
+                        'file': match.group(1),
+                        'line': int(match.group(2)),
+                        'function': match.group(3)
+                    })
+        return errors
+    except Exception as e:
+        print(f"Error getting format string errors: {e}")
+        return []
+
+def fix_format_string_in_file(filepath, line_num, function_name):
+    """Fix a specific format string issue in a file"""
+    full_path = f"/home/mbasim/Documents/components/oc/{filepath}"
+    
+    if not os.path.exists(full_path):
+        print(f"File not found: {full_path}")
+        return False
+        
+    try:
+        with open(full_path, 'r') as f:
+            lines = f.readlines()
+            
+        if line_num > len(lines):
+            print(f"Line {line_num} out of range in {filepath}")
+            return False
+            
+        original_line = lines[line_num - 1]
+        fixed_line = original_line
+        
+        # Common patterns to fix
+        patterns = [
+            # fmt.Fprintf(out, variable) -> fmt.Fprintf(out, "%s", variable)
+            (r'fmt\.Fprintf\(([^,]+),\s*([^,\)]+)\)', r'fmt.Fprintf(\1, "%s", \2)'),
+            # fmt.Errorf(variable) -> fmt.Errorf("%s", variable)  
+            (r'fmt\.Errorf\(([^,\)]+)\)', r'fmt.Errorf("%s", \1)'),
+            # fmt.Sprintf(variable) -> variable (when used in another fmt function)
+            (r'fmt\.Fprintf\(([^,]+),\s*fmt\.Sprintf\(([^)]+)\)\)', r'fmt.Fprintf(\1, \2)'),
+            # util.UsageErrorf(variable) -> util.UsageErrorf("%s", variable)
+            (r'util\.UsageErrorf\(([^,\)]+)\)', r'util.UsageErrorf("%s", \1)'),
+        ]
+        
+        for pattern, replacement in patterns:
+            if re.search(pattern, fixed_line):
+                fixed_line = re.sub(pattern, replacement, fixed_line)
+                break
+                
+        if fixed_line != original_line:
+            lines[line_num - 1] = fixed_line
+            with open(full_path, 'w') as f:
+                f.writelines(lines)
+            print(f"Fixed {filepath}:{line_num}")
+            print(f"  Before: {original_line.strip()}")
+            print(f"  After:  {fixed_line.strip()}")
+            return True
+        else:
+            print(f"Could not automatically fix {filepath}:{line_num}")
+            print(f"  Line: {original_line.strip()}")
+            return False
+            
+    except Exception as e:
+        print(f"Error fixing {filepath}:{line_num}: {e}")
+        return False
+
+def main():
+    print("Finding format string errors...")
+    errors = get_format_string_errors()
+    
+    if not errors:
+        print("No format string errors found!")
+        return
+        
+    print(f"Found {len(errors)} format string errors")
+    
+    fixed_count = 0
+    for error in errors:
+        if fix_format_string_in_file(error['file'], error['line'], error['function']):
+            fixed_count += 1
+            
+    print(f"\nFixed {fixed_count} out of {len(errors)} errors")
+    
+    if fixed_count > 0:
+        print("\nRunning go vet again to check remaining issues...")
+        subprocess.run(['go', 'vet', '-mod=vendor', './...'], cwd='/home/mbasim/Documents/components/oc')
+
+if __name__ == '__main__':
+    main()

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/oc
 
-go 1.19
+go 1.24
 
 require (
 	github.com/AaronO/go-git-http v0.0.0-20161214145340-1d9485b3a98f

--- a/go.sum
+++ b/go.sum
@@ -802,12 +802,14 @@ github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/ginkgo v1.12.1 h1:mFwc4LvZ0xpSvDZ3E+k8Yte0hLOMxXUlP+yXtJqkYfQ=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo/v2 v2.1.6 h1:Fx2POJZfKRQcM1pH49qSZiYeu319wji004qX+GDovrU=
+github.com/onsi/ginkgo/v2 v2.1.6/go.mod h1:MEH45j8TBi6u9BMogfbp0stKC5cdGjumZj5Y7AG4VIk=
 github.com/onsi/gomega v0.0.0-20151007035656-2152b45fa28a/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
 github.com/onsi/gomega v1.20.1 h1:PA/3qinGoukvymdIDV8pii6tiZgC8kbmJO6Z5+b002Q=
+github.com/onsi/gomega v1.20.1/go.mod h1:DtrZpjmvpn2mPm4YWQa0/ALMDj9v4YxLgojwPeREyVo=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=

--- a/images/cli/Dockerfile.rhel
+++ b/images/cli/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.24-openshift-4.12 AS builder
 WORKDIR /go/src/github.com/openshift/oc
 COPY . .
 RUN make build --warn-undefined-variables

--- a/pkg/cli/admin/admin.go
+++ b/pkg/cli/admin/admin.go
@@ -1,8 +1,6 @@
 package admin
 
 import (
-	"fmt"
-
 	"github.com/openshift/oc/pkg/cli/admin/buildchain"
 	"github.com/openshift/oc/pkg/cli/admin/catalog"
 	"github.com/openshift/oc/pkg/cli/admin/copytonode"
@@ -50,7 +48,7 @@ func NewCommandAdmin(f kcmdutil.Factory, streams genericclioptions.IOStreams) *c
 	cmds := &cobra.Command{
 		Use:   "adm",
 		Short: "Tools for managing a cluster",
-		Long:  fmt.Sprintf(adminLong),
+		Long:  adminLong,
 		Run:   kcmdutil.DefaultSubCommandRun(streams.ErrOut),
 	}
 

--- a/pkg/cli/admin/mustgather/mustgather.go
+++ b/pkg/cli/admin/mustgather/mustgather.go
@@ -335,7 +335,7 @@ func (o *MustGatherOptions) Run() error {
 			line := fmt.Sprintf("unable to parse image reference %s: %v", image, err)
 			o.log(line)
 			// ensure the errors bubble up to BackupGathering method for display
-			errs = []error{fmt.Errorf(line)}
+			errs = []error{fmt.Errorf("%s", line)}
 			return err
 		}
 		if o.NodeSelector != "" {

--- a/pkg/cli/admin/mustgather/mustgather_test.go
+++ b/pkg/cli/admin/mustgather/mustgather_test.go
@@ -104,7 +104,7 @@ func withTag(tag, reference string) func(*imagev1.ImageStream) *imagev1.ImageStr
 	return func(imageStream *imagev1.ImageStream) *imagev1.ImageStream {
 		imageStream.Status.Tags = append(imageStream.Status.Tags, imagev1.NamedTagEventList{
 			Tag:   tag,
-			Items: append([]imagev1.TagEvent{{DockerImageReference: reference}}),
+			Items: []imagev1.TagEvent{{DockerImageReference: reference}},
 		})
 		return imageStream
 	}

--- a/pkg/cli/admin/mustgather/summary.go
+++ b/pkg/cli/admin/mustgather/summary.go
@@ -45,7 +45,7 @@ func (o *MustGatherOptions) PrintBasicClusterState(ctx context.Context) {
 		fmt.Fprintf(o.RawOut, "error getting cluster operators: %v\n", err)
 	}
 	fmt.Fprintf(o.RawOut, "ClusterOperators:\n")
-	fmt.Fprintf(o.RawOut, humanSummaryForInterestingClusterOperators(clusterOperators)+"\n")
+	fmt.Fprintf(o.RawOut, "%s", humanSummaryForInterestingClusterOperators(clusterOperators)+"\n")
 
 	// TODO gather and display firing alerts
 	fmt.Fprintf(o.RawOut, "\n\n")

--- a/pkg/cli/admin/ocpcertificates/ocp_certificates.go
+++ b/pkg/cli/admin/ocpcertificates/ocp_certificates.go
@@ -1,8 +1,6 @@
 package ocpcertificates
 
 import (
-	"fmt"
-
 	"github.com/openshift/oc/pkg/cli/admin/ocpcertificates/monitorregeneration"
 
 	"github.com/openshift/oc/pkg/cli/admin/ocpcertificates/certregen"
@@ -25,7 +23,7 @@ func NewCommandOCPCertificates(f kcmdutil.Factory, streams genericclioptions.IOS
 	cmds := &cobra.Command{
 		Use:   "ocp-certificates",
 		Short: "Tools for managing a cluster's certificates",
-		Long:  fmt.Sprintf(ocpCertificatesLong),
+		Long:  ocpCertificatesLong,
 		Run:   kcmdutil.DefaultSubCommandRun(streams.ErrOut),
 	}
 

--- a/pkg/cli/admin/prune/auth/bindings.go
+++ b/pkg/cli/admin/prune/auth/bindings.go
@@ -36,7 +36,7 @@ func reapClusterBindings(removedSubject corev1.ObjectReference, c authv1client.A
 			if _, err := c.ClusterRoleBindings().Update(context.TODO(), &updatedBinding, metav1.UpdateOptions{}); err != nil && !kerrors.IsNotFound(err) {
 				errors = append(errors, err)
 			} else {
-				fmt.Fprintf(out, "clusterrolebinding.rbac.authorization.k8s.io/"+updatedBinding.Name+" updated\n")
+				fmt.Fprintf(out, "%s", "clusterrolebinding.rbac.authorization.k8s.io/"+updatedBinding.Name+" updated\n")
 			}
 		}
 	}
@@ -65,7 +65,7 @@ func reapNamespacedBindings(removedSubject corev1.ObjectReference, c authv1clien
 			if _, err := c.RoleBindings(binding.Namespace).Update(context.TODO(), &updatedBinding, metav1.UpdateOptions{}); err != nil && !kerrors.IsNotFound(err) {
 				errors = append(errors, err)
 			} else {
-				fmt.Fprintf(out, "rolebinding.rbac.authorization.k8s.io/"+updatedBinding.Name+" updated\n")
+				fmt.Fprintf(out, "%s", "rolebinding.rbac.authorization.k8s.io/"+updatedBinding.Name+" updated\n")
 			}
 		}
 	}

--- a/pkg/cli/admin/prune/auth/cluster_role.go
+++ b/pkg/cli/admin/prune/auth/cluster_role.go
@@ -23,7 +23,7 @@ func reapForClusterRole(clusterBindingClient rbacv1client.ClusterRoleBindingsGet
 			if err := clusterBindingClient.ClusterRoleBindings().Delete(context.TODO(), clusterBinding.Name, metav1.DeleteOptions{}); err != nil && !kerrors.IsNotFound(err) {
 				errors = append(errors, err)
 			} else {
-				fmt.Fprintf(out, "clusterrolebinding.rbac.authorization.k8s.io/"+clusterBinding.Name+" deleted\n")
+				fmt.Fprintf(out, "%s", "clusterrolebinding.rbac.authorization.k8s.io/"+clusterBinding.Name+" deleted\n")
 			}
 		}
 	}
@@ -37,7 +37,7 @@ func reapForClusterRole(clusterBindingClient rbacv1client.ClusterRoleBindingsGet
 			if err := bindingClient.RoleBindings(namespacedBinding.Namespace).Delete(context.TODO(), namespacedBinding.Name, metav1.DeleteOptions{}); err != nil && !kerrors.IsNotFound(err) {
 				errors = append(errors, err)
 			} else {
-				fmt.Fprintf(out, "rolebinding.rbac.authorization.k8s.io/"+namespacedBinding.Name+" deleted\n")
+				fmt.Fprintf(out, "%s", "rolebinding.rbac.authorization.k8s.io/"+namespacedBinding.Name+" deleted\n")
 			}
 		}
 	}

--- a/pkg/cli/admin/prune/auth/group.go
+++ b/pkg/cli/admin/prune/auth/group.go
@@ -44,7 +44,7 @@ func reapForGroup(
 			if _, err := securityClient.Update(context.TODO(), &updatedSCC, metav1.UpdateOptions{}); err != nil && !kerrors.IsNotFound(err) {
 				errors = append(errors, err)
 			} else {
-				fmt.Fprintf(out, "securitycontextconstraints.security.openshift.io/"+updatedSCC.Name+" updated\n")
+				fmt.Fprintf(out, "%s", "securitycontextconstraints.security.openshift.io/"+updatedSCC.Name+" updated\n")
 			}
 		}
 	}

--- a/pkg/cli/admin/prune/auth/role.go
+++ b/pkg/cli/admin/prune/auth/role.go
@@ -24,7 +24,7 @@ func reapForRole(bindingClient rbacv1client.RoleBindingsGetter, namespace, name 
 			if err := bindingClient.RoleBindings(namespace).Delete(context.TODO(), binding.Name, metav1.DeleteOptions{PropagationPolicy: &foreground}); err != nil && !kerrors.IsNotFound(err) {
 				errors = append(errors, err)
 			} else {
-				fmt.Fprintf(out, "rolebinding.rbac.authorization.k8s.io/"+binding.Name+" deleted\n")
+				fmt.Fprintf(out, "%s", "rolebinding.rbac.authorization.k8s.io/"+binding.Name+" deleted\n")
 			}
 		}
 	}

--- a/pkg/cli/admin/prune/auth/user.go
+++ b/pkg/cli/admin/prune/auth/user.go
@@ -48,7 +48,7 @@ func reapForUser(
 			if _, err := securityClient.Update(context.TODO(), &updatedSCC, metav1.UpdateOptions{}); err != nil && !kerrors.IsNotFound(err) {
 				errors = append(errors, err)
 			} else {
-				fmt.Fprintf(out, "securitycontextconstraints.security.openshift.io/"+updatedSCC.Name+" updated\n")
+				fmt.Fprintf(out, "%s", "securitycontextconstraints.security.openshift.io/"+updatedSCC.Name+" updated\n")
 			}
 		}
 	}
@@ -71,7 +71,7 @@ func reapForUser(
 			if _, err := userClient.Groups().Update(context.TODO(), &updatedGroup, metav1.UpdateOptions{}); err != nil && !kerrors.IsNotFound(err) {
 				errors = append(errors, err)
 			} else {
-				fmt.Fprintf(out, "group.user.openshift.io/"+updatedGroup.Name+" updated\n")
+				fmt.Fprintf(out, "%s", "group.user.openshift.io/"+updatedGroup.Name+" updated\n")
 			}
 		}
 	}
@@ -88,7 +88,7 @@ func reapForUser(
 			if err := oauthClient.OAuthClientAuthorizations().Delete(context.TODO(), authorization.Name, metav1.DeleteOptions{}); err != nil && !kerrors.IsNotFound(err) {
 				errors = append(errors, err)
 			} else {
-				fmt.Fprintf(out, "oauthclientauthorization.oauth.openshift.io/"+authorization.Name+" updated\n")
+				fmt.Fprintf(out, "%s", "oauthclientauthorization.oauth.openshift.io/"+authorization.Name+" updated\n")
 			}
 		}
 	}

--- a/pkg/cli/admin/prune/imageprune/prune.go
+++ b/pkg/cli/admin/prune/imageprune/prune.go
@@ -1368,7 +1368,7 @@ func deleteFromRegistry(registryClient *http.Client, url string) error {
 	// non-2xx/3xx response doesn't cause an error, so we need to check for it
 	// manually and return it to caller
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusBadRequest {
-		return fmt.Errorf(resp.Status)
+		return fmt.Errorf("%s", resp.Status)
 	}
 
 	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusAccepted {

--- a/pkg/cli/admin/release/extract_tools.go
+++ b/pkg/cli/admin/release/extract_tools.go
@@ -540,7 +540,7 @@ func (o *ExtractOptions) extractCommand(command string) error {
 					if err != nil {
 						return false, err
 					}
-					if _, err := fmt.Fprintf(fw, text); err != nil {
+					if _, err := fmt.Fprintf(fw, "%s", text); err != nil {
 						return false, err
 					}
 				}
@@ -579,7 +579,7 @@ func (o *ExtractOptions) extractCommand(command string) error {
 					}); err != nil {
 						return false, err
 					}
-					if _, err := fmt.Fprintf(tw, text); err != nil {
+					if _, err := fmt.Fprintf(tw, "%s", text); err != nil {
 						return false, err
 					}
 				}
@@ -677,7 +677,7 @@ func (o *ExtractOptions) extractCommand(command string) error {
 
 	if willArchive {
 		buf := &bytes.Buffer{}
-		fmt.Fprintf(buf, heredoc.Doc(`
+		fmt.Fprintf(buf, "%s", heredoc.Doc(`
 			Client tools for OpenShift
 			--------------------------
 

--- a/pkg/cli/admin/release/git.go
+++ b/pkg/cli/admin/release/git.go
@@ -159,7 +159,7 @@ func gitOutputToError(err error, out string) error {
 	if len(out) == 0 {
 		return err
 	}
-	return fmt.Errorf(out)
+	return fmt.Errorf("%s", out)
 }
 
 var (

--- a/pkg/cli/admin/release/info.go
+++ b/pkg/cli/admin/release/info.go
@@ -1476,7 +1476,7 @@ func describeChangelog(out, errOut io.Writer, diff *ReleaseDiff, dir string) err
 		return fmt.Errorf("releases are identical")
 	}
 
-	fmt.Fprintf(out, heredoc.Docf(`
+	fmt.Fprintf(out, "%s", heredoc.Docf(`
 		# %s
 
 		Created: %s

--- a/pkg/cli/admin/release/mirror.go
+++ b/pkg/cli/admin/release/mirror.go
@@ -897,7 +897,7 @@ func printImageContentInstructions(out io.Writer, from string, toList []string, 
 		return fmt.Errorf("Unable to marshal install-config.yaml example yaml: %v", err)
 	}
 	fmt.Fprintf(out, "\nTo use the new mirrored repository to install, add the following section to the install-config.yaml:\n\n")
-	fmt.Fprintf(out, string(installConfigExample))
+	fmt.Fprintf(out, "%s", string(installConfigExample))
 
 	// Create and display ImageContentSourcePolicy example
 	icsp := operatorv1alpha1.ImageContentSourcePolicy{
@@ -925,7 +925,7 @@ func printImageContentInstructions(out io.Writer, from string, toList []string, 
 		return fmt.Errorf("Unable to marshal ImageContentSourcePolicy example yaml: %v", err)
 	}
 	fmt.Fprintf(out, "\n\nTo use the new mirrored repository for upgrades, use the following to create an ImageContentSourcePolicy:\n\n")
-	fmt.Fprintf(out, string(icspExample))
+	fmt.Fprintf(out, "%s", string(icspExample))
 
 	if len(signatureToDir) != 0 {
 		fmt.Fprintf(out, "\n\nTo apply signature configmaps use 'oc apply' on files found in %s\n\n", signatureToDir)

--- a/pkg/cli/config/refreshcabundle/refresh_ca_bundle.go
+++ b/pkg/cli/config/refreshcabundle/refresh_ca_bundle.go
@@ -137,7 +137,7 @@ func (r *RefreshCABundleRuntime) Run(ctx context.Context) error {
 	}
 
 	if r.DryRun {
-		fmt.Fprintf(r.Out, caBundle)
+		fmt.Fprintf(r.Out, "%s", caBundle)
 		return nil
 	}
 

--- a/pkg/cli/debug/debug.go
+++ b/pkg/cli/debug/debug.go
@@ -591,7 +591,7 @@ func (o *DebugOptions) RunDebug() error {
 			if len(o.NodeName) > 0 {
 				msg += fmt.Sprintf(" on node %q", o.NodeName)
 			}
-			return fmt.Errorf(msg)
+			return fmt.Errorf("%s", msg)
 			// switch to logging output
 		case err == krun.ErrPodCompleted, err == conditions.ErrContainerTerminated:
 			resultPod, ok := containerRunningEvent.Object.(*corev1.Pod)

--- a/pkg/cli/deployer/strategy/support/lifecycle.go
+++ b/pkg/cli/deployer/strategy/support/lifecycle.go
@@ -325,7 +325,7 @@ func (e *hookExecutor) executeExecNewPod(hook *appsv1.LifecycleHook, rc *corev1.
 	wg.Wait()
 	if updatedPod.Status.Phase == corev1.PodFailed {
 		fmt.Fprintf(e.out, "--> %s: Failed\n", label)
-		return fmt.Errorf(updatedPod.Status.Message)
+		return fmt.Errorf("%s", updatedPod.Status.Message)
 	}
 	// Only show this message if we created the pod ourselves, or we saw
 	// the pod in a running or pending state.

--- a/pkg/cli/extract/extract.go
+++ b/pkg/cli/extract/extract.go
@@ -186,7 +186,7 @@ func (o *ExtractOptions) Run() error {
 			}
 		}
 		if len(errs) > 0 {
-			return fmt.Errorf(kcmdutil.MultipleErrors("error: ", errs))
+			return fmt.Errorf("%s", kcmdutil.MultipleErrors("error: ", errs))
 		}
 		return nil
 	})

--- a/pkg/cli/login/loginoptions.go
+++ b/pkg/cli/login/loginoptions.go
@@ -103,8 +103,7 @@ func (o *LoginOptions) getClientConfig() (*restclient.Config, error) {
 		if kterm.IsTerminal(o.In) {
 			for !o.serverProvided() {
 				defaultServer := defaultClusterURL
-				promptMsg := fmt.Sprintf("Server [%s]: ", defaultServer)
-				o.Server = term.PromptForStringWithDefault(o.In, o.Out, defaultServer, promptMsg)
+				o.Server = term.PromptForStringWithDefault(o.In, o.Out, defaultServer, "Server [%s]: ", defaultServer)
 			}
 		}
 	}
@@ -306,7 +305,7 @@ func (o *LoginOptions) gatherProjectInfo() error {
 			return err
 		}
 		msg := errors.NoProjectsExistMessage(canRequest)
-		fmt.Fprintf(o.Out, msg)
+		fmt.Fprintf(o.Out, "%s", msg)
 		o.Project = ""
 
 	case 1:
@@ -408,7 +407,7 @@ func (o *LoginOptions) SaveConfig() (bool, error) {
 		}
 
 		out := &bytes.Buffer{}
-		fmt.Fprintf(out, errors.ErrKubeConfigNotWriteable(o.PathOptions.GetDefaultFilename(), o.PathOptions.IsExplicitFile(), err).Error())
+		fmt.Fprintf(out, "%s", errors.ErrKubeConfigNotWriteable(o.PathOptions.GetDefaultFilename(), o.PathOptions.IsExplicitFile(), err).Error())
 		return false, fmt.Errorf("%v", out)
 	}
 

--- a/pkg/cli/login/loginoptions_test.go
+++ b/pkg/cli/login/loginoptions_test.go
@@ -103,7 +103,7 @@ func TestTLSWithCertificateNotMatchingHostname(t *testing.T) {
 
 	server, err := newTLSServer(invalidHostCert, invalidHostKey)
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Errorf("%s", err.Error())
 	}
 	server.StartTLS()
 	defer server.Close()
@@ -182,7 +182,7 @@ func TestTLSWithExpiredCertificate(t *testing.T) {
 
 	server, err := newTLSServer(expiredCert, expiredKey)
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Errorf("%s", err.Error())
 	}
 	server.StartTLS()
 	defer server.Close()

--- a/pkg/cli/newapp/newapp.go
+++ b/pkg/cli/newapp/newapp.go
@@ -720,23 +720,23 @@ func CompleteAppConfig(config *newcmd.AppConfig, f kcmdutil.Factory, c *cobra.Co
 			fmt.Fprintf(buf, "%s:\n", argName)
 			for _, classErr := range config.EnvironmentClassificationErrors {
 				if classErr.Value != nil {
-					fmt.Fprintf(buf, fmt.Sprintf("%s:  %v\n", classErr.Key, classErr.Value))
+					fmt.Fprintf(buf, "%s:  %v\n", classErr.Key, classErr.Value)
 				} else {
-					fmt.Fprintf(buf, fmt.Sprintf("%s\n", classErr.Key))
+					fmt.Fprintf(buf, "%s\n", classErr.Key)
 				}
 			}
 			for _, classErr := range config.SourceClassificationErrors {
-				fmt.Fprintf(buf, fmt.Sprintf("%s:  %v\n", classErr.Key, classErr.Value))
+				fmt.Fprintf(buf, "%s:  %v\n", classErr.Key, classErr.Value)
 			}
 			for _, classErr := range config.TemplateClassificationErrors {
-				fmt.Fprintf(buf, fmt.Sprintf("%s:  %v\n", classErr.Key, classErr.Value))
+				fmt.Fprintf(buf, "%s:  %v\n", classErr.Key, classErr.Value)
 			}
 			for _, classErr := range config.ComponentClassificationErrors {
-				fmt.Fprintf(buf, fmt.Sprintf("%s:  %v\n", classErr.Key, classErr.Value))
+				fmt.Fprintf(buf, "%s:  %v\n", classErr.Key, classErr.Value)
 			}
 			fmt.Fprintln(buf)
 		}
-		return kcmdutil.UsageErrorf(c, heredoc.Docf(buf.String()))
+		return kcmdutil.UsageErrorf(c, "%s", heredoc.Doc(buf.String()))
 	}
 
 	if config.AllowMissingImages && config.AsSearch {
@@ -900,7 +900,7 @@ func HandleError(err error, commandPath string, config *newcmd.AppConfig, transf
 		if len(group.classification) > 0 {
 			fmt.Fprintln(buf)
 		}
-		fmt.Fprintf(buf, group.classification)
+		fmt.Fprintf(buf, "%s", group.classification)
 		if len(group.suggestion) > 0 {
 			if len(group.classification) > 0 {
 				fmt.Fprintln(buf)
@@ -909,7 +909,7 @@ func HandleError(err error, commandPath string, config *newcmd.AppConfig, transf
 		}
 		fmt.Fprint(buf, group.suggestion)
 	}
-	return fmt.Errorf(buf.String())
+	return fmt.Errorf("%s", buf.String())
 }
 
 type ErrorGroup struct {
@@ -1067,10 +1067,10 @@ func TransformRunError(err error, commandPath string, groups ErrorGroups, config
 		groups.Add("", "", "", fmt.Errorf("to install components you must be logged in with an OAuth token (instead of only a certificate)"))
 	case newcmd.ErrNoInputs:
 		// TODO: suggest things to the user
-		groups.Add("", "", "", UsageError(commandPath, newAppNoInput))
+		groups.Add("", "", "", UsageError(commandPath, "%s", newAppNoInput))
 	default:
 		if runtime.IsNotRegisteredError(err) {
-			groups.Add("", "", "", fmt.Errorf(fmt.Sprintf("The template contained an object type unknown to `oc new-app`.  Use `oc process -f <template> | oc create -f -` instead.  Error details: %v", err)))
+			groups.Add("", "", "", fmt.Errorf("The template contained an object type unknown to `oc new-app`.  Use `oc process -f <template> | oc create -f -` instead.  Error details: %v", err))
 		} else {
 			groups.Add("", "", "", err)
 		}

--- a/pkg/cli/newbuild/newbuild.go
+++ b/pkg/cli/newbuild/newbuild.go
@@ -274,7 +274,7 @@ func transformBuildError(err error, commandPath string, groups ocnewapp.ErrorGro
 	}
 	switch err {
 	case newcmd.ErrNoInputs:
-		groups.Add("", "", "", ocnewapp.UsageError(commandPath, newBuildNoInput))
+		groups.Add("", "", "", ocnewapp.UsageError(commandPath, "%s", newBuildNoInput))
 		return
 	}
 	ocnewapp.TransformRunError(err, commandPath, groups, config)

--- a/pkg/cli/newbuild/newbuild_test.go
+++ b/pkg/cli/newbuild/newbuild_test.go
@@ -28,7 +28,7 @@ func TestNewBuildRun(t *testing.T) {
 		{
 			name:        "no input",
 			config:      &newcmd.AppConfig{},
-			expectedErr: ocnewapp.UsageError("oc new-build", newBuildNoInput).Error(),
+			expectedErr: ocnewapp.UsageError("oc new-build", "%s", newBuildNoInput).Error(),
 		},
 		{
 			name: "no matches",

--- a/pkg/cli/observe/observe.go
+++ b/pkg/cli/observe/observe.go
@@ -727,7 +727,7 @@ func (o *ObserveOptions) dumpMetrics() {
 	w := httptest.NewRecorder()
 	promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{}).ServeHTTP(w, &http.Request{})
 	if w.Code == http.StatusOK {
-		fmt.Fprintf(o.Out, w.Body.String())
+		fmt.Fprintf(o.Out, "%s", w.Body.String())
 	}
 }
 

--- a/pkg/cli/process/process.go
+++ b/pkg/cli/process/process.go
@@ -185,7 +185,7 @@ func (p *processPrinter) PrintObj(obj runtime.Object, out io.Writer) error {
 			return fmt.Errorf("error describing %q: %v\n", templateObj.Name, err)
 		}
 
-		fmt.Fprintf(out, s)
+		fmt.Fprintf(out, "%s", s)
 		return nil
 	}
 
@@ -269,7 +269,7 @@ func (o *ProcessOptions) Complete(f kcmdutil.Factory, cmd *cobra.Command, args [
 						errstr += fmt.Sprintf("  %v\n", err)
 					}
 
-					return nil, fmt.Errorf(errstr)
+					return nil, fmt.Errorf("%s", errstr)
 				}
 
 				return nil, fmt.Errorf("unable to process template: %v\n", err)

--- a/pkg/cli/rollout/latest.go
+++ b/pkg/cli/rollout/latest.go
@@ -225,6 +225,6 @@ func (p *revisionPrinter) PrintObj(obj runtime.Object, out io.Writer) error {
 		return fmt.Errorf("%T is not a deployment config", obj)
 	}
 
-	fmt.Fprintf(out, fmt.Sprintf("%d", dc.Status.LatestVersion))
+	fmt.Fprintf(out, "%d", dc.Status.LatestVersion)
 	return nil
 }

--- a/pkg/cli/rollout/retry.go
+++ b/pkg/cli/rollout/retry.go
@@ -90,7 +90,7 @@ func NewCmdRolloutRetry(f kcmdutil.Factory, streams genericclioptions.IOStreams)
 func (o *RetryOptions) Complete(f kcmdutil.Factory, cmd *cobra.Command, args []string) error {
 	var err error
 	if len(args) == 0 && len(o.FilenameOptions.Filenames) == 0 {
-		return kcmdutil.UsageErrorf(cmd, cmd.Use)
+		return kcmdutil.UsageErrorf(cmd, "%s", cmd.Use)
 	}
 
 	o.Resources = args

--- a/pkg/cli/serviceaccounts/create_kubeconfig.go
+++ b/pkg/cli/serviceaccounts/create_kubeconfig.go
@@ -79,7 +79,7 @@ func NewCommandCreateKubeconfig(f cmdutil.Factory, streams genericclioptions.IOS
 
 func (o *CreateKubeconfigOptions) Complete(args []string, f cmdutil.Factory, cmd *cobra.Command) error {
 	if len(args) != 1 {
-		return cmdutil.UsageErrorf(cmd, fmt.Sprintf("expected one service account name as an argument, got %q", args))
+		return cmdutil.UsageErrorf(cmd, "expected one service account name as an argument, got %q", args)
 	}
 	context, err := cmd.Flags().GetString("context")
 	if err != nil {
@@ -182,7 +182,7 @@ func (o *CreateKubeconfigOptions) Run() error {
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(o.Out, string(out))
+			fmt.Fprintf(o.Out, "%s", string(out))
 			return nil
 		}
 	}

--- a/pkg/cli/serviceaccounts/gettoken.go
+++ b/pkg/cli/serviceaccounts/gettoken.go
@@ -74,7 +74,7 @@ func NewCommandGetServiceAccountToken(f cmdutil.Factory, streams genericclioptio
 
 func (o *GetServiceAccountTokenOptions) Complete(args []string, f cmdutil.Factory, cmd *cobra.Command) error {
 	if len(args) != 1 {
-		return cmdutil.UsageErrorf(cmd, fmt.Sprintf("expected one service account name as an argument, got %q", args))
+		return cmdutil.UsageErrorf(cmd, "expected one service account name as an argument, got %q", args)
 	}
 
 	o.SAName = args[0]
@@ -131,7 +131,7 @@ func (o *GetServiceAccountTokenOptions) Run() error {
 				return fmt.Errorf("service account token %q for service account %q did not contain token data", secret.Name, serviceAccount.Name)
 			}
 
-			fmt.Fprintf(o.Out, string(token))
+			fmt.Fprintf(o.Out, "%s", string(token))
 			if term.IsTerminalWriter(o.Out) {
 				// pretty-print for a TTY
 				fmt.Fprintf(o.Out, "\n")

--- a/pkg/cli/serviceaccounts/newtoken.go
+++ b/pkg/cli/serviceaccounts/newtoken.go
@@ -96,7 +96,7 @@ func NewCommandNewServiceAccountToken(f cmdutil.Factory, streams genericclioptio
 
 func (o *ServiceAccountTokenOptions) Complete(args []string, requestedLabels string, f cmdutil.Factory, cmd *cobra.Command) error {
 	if len(args) != 1 {
-		return cmdutil.UsageErrorf(cmd, fmt.Sprintf("expected one service account name as an argument, got %q", args))
+		return cmdutil.UsageErrorf(cmd, "expected one service account name as an argument, got %q", args)
 	}
 
 	o.SAName = args[0]
@@ -104,7 +104,7 @@ func (o *ServiceAccountTokenOptions) Complete(args []string, requestedLabels str
 	if len(requestedLabels) > 0 {
 		labels, err := generate.ParseLabels(requestedLabels)
 		if err != nil {
-			return cmdutil.UsageErrorf(cmd, err.Error())
+			return cmdutil.UsageErrorf(cmd, "%s", err.Error())
 		}
 		o.Labels = labels
 	}
@@ -184,7 +184,7 @@ func (o *ServiceAccountTokenOptions) Run() error {
 		return fmt.Errorf("service account token %q did not contain token data", tokenSecret.Name)
 	}
 
-	fmt.Fprintf(o.Out, string(token))
+	fmt.Fprintf(o.Out, "%s", string(token))
 	if term.IsTerminalWriter(o.Out) {
 		// pretty-print for a TTY
 		fmt.Fprintf(o.Out, "\n")

--- a/pkg/cli/status/status.go
+++ b/pkg/cli/status/status.go
@@ -228,6 +228,6 @@ func (o StatusOptions) RunStatus() error {
 		return fmt.Errorf("invalid output format provided: %s", o.outputFormat)
 	}
 
-	fmt.Fprintf(o.Out, s)
+	fmt.Fprintf(o.Out, "%s", s)
 	return nil
 }

--- a/pkg/helpers/bulk/cmd.go
+++ b/pkg/helpers/bulk/cmd.go
@@ -119,7 +119,7 @@ func (b *Bulk) Run(list *metainternalversion.List, namespace string) []error {
 func NewPrintNameOrErrorAfterIndent(short bool, operation string, out, errs io.Writer, dryRun bool, indent string, prefixForError PrefixForError) AfterFunc {
 	return func(obj *unstructured.Unstructured, err error) bool {
 		if err == nil {
-			fmt.Fprintf(out, indent)
+			fmt.Fprintf(out, "%s", indent)
 			printSuccess(short, out, obj.GroupVersionKind(), obj.GetName(), dryRun, operation)
 		} else {
 			fmt.Fprintf(errs, "%s%s: %v\n", indent, prefixForError(err), err)

--- a/pkg/helpers/describe/describer.go
+++ b/pkg/helpers/describe/describer.go
@@ -540,7 +540,7 @@ func describeBuildTriggers(triggers []buildv1.BuildTriggerPolicy, name, namespac
 			seenHookTypes[webHookType] = true
 			fmt.Fprintf(w, "\tURL:\t%s\n", trigger.URL)
 			if webHookType == string(buildv1.GenericWebHookBuildTriggerType) && trigger.AllowEnv != nil {
-				fmt.Fprintf(w, fmt.Sprintf("\t%s:\t%v\n", "AllowEnv", *trigger.AllowEnv))
+				fmt.Fprintf(w, "\t%s:\t%v\n", "AllowEnv", *trigger.AllowEnv)
 			}
 		}
 	}
@@ -1277,7 +1277,7 @@ func (d *TemplateDescriber) describeObjects(objects []runtime.RawExtension, out 
 				groupKind = gk.String()
 			}
 		}
-		fmt.Fprintf(out, fmt.Sprintf("%s%s\t%s\n", indent, groupKind, name))
+		fmt.Fprintf(out, "%s%s\t%s\n", indent, groupKind, name)
 	}
 }
 
@@ -1389,7 +1389,7 @@ func (d *TemplateInstanceDescriber) DescribeParameters(template templatev1.Templ
 
 	indent := "    "
 	if len(template.Parameters) == 0 {
-		fmt.Fprintf(out, indent+"No parameters found.")
+		fmt.Fprintf(out, "%s", indent+"No parameters found.")
 	} else {
 		for _, p := range template.Parameters {
 			if val, ok := secret.Data[p.Name]; ok {

--- a/pkg/helpers/describe/helpers.go
+++ b/pkg/helpers/describe/helpers.go
@@ -74,14 +74,14 @@ func formatEnv(env corev1.EnvVar) string {
 func formatString(out *tabwriter.Writer, label string, v interface{}) {
 	labelVals := strings.Split(toString(v), "\n")
 
-	fmt.Fprintf(out, fmt.Sprintf("%s:", label))
+	fmt.Fprintf(out, "%s:", label)
 	for _, lval := range labelVals {
 		fmt.Fprintln(out, fmt.Sprintf("\t%s", lval))
 	}
 }
 
 func formatTime(out *tabwriter.Writer, label string, t time.Time) {
-	fmt.Fprintf(out, fmt.Sprintf("%s:\t%s ago\n", label, FormatRelativeTime(t)))
+	fmt.Fprintf(out, "%s:\t%s ago\n", label, FormatRelativeTime(t))
 }
 
 func formatLabels(labelMap map[string]string) string {

--- a/pkg/helpers/describe/projectstatus.go
+++ b/pkg/helpers/describe/projectstatus.go
@@ -263,9 +263,9 @@ func (d *ProjectStatusDescriber) Describe(namespace, name string) (string, error
 	return tabbedString(func(out *tabwriter.Writer) error {
 		indent := "  "
 		if allNamespaces {
-			fmt.Fprintf(out, describeAllProjectsOnServer(f, d.Server))
+			fmt.Fprintf(out, "%s", describeAllProjectsOnServer(f, d.Server))
 		} else {
-			fmt.Fprintf(out, describeProjectAndServer(f, project, d.Server))
+			fmt.Fprintf(out, "%s", describeProjectAndServer(f, project, d.Server))
 		}
 
 		for _, service := range services {
@@ -639,7 +639,7 @@ func getMarkerScanners(logsCommandName, securityPolicyCommandFormat, setProbeCom
 
 func printLines(out io.Writer, indent string, depth int, lines ...string) {
 	for i, s := range lines {
-		fmt.Fprintf(out, strings.Repeat(indent, depth))
+		fmt.Fprintf(out, "%s", strings.Repeat(indent, depth))
 		if i != 0 {
 			fmt.Fprint(out, indent)
 		}

--- a/pkg/helpers/newapp/cmd/newapp.go
+++ b/pkg/helpers/newapp/cmd/newapp.go
@@ -334,7 +334,7 @@ func (c *AppConfig) tryToAddSourceArguments(s string) bool {
 	}
 	c.SourceClassificationErrors[s] = ArgumentClassificationError{
 		Key:   "is not a Git repository",
-		Value: fmt.Errorf(errStr),
+		Value: fmt.Errorf("%s", errStr),
 	}
 
 	return false

--- a/pkg/helpers/newapp/cmd/template.go
+++ b/pkg/helpers/newapp/cmd/template.go
@@ -39,7 +39,7 @@ func formatString(out io.Writer, tab, s string) {
 	labelVals := strings.Split(strings.TrimSuffix(s, "\n"), "\n")
 
 	for _, lval := range labelVals {
-		fmt.Fprintf(out, fmt.Sprintf("%s%s\n", tab, lval))
+		fmt.Fprintf(out, "%s%s\n", tab, lval)
 	}
 }
 


### PR DESCRIPTION

- **Go Module**: Updated from Go 1.19 to 1.24, resolved dependencies
- **Security**: Fixed 60+ format string issues for Go 1.24 compliance  
- **Config**: Updated CI and Docker configs to use Go 1.24 toolchain
- **Testing**:  All verification passes, no breaking changes