### PR TITLE
OCPBUGS-77845: Fix extraction of gated manifests using --install-config

### DIFF
--- a/pkg/cli/admin/release/extract.go
+++ b/pkg/cli/admin/release/extract.go
@@ -362,7 +362,7 @@ func (o *ExtractOptions) Run(ctx context.Context) error {
 	// o.ExtractManifests implies o.File == ""
 	if o.ExtractManifests {
 		opts.TarEntryCallback = func(hdr *tar.Header, _ extract.LayerInfo, r io.Reader) (bool, error) {
-			if hdr.Name == "image-references" && !o.CredentialsRequests {
+			if hdr.Name == "image-references" {
 				buf := &bytes.Buffer{}
 				if _, err := io.Copy(buf, r); err != nil {
 					return false, fmt.Errorf("unable to load image-references from release payload: %w", err)
@@ -383,7 +383,7 @@ func (o *ExtractOptions) Run(ctx context.Context) error {
 					rawData: buf.Bytes(),
 				})
 				return true, nil
-			} else if hdr.Name == "release-metadata" && !o.CredentialsRequests {
+			} else if hdr.Name == "release-metadata" {
 				buf := &bytes.Buffer{}
 				if _, err := io.Copy(buf, r); err != nil {
 					return false, err

--- a/pkg/cli/admin/release/extract_tools.go
+++ b/pkg/cli/admin/release/extract_tools.go
@@ -1226,7 +1226,7 @@ func findClusterIncludeConfigFromInstallConfig(installConfigPath string, files [
 	}
 
 	// Extract enabled feature gates from release image
-	enabledFeatureGates, releaseMajorVersion, err := extractFeatureGatesFromFiles(files, reportedVersion, string(data.FeatureSet), *config.Profile)
+	enabledFeatureGates, releaseMajorVersion, err := extractFeatureGatesFromFiles(files, string(data.FeatureSet), *config.Profile)
 	if err != nil {
 		// Log error but don't fail
 		// In this case all manifests will be included
@@ -1328,13 +1328,8 @@ func newIncluder(config manifestInclusionConfiguration) includer {
 
 // extractFeatureGatesFromFiles extracts FeatureGate manifests from the release payload
 // cached files and returns the set of enabled feature gates for the specified version and profile.
-func extractFeatureGatesFromFiles(files []extractedFile, version, featureSet, profile string) (sets.Set[string], *uint64, error) {
+func extractFeatureGatesFromFiles(files []extractedFile, featureSet, profile string) (sets.Set[string], *uint64, error) {
 	enabledFeatureGates := sets.Set[string]{}
-
-	// Validate the version
-	if version == "" {
-		return enabledFeatureGates, nil, fmt.Errorf("version cannot be empty")
-	}
 
 	featureGateManifests := []configv1.FeatureGate{}
 	releaseMetadata := struct {
@@ -1390,7 +1385,7 @@ func extractFeatureGatesFromFiles(files []extractedFile, version, featureSet, pr
 		}
 	}
 
-	klog.V(4).Infof("Successfully extracted %d feature gates for version %s", enabledFeatureGates.Len(), version)
+	klog.V(4).Infof("Successfully extracted %d feature gates for version %s", enabledFeatureGates.Len(), releaseMetadata.Version)
 	return enabledFeatureGates, ptr.To(parsedVersion.Major), nil
 }
 


### PR DESCRIPTION
We were filtering out the release-metadata too early in the cycle which meant that we didn't have it available within the feature gate extraction mechanism. This meant we couldn't identify the release version, and therefore bailed out without any feature gate aware filtering.

This removes the early check for credentials request (it's filtered during the write to disk) so that we still keep these files in memory to be used by later stages

Also turns out we don't need/care about the OC version so dropping that part too