### PR TITLE
OCPCRT-458: Add feature gate changes to changelog JSON output

### DIFF
--- a/pkg/cli/admin/release/info.go
+++ b/pkg/cli/admin/release/info.go
@@ -1282,6 +1282,10 @@ func printFeatureSetSection(diff *ReleaseDiff, w io.Writer) {
 	}
 }
 
+// removedFeatureSets contains feature sets that were dead-ends and have been removed
+// from the product. They should be excluded from all feature gate diffs.
+var removedFeatureSets = []string{"LatencySensitive"}
+
 func calculateFeatureSetDiff(diff *ReleaseDiff) (*features.ReleaseFeatureDiffInfo, error) {
 	toFiles := features.FilenameToContent{}
 	for filename, featureGateBytes := range diff.To.ManifestFiles {
@@ -1775,6 +1779,37 @@ func describeChangelog(out, errOut io.Writer, releaseInfo *ReleaseInfo, diff *Re
 					Version: version.Version,
 					From:    old.Version,
 				})
+			}
+		}
+		if featureSetDiff, err := calculateFeatureSetDiff(diff); err != nil {
+			fmt.Fprintf(errOut, "error: unable to calculate feature gate diff: %v\n", err)
+			hasError = true
+		} else {
+			orderedFeatureGates := featureSetDiff.GetOrderedFeatureGates()
+			allFeatureSets := featureSetDiff.AllFeatureSets()
+			allFeatureSets.Delete(removedFeatureSets...)
+			allClusterProfiles := featureSetDiff.AllClusterProfiles()
+			for _, fg := range orderedFeatureGates {
+				fgInfo := ChangeLogFeatureGateInfo{
+					Name:   fg,
+					Status: map[string]map[string]string{},
+				}
+				for _, cp := range sets.List(allClusterProfiles) {
+					cpStatus := map[string]string{}
+					for _, fs := range sets.List(allFeatureSets) {
+						if diffInfo := featureSetDiff.FeatureInfoFor(cp, fs); diffInfo != nil {
+							if change, ok := diffInfo.ChangedFeatureGates[fg]; ok {
+								cpStatus[fs] = change
+							}
+						}
+					}
+					if len(cpStatus) > 0 {
+						fgInfo.Status[cp] = cpStatus
+					}
+				}
+				if len(fgInfo.Status) > 0 {
+					changeLog.FeatureGates = append(changeLog.FeatureGates, fgInfo)
+				}
 			}
 		}
 		if len(added) > 0 {
@@ -2712,11 +2747,19 @@ type ChangeLog struct {
 	From ChangeLogReleaseInfo `json:"from"`
 	To   ChangeLogReleaseInfo `json:"to"`
 
-	Components    []ChangeLogComponentInfo `json:"components,omitempty"`
-	NewImages     []ChangeLogImageInfo     `json:"newImages,omitempty"`
-	RemovedImages []ChangeLogImageInfo     `json:"removedImages,omitempty"`
-	RebuiltImages []ChangeLogImageInfo     `json:"rebuiltImages,omitempty"`
-	UpdatedImages []ChangeLogImageInfo     `json:"updatedImages,omitempty"`
+	Components    []ChangeLogComponentInfo   `json:"components,omitempty"`
+	FeatureGates  []ChangeLogFeatureGateInfo `json:"featureGates,omitempty"`
+	NewImages     []ChangeLogImageInfo       `json:"newImages,omitempty"`
+	RemovedImages []ChangeLogImageInfo       `json:"removedImages,omitempty"`
+	RebuiltImages []ChangeLogImageInfo       `json:"rebuiltImages,omitempty"`
+	UpdatedImages []ChangeLogImageInfo       `json:"updatedImages,omitempty"`
+}
+
+// ChangeLogFeatureGateInfo describes the state of a feature gate across cluster profiles and feature sets.
+type ChangeLogFeatureGateInfo struct {
+	Name string `json:"name"`
+	// Status maps clusterProfile -> featureSet -> status string (e.g. "Enabled (Changed)", "Disabled (New)")
+	Status map[string]map[string]string `json:"status"`
 }
 
 type ChangeLogReleaseInfo struct {

--- a/pkg/cli/admin/release/info.go
+++ b/pkg/cli/admin/release/info.go
@@ -1786,29 +1786,28 @@ func describeChangelog(out, errOut io.Writer, releaseInfo *ReleaseInfo, diff *Re
 			hasError = true
 		} else {
 			orderedFeatureGates := featureSetDiff.GetOrderedFeatureGates()
-			allFeatureSets := featureSetDiff.AllFeatureSets()
-			allFeatureSets.Delete(removedFeatureSets...)
-			allClusterProfiles := featureSetDiff.AllClusterProfiles()
+			removedFS := sets.New(removedFeatureSets...)
+			fgStatuses := map[string]map[string]map[string]string{}
+			for _, diffInfo := range featureSetDiff.AllFeatureInfo() {
+				if removedFS.Has(diffInfo.FeatureSet) {
+					continue
+				}
+				for fg, change := range diffInfo.ChangedFeatureGates {
+					if fgStatuses[fg] == nil {
+						fgStatuses[fg] = map[string]map[string]string{}
+					}
+					if fgStatuses[fg][diffInfo.ClusterProfile] == nil {
+						fgStatuses[fg][diffInfo.ClusterProfile] = map[string]string{}
+					}
+					fgStatuses[fg][diffInfo.ClusterProfile][diffInfo.FeatureSet] = change
+				}
+			}
 			for _, fg := range orderedFeatureGates {
-				fgInfo := ChangeLogFeatureGateInfo{
-					Name:   fg,
-					Status: map[string]map[string]string{},
-				}
-				for _, cp := range sets.List(allClusterProfiles) {
-					cpStatus := map[string]string{}
-					for _, fs := range sets.List(allFeatureSets) {
-						if diffInfo := featureSetDiff.FeatureInfoFor(cp, fs); diffInfo != nil {
-							if change, ok := diffInfo.ChangedFeatureGates[fg]; ok {
-								cpStatus[fs] = change
-							}
-						}
-					}
-					if len(cpStatus) > 0 {
-						fgInfo.Status[cp] = cpStatus
-					}
-				}
-				if len(fgInfo.Status) > 0 {
-					changeLog.FeatureGates = append(changeLog.FeatureGates, fgInfo)
+				if status, ok := fgStatuses[fg]; ok {
+					changeLog.FeatureGates = append(changeLog.FeatureGates, ChangeLogFeatureGateInfo{
+						Name:   fg,
+						Status: status,
+					})
 				}
 			}
 		}

--- a/pkg/cli/admin/release/info_changelog_test.go
+++ b/pkg/cli/admin/release/info_changelog_test.go
@@ -1,0 +1,186 @@
+package release
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	digest "github.com/opencontainers/go-digest"
+	imageapi "github.com/openshift/api/image/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func featureGateManifest(clusterProfile, featureSet string, enabled, disabled []string) []byte {
+	enabledItems := ""
+	for _, fg := range enabled {
+		enabledItems += `      - name: ` + fg + "\n"
+	}
+	disabledItems := ""
+	for _, fg := range disabled {
+		disabledItems += `      - name: ` + fg + "\n"
+	}
+	featureSetField := ""
+	if featureSet != "" && featureSet != "Default" {
+		featureSetField = "  featureSet: " + featureSet + "\n"
+	}
+	annotations := ""
+	if clusterProfile != "" {
+		annotations = `  annotations:
+    include.release.openshift.io/` + clusterProfile + `: "true"
+`
+	}
+	return []byte(`apiVersion: config.openshift.io/v1
+kind: FeatureGate
+metadata:
+  name: cluster
+` + annotations + `spec:
+` + featureSetField + `status:
+  featureGates:
+    - version: "4.22"
+      enabled:
+` + enabledItems + `      disabled:
+` + disabledItems)
+}
+
+func TestDescribeChangelogFeatureGatesJSON(t *testing.T) {
+	fromManifest := featureGateManifest(
+		"self-managed-high-availability",
+		"",
+		[]string{"ExistingEnabled"},
+		[]string{"ExistingDisabled", "WillBeEnabled"},
+	)
+	toManifest := featureGateManifest(
+		"self-managed-high-availability",
+		"",
+		[]string{"ExistingEnabled", "WillBeEnabled"},
+		[]string{"ExistingDisabled"},
+	)
+
+	fromDigest := digest.FromString("from")
+	toDigest := digest.FromString("to")
+
+	diff := &ReleaseDiff{
+		From: &ReleaseInfo{
+			Digest: fromDigest,
+			References: &imageapi.ImageStream{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1.Now(),
+				},
+				Spec: imageapi.ImageStreamSpec{
+					Tags: []imageapi.TagReference{{Name: "from-tag"}},
+				},
+			},
+			ManifestFiles: map[string][]byte{
+				"0000_50_cluster-config-api_featureGate-Default-SelfManagedHA.yaml": fromManifest,
+			},
+			ComponentVersions: ComponentVersions{},
+		},
+		To: &ReleaseInfo{
+			Digest: toDigest,
+			References: &imageapi.ImageStream{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1.Now(),
+				},
+				Spec: imageapi.ImageStreamSpec{
+					Tags: []imageapi.TagReference{{Name: "to-tag"}},
+				},
+			},
+			ManifestFiles: map[string][]byte{
+				"0000_50_cluster-config-api_featureGate-Default-SelfManagedHA.yaml": toManifest,
+			},
+			ComponentVersions: ComponentVersions{},
+		},
+		ChangedImages:    map[string]*ImageReferenceDiff{},
+		ChangedManifests: map[string]*ReleaseManifestDiff{},
+	}
+
+	out := &bytes.Buffer{}
+	errOut := &bytes.Buffer{}
+	err := describeChangelog(out, errOut, &ReleaseInfo{}, diff, "", "json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr: %s", err, errOut.String())
+	}
+
+	var changeLog ChangeLog
+	if err := json.Unmarshal(out.Bytes(), &changeLog); err != nil {
+		t.Fatalf("failed to unmarshal JSON output: %v\noutput: %s", err, out.String())
+	}
+
+	if len(changeLog.FeatureGates) == 0 {
+		t.Fatal("expected featureGates in JSON output, got none")
+	}
+
+	// WillBeEnabled changed from Disabled to Enabled
+	found := false
+	for _, fg := range changeLog.FeatureGates {
+		if fg.Name == "WillBeEnabled" {
+			found = true
+			status, ok := fg.Status["SelfManagedHA"]
+			if !ok {
+				t.Fatalf("expected SelfManagedHA cluster profile, got: %v", fg.Status)
+			}
+			defaultStatus, ok := status["Default"]
+			if !ok {
+				t.Fatalf("expected Default feature set, got: %v", status)
+			}
+			if defaultStatus != "Enabled (Changed)" {
+				t.Errorf("expected 'Enabled (Changed)' for WillBeEnabled, got %q", defaultStatus)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected WillBeEnabled in feature gates, got: %v", changeLog.FeatureGates)
+	}
+}
+
+func TestDescribeChangelogNoFeatureGatesJSON(t *testing.T) {
+	fromDigest := digest.FromString("from")
+	toDigest := digest.FromString("to")
+
+	diff := &ReleaseDiff{
+		From: &ReleaseInfo{
+			Digest: fromDigest,
+			References: &imageapi.ImageStream{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1.Now(),
+				},
+				Spec: imageapi.ImageStreamSpec{
+					Tags: []imageapi.TagReference{{Name: "from-tag"}},
+				},
+			},
+			ManifestFiles:     map[string][]byte{},
+			ComponentVersions: ComponentVersions{},
+		},
+		To: &ReleaseInfo{
+			Digest: toDigest,
+			References: &imageapi.ImageStream{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1.Now(),
+				},
+				Spec: imageapi.ImageStreamSpec{
+					Tags: []imageapi.TagReference{{Name: "to-tag"}},
+				},
+			},
+			ManifestFiles:     map[string][]byte{},
+			ComponentVersions: ComponentVersions{},
+		},
+		ChangedImages:    map[string]*ImageReferenceDiff{},
+		ChangedManifests: map[string]*ReleaseManifestDiff{},
+	}
+
+	out := &bytes.Buffer{}
+	errOut := &bytes.Buffer{}
+	err := describeChangelog(out, errOut, &ReleaseInfo{}, diff, "", "json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var changeLog ChangeLog
+	if err := json.Unmarshal(out.Bytes(), &changeLog); err != nil {
+		t.Fatalf("failed to unmarshal JSON output: %v", err)
+	}
+
+	if len(changeLog.FeatureGates) != 0 {
+		t.Errorf("expected no featureGates when no manifests present, got %d", len(changeLog.FeatureGates))
+	}
+}

--- a/pkg/cli/admin/release/info_changelog_test.go
+++ b/pkg/cli/admin/release/info_changelog_test.go
@@ -6,40 +6,55 @@ import (
 	"testing"
 
 	digest "github.com/opencontainers/go-digest"
+	configv1 "github.com/openshift/api/config/v1"
 	imageapi "github.com/openshift/api/image/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 )
 
 func featureGateManifest(clusterProfile, featureSet string, enabled, disabled []string) []byte {
-	enabledItems := ""
+	var enabledAttrs []configv1.FeatureGateAttributes
 	for _, fg := range enabled {
-		enabledItems += `      - name: ` + fg + "\n"
+		enabledAttrs = append(enabledAttrs, configv1.FeatureGateAttributes{Name: configv1.FeatureGateName(fg)})
 	}
-	disabledItems := ""
+	var disabledAttrs []configv1.FeatureGateAttributes
 	for _, fg := range disabled {
-		disabledItems += `      - name: ` + fg + "\n"
+		disabledAttrs = append(disabledAttrs, configv1.FeatureGateAttributes{Name: configv1.FeatureGateName(fg)})
 	}
-	featureSetField := ""
-	if featureSet != "" && featureSet != "Default" {
-		featureSetField = "  featureSet: " + featureSet + "\n"
+
+	fg := configv1.FeatureGate{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "config.openshift.io/v1",
+			Kind:       "FeatureGate",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Spec: configv1.FeatureGateSpec{
+			FeatureGateSelection: configv1.FeatureGateSelection{
+				FeatureSet: configv1.FeatureSet(featureSet),
+			},
+		},
+		Status: configv1.FeatureGateStatus{
+			FeatureGates: []configv1.FeatureGateDetails{{
+				Version:  "4.22",
+				Enabled:  enabledAttrs,
+				Disabled: disabledAttrs,
+			}},
+		},
 	}
-	annotations := ""
+
 	if clusterProfile != "" {
-		annotations = `  annotations:
-    include.release.openshift.io/` + clusterProfile + `: "true"
-`
+		fg.Annotations = map[string]string{
+			"include.release.openshift.io/" + clusterProfile: "true",
+		}
 	}
-	return []byte(`apiVersion: config.openshift.io/v1
-kind: FeatureGate
-metadata:
-  name: cluster
-` + annotations + `spec:
-` + featureSetField + `status:
-  featureGates:
-    - version: "4.22"
-      enabled:
-` + enabledItems + `      disabled:
-` + disabledItems)
+
+	data, err := yaml.Marshal(fg)
+	if err != nil {
+		panic(err)
+	}
+	return data
 }
 
 func TestDescribeChangelogFeatureGatesJSON(t *testing.T) {
@@ -94,9 +109,8 @@ func TestDescribeChangelogFeatureGatesJSON(t *testing.T) {
 		ChangedManifests: map[string]*ReleaseManifestDiff{},
 	}
 
-	out := &bytes.Buffer{}
-	errOut := &bytes.Buffer{}
-	err := describeChangelog(out, errOut, &ReleaseInfo{}, diff, "", "json")
+	var out, errOut bytes.Buffer
+	err := describeChangelog(&out, &errOut, &ReleaseInfo{}, diff, "", "json")
 	if err != nil {
 		t.Fatalf("unexpected error: %v\nstderr: %s", err, errOut.String())
 	}
@@ -168,9 +182,8 @@ func TestDescribeChangelogNoFeatureGatesJSON(t *testing.T) {
 		ChangedManifests: map[string]*ReleaseManifestDiff{},
 	}
 
-	out := &bytes.Buffer{}
-	errOut := &bytes.Buffer{}
-	err := describeChangelog(out, errOut, &ReleaseInfo{}, diff, "", "json")
+	var out, errOut bytes.Buffer
+	err := describeChangelog(&out, &errOut, &ReleaseInfo{}, diff, "", "json")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/cli/admin/release/info_changelog_test.go
+++ b/pkg/cli/admin/release/info_changelog_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	digest "github.com/opencontainers/go-digest"
 	configv1 "github.com/openshift/api/config/v1"
 	imageapi "github.com/openshift/api/image/v1"
@@ -12,7 +13,7 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-func featureGateManifest(clusterProfile, featureSet string, enabled, disabled []string) []byte {
+func featureGateManifest(clusterProfile string, enabled, disabled []string) []byte {
 	var enabledAttrs []configv1.FeatureGateAttributes
 	for _, fg := range enabled {
 		enabledAttrs = append(enabledAttrs, configv1.FeatureGateAttributes{Name: configv1.FeatureGateName(fg)})
@@ -30,11 +31,7 @@ func featureGateManifest(clusterProfile, featureSet string, enabled, disabled []
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "cluster",
 		},
-		Spec: configv1.FeatureGateSpec{
-			FeatureGateSelection: configv1.FeatureGateSelection{
-				FeatureSet: configv1.FeatureSet(featureSet),
-			},
-		},
+		Spec: configv1.FeatureGateSpec{},
 		Status: configv1.FeatureGateStatus{
 			FeatureGates: []configv1.FeatureGateDetails{{
 				Version:  "4.22",
@@ -60,13 +57,11 @@ func featureGateManifest(clusterProfile, featureSet string, enabled, disabled []
 func TestDescribeChangelogFeatureGatesJSON(t *testing.T) {
 	fromManifest := featureGateManifest(
 		"self-managed-high-availability",
-		"",
 		[]string{"ExistingEnabled"},
 		[]string{"ExistingDisabled", "WillBeEnabled"},
 	)
 	toManifest := featureGateManifest(
 		"self-managed-high-availability",
-		"",
 		[]string{"ExistingEnabled", "WillBeEnabled"},
 		[]string{"ExistingDisabled"},
 	)
@@ -116,34 +111,20 @@ func TestDescribeChangelogFeatureGatesJSON(t *testing.T) {
 	}
 
 	var changeLog ChangeLog
-	if err := json.Unmarshal(out.Bytes(), &changeLog); err != nil {
-		t.Fatalf("failed to unmarshal JSON output: %v\noutput: %s", err, out.String())
+	if err := json.NewDecoder(&out).Decode(&changeLog); err != nil {
+		t.Fatalf("failed to decode JSON output: %v", err)
 	}
 
-	if len(changeLog.FeatureGates) == 0 {
-		t.Fatal("expected featureGates in JSON output, got none")
-	}
-
-	// WillBeEnabled changed from Disabled to Enabled
-	found := false
-	for _, fg := range changeLog.FeatureGates {
-		if fg.Name == "WillBeEnabled" {
-			found = true
-			status, ok := fg.Status["SelfManagedHA"]
-			if !ok {
-				t.Fatalf("expected SelfManagedHA cluster profile, got: %v", fg.Status)
-			}
-			defaultStatus, ok := status["Default"]
-			if !ok {
-				t.Fatalf("expected Default feature set, got: %v", status)
-			}
-			if defaultStatus != "Enabled (Changed)" {
-				t.Errorf("expected 'Enabled (Changed)' for WillBeEnabled, got %q", defaultStatus)
-			}
-		}
-	}
-	if !found {
-		t.Errorf("expected WillBeEnabled in feature gates, got: %v", changeLog.FeatureGates)
+	expected := []ChangeLogFeatureGateInfo{{
+		Name: "WillBeEnabled",
+		Status: map[string]map[string]string{
+			"SelfManagedHA": {
+				"Default": "Enabled (Changed)",
+			},
+		},
+	}}
+	if diff := cmp.Diff(expected, changeLog.FeatureGates); diff != "" {
+		t.Errorf("unexpected featureGates (-want +got):\n%s", diff)
 	}
 }
 
@@ -189,11 +170,11 @@ func TestDescribeChangelogNoFeatureGatesJSON(t *testing.T) {
 	}
 
 	var changeLog ChangeLog
-	if err := json.Unmarshal(out.Bytes(), &changeLog); err != nil {
-		t.Fatalf("failed to unmarshal JSON output: %v", err)
+	if err := json.NewDecoder(&out).Decode(&changeLog); err != nil {
+		t.Fatalf("failed to decode JSON output: %v", err)
 	}
 
-	if len(changeLog.FeatureGates) != 0 {
-		t.Errorf("expected no featureGates when no manifests present, got %d", len(changeLog.FeatureGates))
+	if diff := cmp.Diff([]ChangeLogFeatureGateInfo(nil), changeLog.FeatureGates); diff != "" {
+		t.Errorf("unexpected featureGates (-want +got):\n%s", diff)
 	}
 }

--- a/pkg/cli/admin/release/info_diff_writer.go
+++ b/pkg/cli/admin/release/info_diff_writer.go
@@ -11,7 +11,7 @@ import (
 
 func produceDiffMarkdown(testReporting *configv1.TestReporting, releaseFeatureDiffInfo *features.ReleaseFeatureDiffInfo) ([]byte, error) {
 	allFeatureSets := releaseFeatureDiffInfo.AllFeatureSets()
-	allFeatureSets.Delete("LatencySensitive") // this was a dead-end featureset we removed.
+	allFeatureSets.Delete(removedFeatureSets...)
 	allClusterProfiles := releaseFeatureDiffInfo.AllClusterProfiles()
 
 	cols := []features.ColumnTuple{}


### PR DESCRIPTION
## Summary
- The changelog JSON output (`oc adm release info --changelog --output=json`) was missing feature gate change data that was only available in the markdown output
- Adds a `featureGates` field to the `ChangeLog` JSON struct using the existing `calculateFeatureSetDiff()` logic
- This enables downstream consumers (e.g. release-controller API) to access structured feature gate data without parsing markdown

### Sample JSON output

```json
{
  "featureGates": [
    {
      "name": "GatewayAPI",
      "status": {
        "Hypershift": {
          "Default": "Unconditionally Enabled (Changed)",
          "DevPreviewNoUpgrade": "Unconditionally Enabled (Changed)",
          "TechPreviewNoUpgrade": "Unconditionally Enabled (Changed)"
        },
        "SelfManagedHA": {
          "Default": "Unconditionally Enabled (Changed)",
          "DevPreviewNoUpgrade": "Unconditionally Enabled (Changed)",
          "TechPreviewNoUpgrade": "Unconditionally Enabled (Changed)"
        }
      }
    },
    {
      "name": "MachineConfigNodes",
      "status": {
        "Hypershift": {
          "Default": "Unconditionally Enabled (Changed)"
        },
        "SelfManagedHA": {
          "Default": "Unconditionally Enabled (Changed)"
        }
      }
    }
  ]
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)