### PR TITLE
NO-JIRA: claude: Change learn-* agents into skills

### DIFF
--- a/.claude/skills/learn-history/SKILL.md
+++ b/.claude/skills/learn-history/SKILL.md
@@ -1,12 +1,9 @@
 ---
 name: learn-history
-description: "Analyze all past sessions for this project and extract knowledge worth persisting to AGENTS.md or .claude/agents/. One-shot deep analysis of full session history."
-tools: Read, Grep, Glob, Bash
-model: opus
-maxTurns: 30
+description: "Analyze all past sessions for this project and extract knowledge worth persisting to AGENTS.md, .claude/agents/, or memory. Deep analysis of full session history."
 ---
 
-You are analyzing the full session history for this project to extract knowledge worth persisting.
+Analyze the full session history for this project to extract knowledge worth persisting.
 
 ## Session logs location
 

--- a/.claude/skills/learn-session/SKILL.md
+++ b/.claude/skills/learn-session/SKILL.md
@@ -1,12 +1,9 @@
 ---
 name: learn-session
-description: "Review the current session and extract knowledge worth persisting to AGENTS.md or .claude/agents/. Use at the end of a session to capture what was learned."
-tools: Read, Grep, Glob, Bash
-model: opus
-maxTurns: 15
+description: "Review the current session and extract knowledge worth persisting to AGENTS.md, .claude/agents/, or memory. Use at the end of a session to capture what was learned."
 ---
 
-You are reviewing a session transcript to extract knowledge worth persisting for future sessions.
+Review the current conversation to extract knowledge worth persisting for future sessions.
 
 ## What to look for
 
@@ -25,7 +22,7 @@ You are reviewing a session transcript to extract knowledge worth persisting for
 
 1. Read the current state of AGENTS.md and .claude/agents/*.md
 2. Read the memory index for this project at `~/.claude/projects/$(echo "$PWD" | tr '/' '-')/memory/MEMORY.md` (skip if absent)
-3. Summarize the session: what was the task, what was learned, what corrections were made
+3. Review the conversation so far: what was the task, what was learned, what corrections were made
 4. For each finding, determine where it belongs:
    - **AGENTS.md** — brief convention or rule that applies to all sessions (1-2 lines max)
    - **.claude/agents/*.md** — specific to the tester or code-reviewer agent

--- a/README.md
+++ b/README.md
@@ -109,8 +109,13 @@ Available agents in `.claude/agents/`:
 |-------|---------|
 | `code-reviewer` | PR code review — builds, verifies, reviews for Go style, breaking changes, and oc-specific concerns |
 | `tester` | Build, lint, and test runner — validates changes compile and pass tests |
+
+Available skills in `.claude/skills/`:
+
+| Skill | Purpose |
+|-------|---------|
 | `learn-session` | End-of-session knowledge extraction — reviews the conversation and proposes updates to docs |
-| `learn-history` | One-shot analysis of all past sessions to extract recurring patterns worth documenting |
+| `learn-history` | Deep analysis of all past sessions to extract recurring patterns worth documenting |
 
 # License
 


### PR DESCRIPTION
I was being retarded, `learn-session` needs to work with the current context, so it cannot really be an agent. Migrating `learn-history` for consistency also.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skills now support persisting extracted knowledge to memory in addition to existing configuration destinations.

* **Improvements**
  * Streamlined skill configuration by removing unused operational parameters for cleaner setup.
  * Updated documentation with dedicated section describing available skills and their purposes.
  * Refined skill instructions for improved clarity and user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->