### PR TITLE
OCPBUGS-63189: Unify ErrAlreadyExists to correctly match

### DIFF
--- a/pkg/cli/image/mirror/mappings.go
+++ b/pkg/cli/image/mirror/mappings.go
@@ -14,9 +14,6 @@ import (
 	"github.com/openshift/oc/pkg/cli/image/imagesource"
 )
 
-// ErrAlreadyExists may be returned by the blob Create function to indicate that the blob already exists.
-var ErrAlreadyExists = fmt.Errorf("blob already exists in the target location")
-
 type Mapping struct {
 	Source      imagesource.TypedImageReference
 	Destination imagesource.TypedImageReference

--- a/pkg/cli/image/mirror/mirror.go
+++ b/pkg/cli/image/mirror/mirror.go
@@ -723,7 +723,7 @@ func copyBlob(ctx context.Context, plan *workPlan, c *repositoryBlobCopy, blob d
 	copyfn := func() error {
 		w, err := c.to.Create(ctx, options...)
 		// no-op
-		if err == ErrAlreadyExists {
+		if errors.Is(err, imagesource.ErrAlreadyExists) {
 			klog.V(5).Infof("Blob already exists %#v", blob)
 			return nil
 		}


### PR DESCRIPTION
When the uploaded blob is already existed, [S3 raises](https://github.com/openshift/oc/blob/9e4292b2df204c3d29a4441aa653cdc048e6b797/pkg/cli/image/imagesource/s3.go#L357) ErrAlreadyExists error correctly. However, `mirror.go` compares the error against duplicate of `ErrAlreadyExists` error. So it mismatches.

This PR removes duplicate and unused `ErrAlreadyExists` in `mappings.go` and correctly compare the error in S3.