### PR TITLE
OCPBUGS-73844: Let import mode be decided by the cluster when not specified

### DIFF
--- a/pkg/cli/importimage/importimage.go
+++ b/pkg/cli/importimage/importimage.go
@@ -100,7 +100,6 @@ func NewImportImageOptions(streams genericiooptions.IOStreams) *ImportImageOptio
 		PrintFlags:      genericclioptions.NewPrintFlags("imported"),
 		IOStreams:       streams,
 		ReferencePolicy: tag.SourceReferencePolicy,
-		ImportMode:      string(imagev1.ImportModeLegacy),
 	}
 }
 
@@ -129,7 +128,7 @@ func NewCmdImportImage(f kcmdutil.Factory, streams genericiooptions.IOStreams) *
 	cmd.Flags().BoolVar(&o.Confirm, "confirm", o.Confirm, "If true, allow the image stream import location to be set or changed")
 	cmd.Flags().BoolVar(&o.All, "all", o.All, "If true, import all tags from the provided source on creation or if --from is specified")
 	cmd.Flags().StringVar(&o.ReferencePolicy, "reference-policy", o.ReferencePolicy, "Allow to request pullthrough for external image when set to 'local'. Defaults to 'source'.")
-	cmd.Flags().StringVar(&o.ImportMode, "import-mode", o.ImportMode, "Imports the full manifest list of a tag when set to 'PreserveOriginal'. Defaults to 'Legacy'.")
+	cmd.Flags().StringVar(&o.ImportMode, "import-mode", o.ImportMode, "Imports the full manifest list of a tag when set to 'PreserveOriginal'. When set to 'Legacy', imports a single sub-manifest. When unspecified, the cluster determines the import mode.")
 	cmd.Flags().BoolVar(&o.DryRun, "dry-run", o.DryRun, "Fetch information about images without creating or updating an image stream.")
 	cmd.Flags().BoolVar(&o.Scheduled, "scheduled", o.Scheduled, "Set each imported container image to be periodically imported from a remote repository. Defaults to false.")
 	cmd.Flags().BoolVar(&o.Insecure, "insecure", o.Insecure, "If true, allow importing from registries that have invalid HTTPS certificates or are hosted via HTTP. This flag will take precedence over the insecure annotation.")
@@ -218,7 +217,8 @@ func (o *ImportImageOptions) Validate() error {
 	case string(imagev1.ImportModeLegacy):
 	case string(imagev1.ImportModePreserveOriginal):
 	case "":
-		o.ImportMode = string(imagev1.ImportModeLegacy)
+		// Leave empty and let it be decided based on the ClusterVersion's "desired.architecture" value. If the value is "Multi",
+		// the import mode is set to "PreserveOriginal", if not it is set to "Legacy"
 	default:
 		return fmt.Errorf("valid ImportMode values are %s or %s", imagev1.ImportModeLegacy, imagev1.ImportModePreserveOriginal)
 	}

--- a/pkg/cli/importimage/importimage_test.go
+++ b/pkg/cli/importimage/importimage_test.go
@@ -40,7 +40,7 @@ func TestCreateImageImport(t *testing.T) {
 				From:            corev1.ObjectReference{Kind: "DockerImage", Name: "nonexisting"},
 				To:              &corev1.LocalObjectReference{Name: "latest"},
 				ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.SourceTagReferencePolicy},
-				ImportPolicy:    imagev1.TagImportPolicy{ImportMode: imagev1.ImportModeLegacy},
+				ImportPolicy:    imagev1.TagImportPolicy{},
 			}},
 		},
 		"confirmed import all from non-existing": {
@@ -50,7 +50,7 @@ func TestCreateImageImport(t *testing.T) {
 			expectedRepository: &imagev1.RepositoryImportSpec{
 				From:            corev1.ObjectReference{Kind: "DockerImage", Name: "nonexisting"},
 				ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.SourceTagReferencePolicy},
-				ImportPolicy:    imagev1.TagImportPolicy{ImportMode: imagev1.ImportModeLegacy},
+				ImportPolicy:    imagev1.TagImportPolicy{},
 			},
 		},
 		"import from .spec.dockerImageRepository": {
@@ -66,7 +66,7 @@ func TestCreateImageImport(t *testing.T) {
 				From:            corev1.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage"},
 				To:              &corev1.LocalObjectReference{Name: "latest"},
 				ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.SourceTagReferencePolicy},
-				ImportPolicy:    imagev1.TagImportPolicy{ImportMode: imagev1.ImportModeLegacy},
+				ImportPolicy:    imagev1.TagImportPolicy{},
 			}},
 		},
 		"import from .spec.dockerImageRepository non-existing tag": {
@@ -93,7 +93,7 @@ func TestCreateImageImport(t *testing.T) {
 			expectedRepository: &imagev1.RepositoryImportSpec{
 				From:            corev1.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage"},
 				ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.SourceTagReferencePolicy},
-				ImportPolicy:    imagev1.TagImportPolicy{ImportMode: imagev1.ImportModeLegacy},
+				ImportPolicy:    imagev1.TagImportPolicy{},
 			},
 		},
 		"import all from .spec.dockerImageRepository with different from": {
@@ -124,7 +124,7 @@ func TestCreateImageImport(t *testing.T) {
 			expectedRepository: &imagev1.RepositoryImportSpec{
 				From:            corev1.ObjectReference{Kind: "DockerImage", Name: "totally/different/spec"},
 				ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.SourceTagReferencePolicy},
-				ImportPolicy:    imagev1.TagImportPolicy{ImportMode: imagev1.ImportModeLegacy},
+				ImportPolicy:    imagev1.TagImportPolicy{},
 			},
 		},
 		"import all from .spec.tags": {
@@ -144,13 +144,13 @@ func TestCreateImageImport(t *testing.T) {
 					From:            corev1.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:latest"},
 					To:              &corev1.LocalObjectReference{Name: "latest"},
 					ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.SourceTagReferencePolicy},
-					ImportPolicy:    imagev1.TagImportPolicy{ImportMode: imagev1.ImportModeLegacy},
+					ImportPolicy:    imagev1.TagImportPolicy{},
 				},
 				{
 					From:            corev1.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:other"},
 					To:              &corev1.LocalObjectReference{Name: "other"},
 					ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.SourceTagReferencePolicy},
-					ImportPolicy:    imagev1.TagImportPolicy{ImportMode: imagev1.ImportModeLegacy},
+					ImportPolicy:    imagev1.TagImportPolicy{},
 				},
 			},
 		},
@@ -174,13 +174,13 @@ func TestCreateImageImport(t *testing.T) {
 				{
 					From:            corev1.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:latest"},
 					To:              &corev1.LocalObjectReference{Name: "latest"},
-					ImportPolicy:    imagev1.TagImportPolicy{Insecure: true, ImportMode: imagev1.ImportModeLegacy},
+					ImportPolicy:    imagev1.TagImportPolicy{Insecure: true},
 					ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.SourceTagReferencePolicy},
 				},
 				{
 					From:            corev1.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:other"},
 					To:              &corev1.LocalObjectReference{Name: "other"},
-					ImportPolicy:    imagev1.TagImportPolicy{Insecure: true, ImportMode: imagev1.ImportModeLegacy},
+					ImportPolicy:    imagev1.TagImportPolicy{Insecure: true},
 					ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.SourceTagReferencePolicy},
 				},
 			},
@@ -202,13 +202,13 @@ func TestCreateImageImport(t *testing.T) {
 				{
 					From:            corev1.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:latest"},
 					To:              &corev1.LocalObjectReference{Name: "latest"},
-					ImportPolicy:    imagev1.TagImportPolicy{Insecure: true, ImportMode: imagev1.ImportModeLegacy},
+					ImportPolicy:    imagev1.TagImportPolicy{Insecure: true},
 					ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.SourceTagReferencePolicy},
 				},
 				{
 					From:            corev1.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:other"},
 					To:              &corev1.LocalObjectReference{Name: "other"},
-					ImportPolicy:    imagev1.TagImportPolicy{Insecure: true, ImportMode: imagev1.ImportModeLegacy},
+					ImportPolicy:    imagev1.TagImportPolicy{Insecure: true},
 					ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.SourceTagReferencePolicy},
 				},
 			},
@@ -250,7 +250,7 @@ func TestCreateImageImport(t *testing.T) {
 				From:            corev1.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:latest"},
 				To:              &corev1.LocalObjectReference{Name: "latest"},
 				ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.SourceTagReferencePolicy},
-				ImportPolicy:    imagev1.TagImportPolicy{ImportMode: imagev1.ImportModeLegacy},
+				ImportPolicy:    imagev1.TagImportPolicy{},
 			}},
 		},
 		"import existing tag": {
@@ -270,7 +270,7 @@ func TestCreateImageImport(t *testing.T) {
 				From:            corev1.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:latest"},
 				To:              &corev1.LocalObjectReference{Name: "existing"},
 				ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.SourceTagReferencePolicy},
-				ImportPolicy:    imagev1.TagImportPolicy{ImportMode: imagev1.ImportModeLegacy},
+				ImportPolicy:    imagev1.TagImportPolicy{},
 			}},
 		},
 		"import non-existing tag": {
@@ -308,7 +308,7 @@ func TestCreateImageImport(t *testing.T) {
 				From:            corev1.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:mytag"},
 				To:              &corev1.LocalObjectReference{Name: "mytag"},
 				ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.SourceTagReferencePolicy},
-				ImportPolicy:    imagev1.TagImportPolicy{ImportMode: imagev1.ImportModeLegacy},
+				ImportPolicy:    imagev1.TagImportPolicy{},
 			}},
 		},
 		"use tag aliases": {
@@ -330,7 +330,7 @@ func TestCreateImageImport(t *testing.T) {
 				From:            corev1.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:mytag"},
 				To:              &corev1.LocalObjectReference{Name: "mytag"},
 				ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.SourceTagReferencePolicy},
-				ImportPolicy:    imagev1.TagImportPolicy{ImportMode: imagev1.ImportModeLegacy},
+				ImportPolicy:    imagev1.TagImportPolicy{},
 			}},
 		},
 		"import tag from alias of cross-image-stream": {
@@ -403,7 +403,7 @@ func TestCreateImageImport(t *testing.T) {
 			expectedImages: []imagev1.ImageImportSpec{{
 				From:            corev1.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage"},
 				To:              &corev1.LocalObjectReference{Name: "latest"},
-				ImportPolicy:    imagev1.TagImportPolicy{Insecure: true, ImportMode: imagev1.ImportModeLegacy},
+				ImportPolicy:    imagev1.TagImportPolicy{Insecure: true},
 				ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.SourceTagReferencePolicy},
 			}},
 		},
@@ -424,7 +424,7 @@ func TestCreateImageImport(t *testing.T) {
 			expectedImages: []imagev1.ImageImportSpec{{
 				From:            corev1.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage"},
 				To:              &corev1.LocalObjectReference{Name: "latest"},
-				ImportPolicy:    imagev1.TagImportPolicy{Insecure: false, ImportMode: imagev1.ImportModeLegacy},
+				ImportPolicy:    imagev1.TagImportPolicy{Insecure: false},
 				ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.SourceTagReferencePolicy},
 			}},
 		},
@@ -446,7 +446,7 @@ func TestCreateImageImport(t *testing.T) {
 				From:            corev1.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:mytag"},
 				To:              &corev1.LocalObjectReference{Name: "mytag"},
 				ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.LocalTagReferencePolicy},
-				ImportPolicy:    imagev1.TagImportPolicy{ImportMode: imagev1.ImportModeLegacy},
+				ImportPolicy:    imagev1.TagImportPolicy{},
 			}},
 		},
 		"import all from .spec.tags setting referencePolicy": {
@@ -467,13 +467,13 @@ func TestCreateImageImport(t *testing.T) {
 					From:            corev1.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:mytag"},
 					To:              &corev1.LocalObjectReference{Name: "mytag"},
 					ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.LocalTagReferencePolicy},
-					ImportPolicy:    imagev1.TagImportPolicy{ImportMode: imagev1.ImportModeLegacy},
+					ImportPolicy:    imagev1.TagImportPolicy{},
 				},
 				{
 					From:            corev1.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:other"},
 					To:              &corev1.LocalObjectReference{Name: "other"},
 					ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.LocalTagReferencePolicy},
-					ImportPolicy:    imagev1.TagImportPolicy{ImportMode: imagev1.ImportModeLegacy},
+					ImportPolicy:    imagev1.TagImportPolicy{},
 				},
 			},
 		},
@@ -491,7 +491,7 @@ func TestCreateImageImport(t *testing.T) {
 			expectedRepository: &imagev1.RepositoryImportSpec{
 				From:            corev1.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage"},
 				ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.LocalTagReferencePolicy},
-				ImportPolicy:    imagev1.TagImportPolicy{ImportMode: imagev1.ImportModeLegacy},
+				ImportPolicy:    imagev1.TagImportPolicy{},
 			},
 		},
 		"import tag setting scheduled": {
@@ -511,7 +511,7 @@ func TestCreateImageImport(t *testing.T) {
 			expectedImages: []imagev1.ImageImportSpec{{
 				From:            corev1.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:mytag"},
 				To:              &corev1.LocalObjectReference{Name: "mytag"},
-				ImportPolicy:    imagev1.TagImportPolicy{Scheduled: true, ImportMode: imagev1.ImportModeLegacy},
+				ImportPolicy:    imagev1.TagImportPolicy{Scheduled: true},
 				ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.SourceTagReferencePolicy},
 			}},
 		},
@@ -533,7 +533,7 @@ func TestCreateImageImport(t *testing.T) {
 			expectedImages: []imagev1.ImageImportSpec{{
 				From:            corev1.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:mytag"},
 				To:              &corev1.LocalObjectReference{Name: "mytag"},
-				ImportPolicy:    imagev1.TagImportPolicy{Scheduled: true, ImportMode: imagev1.ImportModeLegacy},
+				ImportPolicy:    imagev1.TagImportPolicy{Scheduled: true},
 				ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.SourceTagReferencePolicy},
 			}},
 		},
@@ -554,13 +554,13 @@ func TestCreateImageImport(t *testing.T) {
 				{
 					From:            corev1.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:mytag"},
 					To:              &corev1.LocalObjectReference{Name: "mytag"},
-					ImportPolicy:    imagev1.TagImportPolicy{Scheduled: true, ImportMode: imagev1.ImportModeLegacy},
+					ImportPolicy:    imagev1.TagImportPolicy{Scheduled: true},
 					ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.SourceTagReferencePolicy},
 				},
 				{
 					From:            corev1.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:other"},
 					To:              &corev1.LocalObjectReference{Name: "other"},
-					ImportPolicy:    imagev1.TagImportPolicy{Scheduled: true, ImportMode: imagev1.ImportModeLegacy},
+					ImportPolicy:    imagev1.TagImportPolicy{Scheduled: true},
 					ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.SourceTagReferencePolicy},
 				},
 			},
@@ -586,13 +586,13 @@ func TestCreateImageImport(t *testing.T) {
 				{
 					From:            corev1.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:mytag"},
 					To:              &corev1.LocalObjectReference{Name: "mytag"},
-					ImportPolicy:    imagev1.TagImportPolicy{Scheduled: true, ImportMode: imagev1.ImportModeLegacy},
+					ImportPolicy:    imagev1.TagImportPolicy{Scheduled: true},
 					ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.SourceTagReferencePolicy},
 				},
 				{
 					From:            corev1.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:other"},
 					To:              &corev1.LocalObjectReference{Name: "other"},
-					ImportPolicy:    imagev1.TagImportPolicy{Scheduled: false, ImportMode: imagev1.ImportModeLegacy},
+					ImportPolicy:    imagev1.TagImportPolicy{Scheduled: false},
 					ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.SourceTagReferencePolicy},
 				},
 			},
@@ -610,7 +610,7 @@ func TestCreateImageImport(t *testing.T) {
 			},
 			expectedRepository: &imagev1.RepositoryImportSpec{
 				From:            corev1.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage"},
-				ImportPolicy:    imagev1.TagImportPolicy{Scheduled: true, ImportMode: imagev1.ImportModeLegacy},
+				ImportPolicy:    imagev1.TagImportPolicy{Scheduled: true},
 				ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.SourceTagReferencePolicy},
 			},
 		},

--- a/pkg/cli/newapp/newapp.go
+++ b/pkg/cli/newapp/newapp.go
@@ -302,7 +302,7 @@ func NewCmdNewApplication(f kcmdutil.Factory, streams genericiooptions.IOStreams
 	cmd.Flags().StringVar(&o.Config.SourceSecret, "source-secret", o.Config.SourceSecret, "The name of an existing secret that should be used for cloning a private git repository.")
 	cmd.Flags().BoolVar(&o.Config.SkipGeneration, "no-install", o.Config.SkipGeneration, "Do not attempt to run images that describe themselves as being installable")
 	cmd.Flags().BoolVar(&o.Config.BinaryBuild, "binary", o.Config.BinaryBuild, "Instead of expecting a source URL, set the build to expect binary contents. Will disable triggers.")
-	cmd.Flags().StringVar(&o.Config.ImportMode, "import-mode", o.Config.ImportMode, "Imports the full manifest list of a tag when set to 'PreserveOriginal'. Defaults to 'Legacy'.")
+	cmd.Flags().StringVar(&o.Config.ImportMode, "import-mode", o.Config.ImportMode, "Imports the full manifest list of a tag when set to 'PreserveOriginal'. When set to 'Legacy', imports a single sub-manifest. When unspecified, the cluster determines the import mode.")
 
 	o.Action.BindForOutput(cmd.Flags(), "output", "template")
 	cmd.Flags().String("output-version", "", "The preferred API versions of the output objects")

--- a/pkg/cli/newbuild/newbuild.go
+++ b/pkg/cli/newbuild/newbuild.go
@@ -158,7 +158,7 @@ func NewCmdNewBuild(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cob
 	cmd.Flags().BoolVar(&o.Config.NoOutput, "no-output", o.Config.NoOutput, "If true, the build output will not be pushed anywhere.")
 	cmd.Flags().StringVar(&o.Config.SourceImage, "source-image", o.Config.SourceImage, "Specify an image to use as source for the build.  You must also specify --source-image-path.")
 	cmd.Flags().StringVar(&o.Config.SourceImagePath, "source-image-path", o.Config.SourceImagePath, "Specify the file or directory to copy from the source image and its destination in the build directory. Format: [source]:[destination-dir].")
-	cmd.Flags().StringVar(&o.Config.ImportMode, "import-mode", o.Config.ImportMode, "Imports the full manifest list of a tag when set to 'PreserveOriginal'. Defaults to 'Legacy'.")
+	cmd.Flags().StringVar(&o.Config.ImportMode, "import-mode", o.Config.ImportMode, "Imports the full manifest list of a tag when set to 'PreserveOriginal'. When set to 'Legacy', imports a single sub-manifest. When unspecified, the cluster determines the import mode.")
 
 	o.Action.BindForOutput(cmd.Flags(), "output", "template", "sort-by")
 	cmd.Flags().String("output-version", "", "The preferred API versions of the output objects")

--- a/pkg/cli/tag/tag.go
+++ b/pkg/cli/tag/tag.go
@@ -116,7 +116,7 @@ func NewCmdTag(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Co
 	cmd.Flags().BoolVar(&o.scheduleTag, "scheduled", o.scheduleTag, "Set a container image to be periodically imported from a remote repository. Defaults to false.")
 	cmd.Flags().BoolVar(&o.insecureTag, "insecure", o.insecureTag, "Set to true if importing the specified container image requires HTTP or has a self-signed certificate. Defaults to false.")
 	cmd.Flags().StringVar(&o.referencePolicy, "reference-policy", SourceReferencePolicy, "Allow to request pullthrough for external image when set to 'local'. Defaults to 'source'.")
-	cmd.Flags().StringVar(&o.importMode, "import-mode", o.importMode, "Imports the full manifest list of a tag when set to 'PreserveOriginal'. Defaults to 'Legacy'.")
+	cmd.Flags().StringVar(&o.importMode, "import-mode", o.importMode, "Imports the full manifest list of a tag when set to 'PreserveOriginal'. When set to 'Legacy', imports a single sub-manifest. When unspecified, the cluster determines the import mode.")
 
 	return cmd
 }
@@ -367,7 +367,8 @@ func (o *TagOptions) Validate() error {
 	case string(imagev1.ImportModeLegacy):
 	case string(imagev1.ImportModePreserveOriginal):
 	case "":
-		o.importMode = string(imagev1.ImportModeLegacy)
+		// Leave empty and let it be decided based on the ClusterVersion's "desired.architecture" value. If the value is "Multi",
+		// the import mode is set to "PreserveOriginal", if not it is set to "Legacy"
 	default:
 		return fmt.Errorf("valid ImportMode values are %s or %s", imagev1.ImportModeLegacy, imagev1.ImportModePreserveOriginal)
 	}

--- a/pkg/cli/tag/tag_test.go
+++ b/pkg/cli/tag/tag_test.go
@@ -433,8 +433,9 @@ func TestRunTag_AddImportMode(t *testing.T) {
 				destNameAndTag:  []string{"rails:tip"},
 			},
 			expectedActions: []testActionWithImportMode{
-				{verb: "update", resource: "imagestreamtags", importMode: string(imagev1.ImportModeLegacy)},
-				{verb: "create", resource: "imagestreamtags", importMode: string(imagev1.ImportModeLegacy)},
+				// Empty import mode - let the cluster decide based on its configuration
+				{verb: "update", resource: "imagestreamtags", importMode: ""},
+				{verb: "create", resource: "imagestreamtags", importMode: ""},
 			},
 		},
 		"valid tag with import mode PreserveOriginal": {

--- a/pkg/helpers/newapp/cmd/newapp.go
+++ b/pkg/helpers/newapp/cmd/newapp.go
@@ -888,7 +888,8 @@ func (c *AppConfig) Run() (*AppResult, error) {
 	case string(imagev1.ImportModeLegacy):
 	case string(imagev1.ImportModePreserveOriginal):
 	case "":
-		c.ImportMode = string(imagev1.ImportModeLegacy)
+		// Leave empty and let it be decided based on the ClusterVersion's "desired.architecture" value. If the value is "Multi",
+		// the import mode is set to "PreserveOriginal", if not it is set to "Legacy"
 	default:
 		return nil, fmt.Errorf("valid ImportMode values are %s or %s", imagev1.ImportModeLegacy, imagev1.ImportModePreserveOriginal)
 	}


### PR DESCRIPTION
Today, we default to "Legacy" importmode when no option is specified. With the introduction of
https://issues.redhat.com/browse/MULTIARCH-4552, the importmode is determined by the Cluster version's `desired.architecture` - which if set to "Multi", the import mode is PreserveOriginal else Legacy. Hence we don't need to default to Legacy all the time.