### PR TITLE
OCPBUGS-62799: Add required-scc annotation to node-joiner pod 

### DIFF
--- a/pkg/cli/admin/nodeimage/create.go
+++ b/pkg/cli/admin/nodeimage/create.go
@@ -712,6 +712,9 @@ func (o *CreateOptions) createPod(ctx context.Context) error {
 			Labels: map[string]string{
 				"app": "node-joiner",
 			},
+			Annotations: map[string]string{
+				"openshift.io/required-scc": "restricted-v2",
+			},
 		},
 		Spec: corev1.PodSpec{
 			RestartPolicy:      corev1.RestartPolicyNever,

--- a/pkg/cli/admin/nodeimage/create_test.go
+++ b/pkg/cli/admin/nodeimage/create_test.go
@@ -236,6 +236,18 @@ func TestRun(t *testing.T) {
 			objects:          ClusterVersion_4_17_ObjectFn,
 			remoteExecOutput: "0",
 		},
+		{
+			name:        "node-joiner pod has required-scc annotation",
+			nodesConfig: defaultNodesConfigYaml,
+			objects:     defaultClusterVersionObjectFn,
+			expectedPod: func(t *testing.T, pod *corev1.Pod) {
+				expected := "restricted-v2"
+				got := pod.Annotations["openshift.io/required-scc"]
+				if got != expected {
+					t.Errorf("annotation openshift.io/required-scc = %q, want %q", got, expected)
+				}
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/cli/admin/nodeimage/monitor.go
+++ b/pkg/cli/admin/nodeimage/monitor.go
@@ -263,6 +263,9 @@ func (o *MonitorOptions) createPod(ctx context.Context) error {
 			Labels: map[string]string{
 				"app": "node-joiner-monitor",
 			},
+			Annotations: map[string]string{
+				"openshift.io/required-scc": "restricted-v2",
+			},
 		},
 		Spec: corev1.PodSpec{
 			RestartPolicy:      corev1.RestartPolicyNever,

--- a/pkg/cli/admin/nodeimage/monitor_test.go
+++ b/pkg/cli/admin/nodeimage/monitor_test.go
@@ -3,6 +3,7 @@ package nodeimage
 import (
 	"bytes"
 	fakeoperatorconfig "github.com/openshift/client-go/operator/clientset/versioned/fake"
+	corev1 "k8s.io/api/core/v1"
 	"strings"
 	"testing"
 
@@ -73,6 +74,7 @@ func TestMonitorRun(t *testing.T) {
 		remoteExecOutput string
 
 		expectedError string
+		expectedPod   func(t *testing.T, pod *corev1.Pod)
 	}{
 		{
 			name:    "default",
@@ -81,6 +83,17 @@ func TestMonitorRun(t *testing.T) {
 		{
 			name:          "missing cluster connection",
 			expectedError: `command expects a connection to an OpenShift 4.x server`,
+		},
+		{
+			name:    "node-joiner monitor pod has required-scc annotation",
+			objects: defaultClusterVersionObjectFn,
+			expectedPod: func(t *testing.T, pod *corev1.Pod) {
+				expected := "restricted-v2"
+				got := pod.Annotations["openshift.io/required-scc"]
+				if got != expected {
+					t.Errorf("annotation openshift.io/required-scc = %q, want %q", got, expected)
+				}
+			},
 		},
 	}
 	for _, tc := range testCases {
@@ -133,6 +146,10 @@ func TestMonitorRun(t *testing.T) {
 				if fakeLogContent != logContents.String() {
 					t.Errorf("expected %v, actual %v", fakeLogContent, logContents.String())
 				}
+			}
+			if tc.expectedPod != nil {
+				pod := getTestPod(fakeClient, nodeJoinerMonitorContainer)
+				tc.expectedPod(t, pod)
 			}
 		})
 	}


### PR DESCRIPTION
When a third-party SCC (e.g. Pure Storage CSI) with readOnlyRootFilesystem: true and higher priority is broadly accessible via RBAC, the SCC admission controller may assign it to the node-joiner pod instead of restricted-v2. This causes the node-joiner tool to fail with 'read-only file system' errors when writing to /tmp.

Adding the openshift.io/required-scc annotation ensures restricted-v2 is always assigned regardless of other SCCs' priority or restrictiveness, as required by the custom SCC preemption prevention enhancement:
https://github.com/openshift/enhancements/blob/master/enhancements/authentication/custom-scc-preemption-prevention.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pod creation operations in node image utilities now include proper OpenShift security constraint annotations, ensuring pods are created with appropriate cluster security policies.

* **Tests**
  * Added test coverage to validate that security constraint annotations are correctly applied during pod creation and monitoring operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->