### PR TITLE
OCPBUGS-58038: Clear defaultNodeSelector to run on any node

### DIFF
--- a/pkg/cli/admin/pernodepod/runtime.go
+++ b/pkg/cli/admin/pernodepod/runtime.go
@@ -74,6 +74,11 @@ func (r *PerNodePodRuntime) Run(ctx context.Context, prePodHookFn PrePodHookFunc
 	if !r.DryRun {
 		nsToCreate := namespace.DeepCopy()
 		nsToCreate.GenerateName = r.NamespacePrefix
+		// If defaultNodeSelector is configured in the cluster.
+		// We need to clear this, because this namespace can run on any node type.
+		nsToCreate.Annotations = map[string]string{
+			"openshift.io/node-selector": "",
+		}
 		actualNamespace, err := r.KubeClient.CoreV1().Namespaces().Create(ctx, nsToCreate, metav1.CreateOptions{})
 		if err != nil {
 			return fmt.Errorf("failed to create namespace: %w", err)


### PR DESCRIPTION
`oc adm copy-to-node` and `oc adm restart-kubelet` commands can run on any node type (either control-plane or worker) by creating a pod in its dedicated namespace. If defaultNodeSelector is configured within the cluster, its dedicated namespace is not allowed to run pods in excluded node types. 

Therefore, we intentionally clear `openshift.io/node-selector` annotation to disable `defaultNodeSelector` for this namespace.