### PR TITLE
RFE-3594: Add group membership info

### DIFF
--- a/pkg/cli/whoami/whoami.go
+++ b/pkg/cli/whoami/whoami.go
@@ -6,20 +6,23 @@ import (
 
 	"github.com/spf13/cobra"
 
+	userv1 "github.com/openshift/api/user/v1"
+	userv1typedclient "github.com/openshift/client-go/user/clientset/versioned/typed/user/v1"
+
 	v1 "k8s.io/api/authentication/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/client-go/kubernetes"
 	authenticationv1client "k8s.io/client-go/kubernetes/typed/authentication/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/klog/v2"
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util/templates"
-
-	userv1 "github.com/openshift/api/user/v1"
-	userv1typedclient "github.com/openshift/client-go/user/clientset/versioned/typed/user/v1"
 )
 
 const (
@@ -52,12 +55,16 @@ type WhoAmIOptions struct {
 	ShowServer     bool
 	ShowConsoleUrl bool
 
+	PrintFlags          *genericclioptions.PrintFlags
+	resourcePrinterFunc printers.ResourcePrinterFunc
+
 	genericiooptions.IOStreams
 }
 
 func NewWhoAmIOptions(streams genericiooptions.IOStreams) *WhoAmIOptions {
 	return &WhoAmIOptions{
-		IOStreams: streams,
+		PrintFlags: genericclioptions.NewPrintFlags("").WithTypeSetter(scheme.Scheme),
+		IOStreams:  streams,
 	}
 }
 
@@ -80,6 +87,7 @@ func NewCmdWhoAmI(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra
 	cmd.Flags().BoolVarP(&o.ShowContext, "show-context", "c", o.ShowContext, "Print the current user context name")
 	cmd.Flags().BoolVar(&o.ShowServer, "show-server", o.ShowServer, "If true, print the current server's REST API URL")
 	cmd.Flags().BoolVar(&o.ShowConsoleUrl, "show-console", o.ShowConsoleUrl, "If true, print the current server's web console URL")
+	o.PrintFlags.AddFlags(cmd)
 
 	return cmd
 }
@@ -93,14 +101,19 @@ func (o WhoAmIOptions) WhoAmI() (*userv1.User, error) {
 			},
 			Groups: res.Status.UserInfo.Groups,
 		}
+		if o.resourcePrinterFunc != nil {
+			return me, o.resourcePrinterFunc(me, o.Out)
+		}
 		fmt.Fprintf(o.Out, "%s\n", me.Name)
 		return me, nil
 	} else {
 		klog.V(2).Infof("selfsubjectreview request error %v, falling back to user object", err)
 	}
-
 	me, err := o.UserInterface.Users().Get(context.TODO(), "~", metav1.GetOptions{})
 	if err == nil {
+		if o.resourcePrinterFunc != nil {
+			return me, o.resourcePrinterFunc(me, o.Out)
+		}
 		fmt.Fprintf(o.Out, "%s\n", me.Name)
 	}
 
@@ -122,17 +135,29 @@ func (o *WhoAmIOptions) Complete(f kcmdutil.Factory) error {
 	o.KubeClient = kubeClient
 
 	o.RawConfig, err = f.ToRawKubeConfigLoader().RawConfig()
-	return err
+	if err != nil {
+		return err
+	}
+	if o.PrintFlags.OutputFlagSpecified() {
+		printer, err := o.PrintFlags.ToPrinter()
+		if err != nil {
+			return err
+		}
+		o.resourcePrinterFunc = printer.PrintObj
+	}
+	return nil
 }
 
 func (o *WhoAmIOptions) Validate() error {
+	if o.PrintFlags.OutputFlagSpecified() && (o.ShowToken || o.ShowContext || o.ShowServer || o.ShowConsoleUrl) {
+		return fmt.Errorf("--output cannot be used with --show-token, --show-context, --show-server, or --show-console")
+	}
 	if o.ShowToken && len(o.ClientConfig.BearerToken) == 0 {
 		return fmt.Errorf("no token is currently in use for this session")
 	}
 	if o.ShowContext && len(o.RawConfig.CurrentContext) == 0 {
 		return fmt.Errorf("no context has been set")
 	}
-
 	return nil
 }
 

--- a/pkg/cli/whoami/whoami_test.go
+++ b/pkg/cli/whoami/whoami_test.go
@@ -2,23 +2,27 @@ package whoami
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 
+	userv1 "github.com/openshift/api/user/v1"
+	userv1fake "github.com/openshift/client-go/user/clientset/versioned/fake"
+
 	v1 "k8s.io/api/authentication/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	authfake "k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
-
-	userv1 "github.com/openshift/api/user/v1"
-	userv1fake "github.com/openshift/client-go/user/clientset/versioned/fake"
+	"k8s.io/kubectl/pkg/scheme"
+	"sigs.k8s.io/yaml"
 )
 
 func TestWhoAmIInternalBothReadyChooseSSR(t *testing.T) {
@@ -267,5 +271,214 @@ func TestWhoAmIInternalDisabledNotFound(t *testing.T) {
 	_, err := opts.WhoAmI()
 	if !apierrors.IsNotFound(err) {
 		t.Errorf("expected unauthorized error but not got different %v", err)
+	}
+}
+
+func TestWhoAmIOutputJSON(t *testing.T) {
+	var b bytes.Buffer
+
+	fakeAuthClientSet := &authfake.Clientset{}
+	fakeUserClientSet := &userv1fake.Clientset{}
+
+	fakeAuthClientSet.AddReactor("create", "selfsubjectreviews",
+		func(action core.Action) (handled bool, ret runtime.Object, err error) {
+			ui := v1.UserInfo{
+				Username: "jane.doe",
+				UID:      "uniq-id",
+				Groups:   []string{"developers", "admins"},
+			}
+
+			res := &v1.SelfSubjectReview{
+				Status: v1.SelfSubjectReviewStatus{
+					UserInfo: ui,
+				},
+			}
+			return true, res, nil
+		})
+
+	printFlags := genericclioptions.NewPrintFlags("").WithTypeSetter(scheme.Scheme).WithDefaultOutput("json")
+	if err := userv1.Install(scheme.Scheme); err != nil {
+		t.Fatalf("failed to register user types: %v", err)
+	}
+	printer, err := printFlags.ToPrinter()
+	if err != nil {
+		t.Fatalf("failed to create printer: %v", err)
+	}
+
+	opts := &WhoAmIOptions{
+		UserInterface:       fakeUserClientSet.UserV1(),
+		AuthV1Client:        fakeAuthClientSet.AuthenticationV1(),
+		resourcePrinterFunc: printer.PrintObj,
+		IOStreams: genericiooptions.IOStreams{
+			Out:    &b,
+			ErrOut: io.Discard,
+		},
+	}
+
+	_, err = opts.WhoAmI()
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	if b.Len() == 0 {
+		t.Fatalf("expected JSON output, but received empty response")
+	}
+	var actualUser userv1.User
+	if err := json.Unmarshal(b.Bytes(), &actualUser); err != nil {
+		t.Fatalf("failed to unmarshal JSON output: %v\nOutput: %s", err, b.String())
+	}
+
+	expectedUser := userv1.User{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "user.openshift.io/v1",
+			Kind:       "User",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "jane.doe",
+		},
+		Groups: []string{"developers", "admins"},
+	}
+
+	if diff := cmp.Diff(expectedUser, actualUser); diff != "" {
+		t.Errorf("User mismatch (-expected +actual):\n%s", diff)
+	}
+}
+
+func TestWhoAmIOutputYAML(t *testing.T) {
+	var b bytes.Buffer
+
+	fakeAuthClientSet := &authfake.Clientset{}
+	fakeUserClientSet := &userv1fake.Clientset{}
+
+	fakeAuthClientSet.AddReactor("create", "selfsubjectreviews",
+		func(action core.Action) (handled bool, ret runtime.Object, err error) {
+			ui := v1.UserInfo{
+				Username: "john.smith",
+				UID:      "unique-id-123",
+				Groups:   []string{"developers", "admins"},
+			}
+
+			res := &v1.SelfSubjectReview{
+				Status: v1.SelfSubjectReviewStatus{
+					UserInfo: ui,
+				},
+			}
+			return true, res, nil
+		})
+
+	printFlags := genericclioptions.NewPrintFlags("").WithTypeSetter(scheme.Scheme).WithDefaultOutput("yaml")
+	if err := userv1.Install(scheme.Scheme); err != nil {
+		t.Fatalf("failed to register user types: %v", err)
+	}
+	printer, err := printFlags.ToPrinter()
+	if err != nil {
+		t.Fatalf("failed to create printer: %v", err)
+	}
+
+	opts := &WhoAmIOptions{
+		UserInterface:       fakeUserClientSet.UserV1(),
+		AuthV1Client:        fakeAuthClientSet.AuthenticationV1(),
+		resourcePrinterFunc: printer.PrintObj,
+		IOStreams: genericiooptions.IOStreams{
+			Out:    &b,
+			ErrOut: io.Discard,
+		},
+	}
+
+	_, err = opts.WhoAmI()
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	if b.Len() == 0 {
+		t.Fatalf("expected YAML output, but received empty response")
+	}
+	var actualUser userv1.User
+	if err := yaml.Unmarshal(b.Bytes(), &actualUser); err != nil {
+		t.Fatalf("failed to unmarshal YAML output: %v\nOutput: %s", err, b.String())
+	}
+
+	expectedUser := userv1.User{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "user.openshift.io/v1",
+			Kind:       "User",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "john.smith",
+		},
+		Groups: []string{"developers", "admins"},
+	}
+
+	if diff := cmp.Diff(expectedUser, actualUser); diff != "" {
+		t.Errorf("User mismatch (-expected +actual):\n%s", diff)
+	}
+}
+
+func TestWhoAmIOutputJSONFallbackToUserAPI(t *testing.T) {
+	var b bytes.Buffer
+
+	fakeAuthClientSet := &authfake.Clientset{}
+	fakeUserClientSet := &userv1fake.Clientset{}
+
+	fakeUserClientSet.AddReactor("get", "users",
+		func(action core.Action) (handled bool, ret runtime.Object, err error) {
+			return true, &userv1.User{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "legacy.user",
+				},
+				Groups: []string{"legacy-group"},
+			}, nil
+		})
+
+	fakeAuthClientSet.AddReactor("create", "selfsubjectreviews",
+		func(action core.Action) (handled bool, ret runtime.Object, err error) {
+			return true, nil, fmt.Errorf("unknown API")
+		})
+
+	printFlags := genericclioptions.NewPrintFlags("").WithTypeSetter(scheme.Scheme).WithDefaultOutput("json")
+	if err := userv1.Install(scheme.Scheme); err != nil {
+		t.Fatalf("failed to register user types: %v", err)
+	}
+	printer, err := printFlags.ToPrinter()
+	if err != nil {
+		t.Fatalf("failed to create printer: %v", err)
+	}
+
+	opts := &WhoAmIOptions{
+		UserInterface:       fakeUserClientSet.UserV1(),
+		AuthV1Client:        fakeAuthClientSet.AuthenticationV1(),
+		resourcePrinterFunc: printer.PrintObj,
+		IOStreams: genericiooptions.IOStreams{
+			Out:    &b,
+			ErrOut: io.Discard,
+		},
+	}
+
+	_, err = opts.WhoAmI()
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	if b.Len() == 0 {
+		t.Fatalf("expected JSON output, but received empty response")
+	}
+	var actualUser userv1.User
+	if err := json.Unmarshal(b.Bytes(), &actualUser); err != nil {
+		t.Fatalf("failed to unmarshal JSON output: %v\nOutput: %s", err, b.String())
+	}
+
+	expectedUser := userv1.User{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "user.openshift.io/v1",
+			Kind:       "User",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "legacy.user",
+		},
+		Groups: []string{"legacy-group"},
+	}
+
+	if diff := cmp.Diff(expectedUser, actualUser); diff != "" {
+		t.Errorf("User mismatch (-expected +actual):\n%s", diff)
 	}
 }

--- a/test/e2e/cli.go
+++ b/test/e2e/cli.go
@@ -13,8 +13,12 @@ import (
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
+
 	oteginkgo "github.com/openshift-eng/openshift-tests-extension/pkg/ginkgo"
+	userv1 "github.com/openshift/api/user/v1"
+
 	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/yaml"
 )
 
 var _ = g.Describe("[sig-cli] Workloads test oc works well", func() {
@@ -740,6 +744,57 @@ var _ = g.Describe("[sig-cli] Workloads client test", func() {
 			return false, nil
 		})
 		AssertWaitPollNoErr(errPod, fmt.Sprintf("Pod not running :: %v", poderr))
+	})
+
+	// author: yshanmug@redhat.com
+	g.It("MicroShiftBoth-ROSA-OSD_CCS-ARO-Author:yshanmug-Medium-oc whoami should support JSON output format", oteginkgo.Informing(), func() {
+		By("Run oc whoami with JSON output format")
+		output, err := oc.AsAdmin().Run("whoami").Args("-o", "json").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		By("Verify JSON output structure and data")
+		actualUser := &userv1.User{}
+		err = json.Unmarshal([]byte(output), actualUser)
+		o.Expect(err).NotTo(o.HaveOccurred(), "Output should be valid JSON matching the User schema")
+		o.Expect(actualUser.Kind).To(o.Equal("User"))
+		o.Expect(actualUser.APIVersion).To(o.Equal("user.openshift.io/v1"))
+		o.Expect(actualUser.Name).NotTo(o.BeEmpty(), "User name should be populated in metadata")
+		o.Expect(actualUser.Groups).NotTo(o.BeEmpty(), "Groups field should exist in the output and not be empty")
+	})
+
+	// author: yshanmug@redhat.com
+	g.It("MicroShiftBoth-ROSA-OSD_CCS-ARO-Author:yshanmug-Medium-oc whoami should support YAML output format", oteginkgo.Informing(), func() {
+		By("Run oc whoami with YAML output format")
+		output, err := oc.AsAdmin().Run("whoami").Args("-o", "yaml").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		By("Verify YAML output structure and data")
+		actualUser := &userv1.User{}
+		err = yaml.Unmarshal([]byte(output), actualUser)
+		o.Expect(err).NotTo(o.HaveOccurred(), "Output should be valid YAML matching the User schema")
+		o.Expect(actualUser.Kind).To(o.Equal("User"))
+		o.Expect(actualUser.APIVersion).To(o.Equal("user.openshift.io/v1"))
+		o.Expect(actualUser.Name).NotTo(o.BeEmpty(), "User name should be populated")
+		o.Expect(actualUser.Groups).NotTo(o.BeEmpty(), "Groups field should exist in the output and not be empty")
+	})
+
+	// author: yshanmug@redhat.com
+	g.It("MicroShiftBoth-ROSA-OSD_CCS-ARO-Author:yshanmug-oc whoami output format should be mutually exclusive with show flags", oteginkgo.Informing(), func() {
+		expectedErr := "--output cannot be used with --show-token, --show-context, --show-server, or --show-console"
+		cases := []struct {
+			output string
+			flag   string
+		}{
+			{"json", "--show-token"},
+			{"yaml", "--show-context"},
+			{"json", "--show-server"},
+			{"yaml", "--show-console"},
+		}
+		for _, c := range cases {
+			By(fmt.Sprintf("Verify -o %s cannot be used with %s", c.output, c.flag))
+			out, err := oc.AsAdmin().Run("whoami").Args("-o", c.output, c.flag).Output()
+			o.Expect(err).To(o.HaveOccurred())
+			o.Expect(out).To(o.ContainSubstring(expectedErr))
+		}
 	})
 
 	// author: yinzhou@redhat.com


### PR DESCRIPTION
Add structured Output to oc whoami

This PR enhances oc whoami to support user group visibility and standard Kubernetes output formatting. These changes improve the command's utility for debugging permissions and integrating with automation scripts.

Key Changes
-  Structured Output Integration (-o json|yaml)
 Added genericclioptions.PrintFlags to enable standard Kubernetes output formatting.
 Enabled support for -o go-template and -o jsonpath, allowing users to parse group data/metadata programmatically.

- Validation and Flag Organization
Mutual Exclusion: Updated Validate() to prevent the use of --output alongside specific display flags (like --show-token or --show-token) to maintain output clarity.

**Tests** (Tests are run with both selfsubjectreview request and  user object)
sh-5.2$ ./oc whoami
yamuna

sh-5.2$ ./oc whoami -o yaml
apiVersion: user.openshift.io/v1
groups:
- system:authenticated:oauth
- system:authenticated
kind: User
metadata:
  name: yamuna

sh-5.2$ ./oc whoami -o json
{
    "kind": "User",
    "apiVersion": "user.openshift.io/v1",
    "metadata": {
        "name": "yamuna"
    },
    "groups": [
        "system:authenticated:oauth",
        "system:authenticated"
    ]
}

/oc whoami -o go-template --template='Logged in as {{.metadata.name}} (Member of {{len .groups}} groups){{"\n"}}'e}} (Member of {{len .groups}} groups){{"\n"}}'
Logged in as yamuna (Member of 2 groups)

[Test_results.txt](https://github.com/user-attachments/files/26793691/Test_results.txt)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured output for whoami (JSON/YAML) for integration with tooling.

* **Bug Fixes / Validation**
  * Enforced mutual exclusivity for --show-* options.
  * Prevented combining structured output with --show-* flags; command now errors when both are used.

* **Tests**
  * Added unit and end-to-end tests validating JSON/YAML output and the new validation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->