### PR TITLE
OCPBUGS-78768: Skip filter validation for RFC2307 group query when groupUIDAttribute is "dn"

### DIFF
--- a/pkg/helpers/groupsync/ldap/ldap.go
+++ b/pkg/helpers/groupsync/ldap/ldap.go
@@ -165,7 +165,8 @@ func ValidateLDAPClientConfig(url, bindDN, bindPassword, CA string, insecure boo
 func ValidateRFC2307Config(config *legacyconfigv1.RFC2307Config) validation.ValidationResults {
 	validationResults := validation.ValidationResults{}
 
-	validationResults.Append(ValidateLDAPQuery(config.AllGroupsQuery, field.NewPath("groupsQuery")))
+	isGroupDNQuery := strings.TrimSpace(strings.ToLower(config.GroupUIDAttribute)) == "dn"
+	validationResults.Append(validateLDAPQuery(config.AllGroupsQuery, field.NewPath("groupsQuery"), isGroupDNQuery))
 	if len(config.GroupUIDAttribute) == 0 {
 		validationResults.AddErrors(field.Required(field.NewPath("groupUIDAttribute"), ""))
 	}
@@ -255,10 +256,7 @@ func validateLDAPQuery(query legacyconfigv1.LDAPQuery, fldPath *field.Path, isDN
 			"timeout must be equal to or greater than zero"))
 	}
 
-	if isDNOnly {
-		if len(query.Filter) != 0 {
-			validationResults.AddErrors(field.Invalid(fldPath.Child("filter"), query.Filter, `cannot specify a filter when using "dn" as the UID attribute`))
-		}
+	if isDNOnly && len(query.Filter) == 0 {
 		return validationResults
 	}
 

--- a/pkg/helpers/groupsync/ldap/ldap_test.go
+++ b/pkg/helpers/groupsync/ldap/ldap_test.go
@@ -1,0 +1,66 @@
+package ldap
+
+import (
+	"testing"
+
+	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
+)
+
+func TestValidateRFC2307Config_GroupUIDAttributeDN_NoFilter(t *testing.T) {
+	config := &legacyconfigv1.RFC2307Config{
+		AllGroupsQuery: legacyconfigv1.LDAPQuery{
+			BaseDN:       "ou=groups,dc=example,dc=com",
+			Scope:        "sub",
+			DerefAliases: "never",
+			PageSize:     0,
+		},
+		GroupUIDAttribute:         "dn",
+		GroupNameAttributes:       []string{"cn"},
+		GroupMembershipAttributes: []string{"member"},
+		AllUsersQuery: legacyconfigv1.LDAPQuery{
+			BaseDN:       "ou=users,dc=example,dc=com",
+			Scope:        "sub",
+			DerefAliases: "never",
+			PageSize:     0,
+		},
+		UserUIDAttribute:               "dn",
+		UserNameAttributes:             []string{"mail"},
+		TolerateMemberNotFoundErrors:   false,
+		TolerateMemberOutOfScopeErrors: false,
+	}
+
+	results := ValidateRFC2307Config(config)
+	if len(results.Errors) > 0 {
+		t.Errorf("expected no validation errors when groupUIDAttribute is 'dn' and no filter is set, got: %v", results.Errors)
+	}
+}
+
+func TestValidateRFC2307Config_GroupUIDAttributeDN_WithValidFilter(t *testing.T) {
+	config := &legacyconfigv1.RFC2307Config{
+		AllGroupsQuery: legacyconfigv1.LDAPQuery{
+			BaseDN:       "ou=groups,dc=example,dc=com",
+			Scope:        "sub",
+			DerefAliases: "never",
+			PageSize:     0,
+			Filter:       "(objectclass=groupOfNames)",
+		},
+		GroupUIDAttribute:         "dn",
+		GroupNameAttributes:       []string{"cn"},
+		GroupMembershipAttributes: []string{"member"},
+		AllUsersQuery: legacyconfigv1.LDAPQuery{
+			BaseDN:       "ou=users,dc=example,dc=com",
+			Scope:        "sub",
+			DerefAliases: "never",
+			PageSize:     0,
+		},
+		UserUIDAttribute:               "dn",
+		UserNameAttributes:             []string{"mail"},
+		TolerateMemberNotFoundErrors:   false,
+		TolerateMemberOutOfScopeErrors: false,
+	}
+
+	results := ValidateRFC2307Config(config)
+	if len(results.Errors) > 0 {
+		t.Errorf("expected no validation errors when groupUIDAttribute is 'dn' and a valid filter is set, got: %v", results.Errors)
+	}
+}


### PR DESCRIPTION
When `groupUIDAttribute` is set to `"dn"`, the group query uses the base DN directly rather than performing a search, so requiring a filter is unnecessary. Pass the `isDNOnly` flag to `validateLDAPQuery` to allow filterless group queries in this case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * LDAP group sync validation no longer incorrectly rejects group queries that include a filter when the group UID attribute resolves to "dn"; validation accepts both DN-only and filtered group queries as appropriate.

* **Tests**
  * Added unit tests covering validation for DN-based group UID attributes, with and without group query filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->