### PR TITLE
NO-JIRA: Fix `oc` builds on Mac OS X Apple Silicon machines

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -228,6 +228,6 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
 )
 
-replace github.com/apcera/gssapi => github.com/openshift/gssapi v0.0.0-20161010215902-5fb4217df13b
+replace github.com/apcera/gssapi => github.com/openshift/gssapi v0.0.0-20260819120910-d6b72669a11e
 
 replace github.com/onsi/ginkgo/v2 => github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1

--- a/go.sum
+++ b/go.sum
@@ -385,8 +385,8 @@ github.com/openshift/build-machinery-go v0.0.0-20260629141115-154a2b810491 h1:P/
 github.com/openshift/build-machinery-go v0.0.0-20260629141115-154a2b810491/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/openshift/client-go v0.0.0-20260715172546-dac61734e0ec h1:UDjX+mot5IVLpcChyBqLXG1oSB29s4UkqFmgNb0Xsqc=
 github.com/openshift/client-go v0.0.0-20260715172546-dac61734e0ec/go.mod h1:iMHec0APKVjOH8GfL/RxddX8DuiuSvPlRe+s7KDqlyA=
-github.com/openshift/gssapi v0.0.0-20161010215902-5fb4217df13b h1:it0YPE/evO6/m8t8wxis9KFI2F/aleOKsI6d9uz0cEk=
-github.com/openshift/gssapi v0.0.0-20161010215902-5fb4217df13b/go.mod h1:tNrEB5k8SI+g5kOlsCmL2ELASfpqEofI0+FLBgBdN08=
+github.com/openshift/gssapi v0.0.0-20260819120910-d6b72669a11e h1:UCxtFDw0ObWGm4bmaAhFZ1hEwZPZnwiSONKj7G6WBr0=
+github.com/openshift/gssapi v0.0.0-20260819120910-d6b72669a11e/go.mod h1:tNrEB5k8SI+g5kOlsCmL2ELASfpqEofI0+FLBgBdN08=
 github.com/openshift/library-go v0.0.0-20260720123941-85336565c3c7 h1:ANCld7YKQ8EI3fwRGo3oSrYzF1aOwJdXOwN15HLNa3g=
 github.com/openshift/library-go v0.0.0-20260720123941-85336565c3c7/go.mod h1:iWcB6wgeOhsByZAZGhmzBtEnrLQzABL0s3aeou8AmSI=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1 h1:PMTgifBcBRLJJiM+LgSzPDTk9/Rx4qS09OUrfpY6GBQ=

--- a/vendor/github.com/apcera/gssapi/name.go
+++ b/vendor/github.com/apcera/gssapi/name.go
@@ -16,9 +16,10 @@ package gssapi
 //
 // Using "MacPorts" on MacOS gives us: -I/opt/local/include
 // Using "brew" on MacOS gives us: -I/usr/local/opt/heimdal/include
+// Using "brew" on MacOS (Apple Silicon) gives us: -I/opt/homebrew/opt/heimdal/include
 
 /*
-#cgo darwin CFLAGS: -I/opt/local/include -I/usr/local/opt/heimdal/include
+#cgo darwin CFLAGS: -I/opt/local/include -I/usr/local/opt/heimdal/include -I/opt/homebrew/opt/heimdal/include
 #include <stdio.h>
 
 #include <gssapi/gssapi.h>

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -51,7 +51,7 @@ github.com/alicebob/sqlittle/sql
 # github.com/antlr4-go/antlr/v4 v4.13.0
 ## explicit; go 1.20
 github.com/antlr4-go/antlr/v4
-# github.com/apcera/gssapi v0.0.0-00010101000000-000000000000 => github.com/openshift/gssapi v0.0.0-20161010215902-5fb4217df13b
+# github.com/apcera/gssapi v0.0.0-00010101000000-000000000000 => github.com/openshift/gssapi v0.0.0-20260819120910-d6b72669a11e
 ## explicit
 github.com/apcera/gssapi
 # github.com/aws/aws-sdk-go-v2 v1.41.3
@@ -2060,5 +2060,5 @@ sigs.k8s.io/structured-merge-diff/v6/value
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v3
 sigs.k8s.io/yaml/kyaml
-# github.com/apcera/gssapi => github.com/openshift/gssapi v0.0.0-20161010215902-5fb4217df13b
+# github.com/apcera/gssapi => github.com/openshift/gssapi v0.0.0-20260819120910-d6b72669a11e
 # github.com/onsi/ginkgo/v2 => github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1


### PR DESCRIPTION
Homebrew uses a different prefix path than is hard-coded in the `gssapi` library.

This change sets the include path dynamically based on Homebrew, when available.

Fixes #2136 

I also cleaned up the Makefile a bit in a separate commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the GSSAPI integration to a newer implementation, improving compatibility and maintenance without changing user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->