### PR TITLE
OTA-1817: Adding unit tests for the extend recommended alerts

### DIFF
--- a/pkg/cli/admin/upgrade/recommend/examples/4.22.0-extend-recommended-alert-alerts.json
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.22.0-extend-recommended-alert-alerts.json
@@ -1,0 +1,124 @@
+{
+  "status": "success",
+  "data": {
+    "alerts": [
+      {
+        "labels": {
+          "alertname": "ClusterNotUpgradeable",
+          "condition": "Upgradeable",
+          "endpoint": "metrics",
+          "name": "version",
+          "namespace": "openshift-cluster-version",
+          "severity": "info"
+        },
+        "annotations": {
+          "description": "In most cases, you will still be able to apply patch releases. Reason ClusterVersionOverridesSet. For more information refer to 'oc adm upgrade' or https://console-openshift-console.apps.ci-ln-j6jzqdt-76ef8.aws-4.ci.openshift.org/settings/cluster/.",
+          "summary": "One or more cluster operators have been blocking minor or major version cluster updates for at least an hour."
+        },
+        "state": "firing",
+        "activeAt": "2026-03-11T06:13:27.764925273Z",
+        "value": "0e+00",
+        "partialResponseStrategy": "WARN"
+      },
+      {
+        "labels": {
+          "alertname": "TestAlert",
+          "container": "cluster-version-operator",
+          "endpoint": "metrics",
+          "instance": "10.0.50.249:9099",
+          "job": "cluster-version-operator",
+          "namespace": "openshift-cluster-version",
+          "openShiftUpdatePrecheck": "true",
+          "pod": "cluster-version-operator-678868c58f-llmd9",
+          "reason": "UpdatingPrometheusFailed",
+          "service": "cluster-version-operator",
+          "severity": "warning"
+        },
+        "annotations": {
+          "description": "Test description.",
+          "summary": "Test summary."
+        },
+        "state": "firing",
+        "activeAt": "2026-03-11T07:10:31.401713949Z",
+        "value": "1e+00",
+        "partialResponseStrategy": "WARN"
+      },
+      {
+        "labels": {
+          "alertname": "VMCannotBeEvicted",
+          "container": "cluster-version-operator",
+          "endpoint": "metrics",
+          "instance": "10.0.50.249:9099",
+          "job": "cluster-version-operator",
+          "namespace": "openshift-cluster-version",
+          "openShiftUpdatePrecheck": "false",
+          "pod": "cluster-version-operator-678868c58f-llmd9",
+          "reason": "UpdatingPrometheusFailed",
+          "service": "cluster-version-operator",
+          "severity": "warning"
+        },
+        "annotations": {
+          "description": "Test description.",
+          "summary": "Test summary."
+        },
+        "state": "firing",
+        "activeAt": "2026-03-11T07:10:27.514385838Z",
+        "value": "1e+00",
+        "partialResponseStrategy": "WARN"
+      },
+      {
+        "labels": {
+          "alertname": "VirtHandlerDaemonSetRolloutFailing",
+          "container": "cluster-version-operator",
+          "endpoint": "metrics",
+          "instance": "10.0.50.249:9099",
+          "job": "cluster-version-operator",
+          "namespace": "openshift-cluster-version",
+          "openShiftUpdatePrecheck": "true",
+          "pod": "cluster-version-operator-678868c58f-llmd9",
+          "reason": "UpdatingPrometheusFailed",
+          "service": "cluster-version-operator",
+          "severity": "warning"
+        },
+        "annotations": {
+          "description": "Test description.",
+          "summary": "Test summary."
+        },
+        "state": "firing",
+        "activeAt": "2026-03-11T07:10:38.799267484Z",
+        "value": "1e+00",
+        "partialResponseStrategy": "WARN"
+      },
+      {
+        "labels": {
+          "alertname": "Watchdog",
+          "namespace": "openshift-monitoring",
+          "severity": "none"
+        },
+        "annotations": {
+          "description": "This is an alert meant to ensure that the entire alerting pipeline is functional.\nThis alert is always firing, therefore it should always be firing in Alertmanager\nand always fire against a receiver. There are integrations with various notification\nmechanisms that send a notification when this alert is not firing. For example the\n\"DeadMansSnitch\" integration in PagerDuty.\n",
+          "summary": "An alert that should always be firing to certify that Alertmanager is working properly."
+        },
+        "state": "firing",
+        "activeAt": "2026-03-11T06:14:54.219018244Z",
+        "value": "1e+00",
+        "partialResponseStrategy": "WARN"
+      },
+      {
+        "labels": {
+          "alertname": "AlertmanagerReceiversNotConfigured",
+          "namespace": "openshift-monitoring",
+          "severity": "warning"
+        },
+        "annotations": {
+          "description": "Alerts are not configured to be sent to a notification system, meaning that you may not be notified in a timely fashion when important failures occur. Check the OpenShift documentation to learn how to configure notifications with Alertmanager.",
+          "summary": "Receivers (notification integrations) are not configured on Alertmanager"
+        },
+        "state": "firing",
+        "activeAt": "2026-03-11T06:14:06.604561468Z",
+        "value": "0e+00",
+        "partialResponseStrategy": "WARN"
+      }
+    ]
+  }
+}

--- a/pkg/cli/admin/upgrade/recommend/examples/4.22.0-extend-recommended-alert-cv.yaml
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.22.0-extend-recommended-alert-cv.yaml
@@ -1,0 +1,101 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+metadata:
+  creationTimestamp: "2026-03-11T05:56:14Z"
+  generation: 2
+  name: version
+  resourceVersion: "32154"
+  uid: f31d2fb4-c70b-44fb-b18c-a78ccbe98427
+spec:
+  clusterID: 5e65da93-4167-4f1e-9571-f99963cda23e
+  overrides:
+  - group: config.openshift.io
+    kind: ClusterImagePolicy
+    name: openshift
+    namespace: ""
+    unmanaged: true
+status:
+  availableUpdates: null
+  capabilities:
+    enabledCapabilities:
+    - Build
+    - CSISnapshot
+    - CloudControllerManager
+    - CloudCredential
+    - Console
+    - DeploymentConfig
+    - ImageRegistry
+    - Ingress
+    - Insights
+    - MachineAPI
+    - NodeTuning
+    - OperatorLifecycleManager
+    - OperatorLifecycleManagerV1
+    - Storage
+    - baremetal
+    - marketplace
+    - openshift-samples
+    knownCapabilities:
+    - Build
+    - CSISnapshot
+    - CloudControllerManager
+    - CloudCredential
+    - Console
+    - DeploymentConfig
+    - ImageRegistry
+    - Ingress
+    - Insights
+    - MachineAPI
+    - NodeTuning
+    - OperatorLifecycleManager
+    - OperatorLifecycleManagerV1
+    - Storage
+    - baremetal
+    - marketplace
+    - openshift-samples
+  conditions:
+  - lastTransitionTime: "2026-03-11T05:57:05Z"
+    message: The update channel has not been configured.
+    reason: NoChannel
+    status: "False"
+    type: RetrievedUpdates
+  - lastTransitionTime: "2026-03-11T05:57:05Z"
+    message: Disabling ownership via cluster version overrides prevents upgrades.
+      Please remove overrides before continuing.
+    reason: ClusterVersionOverridesSet
+    status: "False"
+    type: Upgradeable
+  - lastTransitionTime: "2026-03-11T05:57:05Z"
+    message: Capabilities match configured spec
+    reason: AsExpected
+    status: "False"
+    type: ImplicitlyEnabledCapabilities
+  - lastTransitionTime: "2026-03-11T05:57:05Z"
+    message: Payload loaded version="4.22.0-0.nightly-2026-03-10-194001" image="registry.build09.ci.openshift.org/ci-ln-j6jzqdt/release@sha256:438c895e0391ec0187d7d0df1961b70a65068d1a8c93256817fdd0d4ee06172d"
+      architecture="amd64"
+    reason: PayloadLoaded
+    status: "True"
+    type: ReleaseAccepted
+  - lastTransitionTime: "2026-03-11T06:26:37Z"
+    message: Done applying 4.22.0-0.nightly-2026-03-10-194001
+    status: "True"
+    type: Available
+  - lastTransitionTime: "2026-03-11T06:26:37Z"
+    status: "False"
+    type: Failing
+  - lastTransitionTime: "2026-03-11T06:26:37Z"
+    message: Cluster version is 4.22.0-0.nightly-2026-03-10-194001
+    status: "False"
+    type: Progressing
+  desired:
+    image: registry.build09.ci.openshift.org/ci-ln-j6jzqdt/release@sha256:438c895e0391ec0187d7d0df1961b70a65068d1a8c93256817fdd0d4ee06172d
+    version: 4.22.0-0.nightly-2026-03-10-194001
+  history:
+  - completionTime: "2026-03-11T06:26:37Z"
+    image: registry.build09.ci.openshift.org/ci-ln-j6jzqdt/release@sha256:438c895e0391ec0187d7d0df1961b70a65068d1a8c93256817fdd0d4ee06172d
+    startedTime: "2026-03-11T05:57:05Z"
+    state: Completed
+    verified: false
+    version: 4.22.0-0.nightly-2026-03-10-194001
+  observedGeneration: 2
+  versionHash: hiSqsVihDbY=

--- a/pkg/cli/admin/upgrade/recommend/examples/4.22.0-extend-recommended-alert.output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.22.0-extend-recommended-alert.output
@@ -1,0 +1,20 @@
+The following conditions found no cause for concern in updating this cluster to later releases: recommended/CriticalAlerts (AsExpected), recommended/NodeAlerts (AsExpected), recommended/PodDisruptionBudgetAlerts (AsExpected), recommended/PodImagePullAlerts (AsExpected)
+
+The following conditions found cause for concern in updating this cluster to later releases: recommended/UpdatePrecheckAlerts/TestAlert/0, recommended/UpdatePrecheckAlerts/VirtHandlerDaemonSetRolloutFailing/2, recommended/VirtAlerts/VMCannotBeEvicted/1
+
+recommended/UpdatePrecheckAlerts/TestAlert/0=False:
+
+  Reason: Alert:firing
+  Message: warning alert TestAlert firing, suggesting issues worth investigating before updating the cluster. Test summary. The alert description is: Test description. <alert does not have a runbook_url annotation>
+
+recommended/VirtAlerts/VMCannotBeEvicted/1=False:
+
+  Reason: Alert:firing
+  Message: warning alert VMCannotBeEvicted firing, which may slow workload redistribution during rolling node updates. Test summary. The alert description is: Test description. <alert does not have a runbook_url annotation>
+
+recommended/UpdatePrecheckAlerts/VirtHandlerDaemonSetRolloutFailing/2=False:
+
+  Reason: Alert:firing
+  Message: warning alert VirtHandlerDaemonSetRolloutFailing firing, suggesting issues worth investigating before updating the cluster. Test summary. The alert description is: Test description. <alert does not have a runbook_url annotation>
+
+No updates available. You may still upgrade to a specific release image with --to-image or wait for new updates to be available.

--- a/pkg/cli/admin/upgrade/recommend/examples/4.22.0-extend-recommended-alert.show-outdated-releases-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.22.0-extend-recommended-alert.show-outdated-releases-output
@@ -1,0 +1,20 @@
+The following conditions found no cause for concern in updating this cluster to later releases: recommended/CriticalAlerts (AsExpected), recommended/NodeAlerts (AsExpected), recommended/PodDisruptionBudgetAlerts (AsExpected), recommended/PodImagePullAlerts (AsExpected)
+
+The following conditions found cause for concern in updating this cluster to later releases: recommended/UpdatePrecheckAlerts/TestAlert/0, recommended/UpdatePrecheckAlerts/VirtHandlerDaemonSetRolloutFailing/2, recommended/VirtAlerts/VMCannotBeEvicted/1
+
+recommended/UpdatePrecheckAlerts/TestAlert/0=False:
+
+  Reason: Alert:firing
+  Message: warning alert TestAlert firing, suggesting issues worth investigating before updating the cluster. Test summary. The alert description is: Test description. <alert does not have a runbook_url annotation>
+
+recommended/VirtAlerts/VMCannotBeEvicted/1=False:
+
+  Reason: Alert:firing
+  Message: warning alert VMCannotBeEvicted firing, which may slow workload redistribution during rolling node updates. Test summary. The alert description is: Test description. <alert does not have a runbook_url annotation>
+
+recommended/UpdatePrecheckAlerts/VirtHandlerDaemonSetRolloutFailing/2=False:
+
+  Reason: Alert:firing
+  Message: warning alert VirtHandlerDaemonSetRolloutFailing firing, suggesting issues worth investigating before updating the cluster. Test summary. The alert description is: Test description. <alert does not have a runbook_url annotation>
+
+No updates available. You may still upgrade to a specific release image with --to-image or wait for new updates to be available.

--- a/pkg/cli/admin/upgrade/recommend/examples/4.22.0-extend-recommended-alert.version-1.2.3-not-important-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.22.0-extend-recommended-alert.version-1.2.3-not-important-output
@@ -1,0 +1,21 @@
+The following conditions found no cause for concern in updating this cluster to later releases: recommended/CriticalAlerts (AsExpected), recommended/NodeAlerts (AsExpected), recommended/PodDisruptionBudgetAlerts (AsExpected), recommended/PodImagePullAlerts (AsExpected)
+
+The following conditions found cause for concern in updating this cluster to later releases: recommended/UpdatePrecheckAlerts/TestAlert/0, recommended/UpdatePrecheckAlerts/VirtHandlerDaemonSetRolloutFailing/2, recommended/VirtAlerts/VMCannotBeEvicted/1
+
+recommended/UpdatePrecheckAlerts/TestAlert/0=False:
+
+  Reason: Alert:firing
+  Message: warning alert TestAlert firing, suggesting issues worth investigating before updating the cluster. Test summary. The alert description is: Test description. <alert does not have a runbook_url annotation>
+
+recommended/VirtAlerts/VMCannotBeEvicted/1=False:
+
+  Reason: Alert:firing
+  Message: warning alert VMCannotBeEvicted firing, which may slow workload redistribution during rolling node updates. Test summary. The alert description is: Test description. <alert does not have a runbook_url annotation>
+
+recommended/UpdatePrecheckAlerts/VirtHandlerDaemonSetRolloutFailing/2=False:
+
+  Reason: Alert:firing
+  Message: warning alert VirtHandlerDaemonSetRolloutFailing firing, suggesting issues worth investigating before updating the cluster. Test summary. The alert description is: Test description. <alert does not have a runbook_url annotation>
+
+
+error: no updates available, so cannot display context for the requested release 1.2.3-not-important

--- a/pkg/cli/admin/upgrade/recommend/examples/4.22.0-extend-recommended-critical-alert-alerts.json
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.22.0-extend-recommended-critical-alert-alerts.json
@@ -1,0 +1,101 @@
+{
+  "status": "success",
+  "data": {
+    "alerts": [
+      {
+        "labels": {
+          "alertname": "ClusterNotUpgradeable",
+          "condition": "Upgradeable",
+          "endpoint": "metrics",
+          "name": "version",
+          "namespace": "openshift-cluster-version",
+          "severity": "info"
+        },
+        "annotations": {
+          "description": "In most cases, you will still be able to apply patch releases. Reason ClusterVersionOverridesSet. For more information refer to 'oc adm upgrade' or https://console-openshift-console.apps.ci-ln-j6jzqdt-76ef8.aws-4.ci.openshift.org/settings/cluster/.",
+          "summary": "One or more cluster operators have been blocking minor or major version cluster updates for at least an hour."
+        },
+        "state": "firing",
+        "activeAt": "2026-03-11T06:13:57.769131832Z",
+        "value": "0e+00",
+        "partialResponseStrategy": "WARN"
+      },
+      {
+        "labels": {
+          "alertname": "VMCannotBeEvicted",
+          "container": "cluster-version-operator",
+          "endpoint": "metrics",
+          "instance": "10.0.50.249:9099",
+          "job": "cluster-version-operator",
+          "namespace": "openshift-cluster-version",
+          "openShiftUpdatePrecheck": "true",
+          "pod": "cluster-version-operator-678868c58f-llmd9",
+          "reason": "UpdatingPrometheusFailed",
+          "service": "cluster-version-operator",
+          "severity": "critical"
+        },
+        "annotations": {
+          "description": "Test description.",
+          "summary": "Test summary."
+        },
+        "state": "pending",
+        "activeAt": "2026-03-11T07:26:40.359329532Z",
+        "value": "1e+00",
+        "partialResponseStrategy": "WARN"
+      },
+      {
+        "labels": {
+          "alertname": "VirtHandlerDaemonSetRolloutFailing",
+          "container": "cluster-version-operator",
+          "endpoint": "metrics",
+          "instance": "10.0.50.249:9099",
+          "job": "cluster-version-operator",
+          "namespace": "openshift-cluster-version",
+          "openShiftUpdatePrecheck": "true",
+          "pod": "cluster-version-operator-678868c58f-llmd9",
+          "reason": "UpdatingPrometheusFailed",
+          "service": "cluster-version-operator",
+          "severity": "critical"
+        },
+        "annotations": {
+          "description": "Test description.",
+          "summary": "Test summary."
+        },
+        "state": "firing",
+        "activeAt": "2026-03-11T07:26:13.424841002Z",
+        "value": "1e+00",
+        "partialResponseStrategy": "WARN"
+      },
+      {
+        "labels": {
+          "alertname": "Watchdog",
+          "namespace": "openshift-monitoring",
+          "severity": "none"
+        },
+        "annotations": {
+          "description": "This is an alert meant to ensure that the entire alerting pipeline is functional.\nThis alert is always firing, therefore it should always be firing in Alertmanager\nand always fire against a receiver. There are integrations with various notification\nmechanisms that send a notification when this alert is not firing. For example the\n\"DeadMansSnitch\" integration in PagerDuty.\n",
+          "summary": "An alert that should always be firing to certify that Alertmanager is working properly."
+        },
+        "state": "firing",
+        "activeAt": "2026-03-11T06:14:54.219018244Z",
+        "value": "1e+00",
+        "partialResponseStrategy": "WARN"
+      },
+      {
+        "labels": {
+          "alertname": "AlertmanagerReceiversNotConfigured",
+          "namespace": "openshift-monitoring",
+          "severity": "warning"
+        },
+        "annotations": {
+          "description": "Alerts are not configured to be sent to a notification system, meaning that you may not be notified in a timely fashion when important failures occur. Check the OpenShift documentation to learn how to configure notifications with Alertmanager.",
+          "summary": "Receivers (notification integrations) are not configured on Alertmanager"
+        },
+        "state": "firing",
+        "activeAt": "2026-03-11T06:14:06.604561468Z",
+        "value": "0e+00",
+        "partialResponseStrategy": "WARN"
+      }
+    ]
+  }
+}

--- a/pkg/cli/admin/upgrade/recommend/examples/4.22.0-extend-recommended-critical-alert-cv.yaml
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.22.0-extend-recommended-critical-alert-cv.yaml
@@ -1,0 +1,101 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+metadata:
+  creationTimestamp: "2026-03-11T05:56:14Z"
+  generation: 2
+  name: version
+  resourceVersion: "32154"
+  uid: f31d2fb4-c70b-44fb-b18c-a78ccbe98427
+spec:
+  clusterID: 5e65da93-4167-4f1e-9571-f99963cda23e
+  overrides:
+  - group: config.openshift.io
+    kind: ClusterImagePolicy
+    name: openshift
+    namespace: ""
+    unmanaged: true
+status:
+  availableUpdates: null
+  capabilities:
+    enabledCapabilities:
+    - Build
+    - CSISnapshot
+    - CloudControllerManager
+    - CloudCredential
+    - Console
+    - DeploymentConfig
+    - ImageRegistry
+    - Ingress
+    - Insights
+    - MachineAPI
+    - NodeTuning
+    - OperatorLifecycleManager
+    - OperatorLifecycleManagerV1
+    - Storage
+    - baremetal
+    - marketplace
+    - openshift-samples
+    knownCapabilities:
+    - Build
+    - CSISnapshot
+    - CloudControllerManager
+    - CloudCredential
+    - Console
+    - DeploymentConfig
+    - ImageRegistry
+    - Ingress
+    - Insights
+    - MachineAPI
+    - NodeTuning
+    - OperatorLifecycleManager
+    - OperatorLifecycleManagerV1
+    - Storage
+    - baremetal
+    - marketplace
+    - openshift-samples
+  conditions:
+  - lastTransitionTime: "2026-03-11T05:57:05Z"
+    message: The update channel has not been configured.
+    reason: NoChannel
+    status: "False"
+    type: RetrievedUpdates
+  - lastTransitionTime: "2026-03-11T05:57:05Z"
+    message: Disabling ownership via cluster version overrides prevents upgrades.
+      Please remove overrides before continuing.
+    reason: ClusterVersionOverridesSet
+    status: "False"
+    type: Upgradeable
+  - lastTransitionTime: "2026-03-11T05:57:05Z"
+    message: Capabilities match configured spec
+    reason: AsExpected
+    status: "False"
+    type: ImplicitlyEnabledCapabilities
+  - lastTransitionTime: "2026-03-11T05:57:05Z"
+    message: Payload loaded version="4.22.0-0.nightly-2026-03-10-194001" image="registry.build09.ci.openshift.org/ci-ln-j6jzqdt/release@sha256:438c895e0391ec0187d7d0df1961b70a65068d1a8c93256817fdd0d4ee06172d"
+      architecture="amd64"
+    reason: PayloadLoaded
+    status: "True"
+    type: ReleaseAccepted
+  - lastTransitionTime: "2026-03-11T06:26:37Z"
+    message: Done applying 4.22.0-0.nightly-2026-03-10-194001
+    status: "True"
+    type: Available
+  - lastTransitionTime: "2026-03-11T06:26:37Z"
+    status: "False"
+    type: Failing
+  - lastTransitionTime: "2026-03-11T06:26:37Z"
+    message: Cluster version is 4.22.0-0.nightly-2026-03-10-194001
+    status: "False"
+    type: Progressing
+  desired:
+    image: registry.build09.ci.openshift.org/ci-ln-j6jzqdt/release@sha256:438c895e0391ec0187d7d0df1961b70a65068d1a8c93256817fdd0d4ee06172d
+    version: 4.22.0-0.nightly-2026-03-10-194001
+  history:
+  - completionTime: "2026-03-11T06:26:37Z"
+    image: registry.build09.ci.openshift.org/ci-ln-j6jzqdt/release@sha256:438c895e0391ec0187d7d0df1961b70a65068d1a8c93256817fdd0d4ee06172d
+    startedTime: "2026-03-11T05:57:05Z"
+    state: Completed
+    verified: false
+    version: 4.22.0-0.nightly-2026-03-10-194001
+  observedGeneration: 2
+  versionHash: hiSqsVihDbY=

--- a/pkg/cli/admin/upgrade/recommend/examples/4.22.0-extend-recommended-critical-alert.output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.22.0-extend-recommended-critical-alert.output
@@ -1,0 +1,10 @@
+The following conditions found no cause for concern in updating this cluster to later releases: recommended/NodeAlerts (AsExpected), recommended/PodDisruptionBudgetAlerts (AsExpected), recommended/PodImagePullAlerts (AsExpected), recommended/UpdatePrecheckAlerts (AsExpected)
+
+The following conditions found cause for concern in updating this cluster to later releases: recommended/CriticalAlerts/VirtHandlerDaemonSetRolloutFailing/0
+
+recommended/CriticalAlerts/VirtHandlerDaemonSetRolloutFailing/0=False:
+
+  Reason: Alert:firing
+  Message: critical alert VirtHandlerDaemonSetRolloutFailing firing, suggesting significant cluster issues worth investigating. Test summary. The alert description is: Test description. <alert does not have a runbook_url annotation>
+
+No updates available. You may still upgrade to a specific release image with --to-image or wait for new updates to be available.

--- a/pkg/cli/admin/upgrade/recommend/examples/4.22.0-extend-recommended-critical-alert.show-outdated-releases-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.22.0-extend-recommended-critical-alert.show-outdated-releases-output
@@ -1,0 +1,10 @@
+The following conditions found no cause for concern in updating this cluster to later releases: recommended/NodeAlerts (AsExpected), recommended/PodDisruptionBudgetAlerts (AsExpected), recommended/PodImagePullAlerts (AsExpected), recommended/UpdatePrecheckAlerts (AsExpected)
+
+The following conditions found cause for concern in updating this cluster to later releases: recommended/CriticalAlerts/VirtHandlerDaemonSetRolloutFailing/0
+
+recommended/CriticalAlerts/VirtHandlerDaemonSetRolloutFailing/0=False:
+
+  Reason: Alert:firing
+  Message: critical alert VirtHandlerDaemonSetRolloutFailing firing, suggesting significant cluster issues worth investigating. Test summary. The alert description is: Test description. <alert does not have a runbook_url annotation>
+
+No updates available. You may still upgrade to a specific release image with --to-image or wait for new updates to be available.

--- a/pkg/cli/admin/upgrade/recommend/examples/4.22.0-extend-recommended-critical-alert.version-1.2.3-not-important-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/4.22.0-extend-recommended-critical-alert.version-1.2.3-not-important-output
@@ -1,0 +1,11 @@
+The following conditions found no cause for concern in updating this cluster to later releases: recommended/NodeAlerts (AsExpected), recommended/PodDisruptionBudgetAlerts (AsExpected), recommended/PodImagePullAlerts (AsExpected), recommended/UpdatePrecheckAlerts (AsExpected)
+
+The following conditions found cause for concern in updating this cluster to later releases: recommended/CriticalAlerts/VirtHandlerDaemonSetRolloutFailing/0
+
+recommended/CriticalAlerts/VirtHandlerDaemonSetRolloutFailing/0=False:
+
+  Reason: Alert:firing
+  Message: critical alert VirtHandlerDaemonSetRolloutFailing firing, suggesting significant cluster issues worth investigating. Test summary. The alert description is: Test description. <alert does not have a runbook_url annotation>
+
+
+error: no updates available, so cannot display context for the requested release 1.2.3-not-important

--- a/pkg/cli/admin/upgrade/recommend/examples_test.go
+++ b/pkg/cli/admin/upgrade/recommend/examples_test.go
@@ -80,6 +80,10 @@ func TestExamples(t *testing.T) {
 			var version string
 			if version = variant.versions[cv]; version != "" {
 				variant.outputSuffix = fmt.Sprintf(variant.outputSuffixPattern, version)
+			} else {
+				if variant.name == "specific version" {
+					continue
+				}
 			}
 			t.Run(fmt.Sprintf("%s-%s", cv, variant.name), func(t *testing.T) {
 				t.Parallel()

--- a/pkg/cli/admin/upgrade/recommend/examples_test.go
+++ b/pkg/cli/admin/upgrade/recommend/examples_test.go
@@ -63,11 +63,13 @@ func TestExamples(t *testing.T) {
 		{
 			name: "specific version",
 			versions: map[string]string{
-				"examples/4.12.16-longest-not-recommended-cv.yaml": "4.12.51",
-				"examples/4.12.16-longest-recommended-cv.yaml":     "4.12.51",
-				"examples/4.14.1-all-recommended-cv.yaml":          "4.12.51",
-				"examples/4.16.27-degraded-monitoring-cv.yaml":     "4.16.32",
-				"examples/4.19.0-okd-scos.16-cv.yaml":              "4.19.0-okd-scos.17",
+				"examples/4.12.16-longest-not-recommended-cv.yaml":          "4.12.51",
+				"examples/4.12.16-longest-recommended-cv.yaml":              "4.12.51",
+				"examples/4.14.1-all-recommended-cv.yaml":                   "4.12.51",
+				"examples/4.16.27-degraded-monitoring-cv.yaml":              "4.16.32",
+				"examples/4.19.0-okd-scos.16-cv.yaml":                       "4.19.0-okd-scos.17",
+				"examples/4.22.0-extend-recommended-alert-cv.yaml":          "1.2.3-not-important",
+				"examples/4.22.0-extend-recommended-critical-alert-cv.yaml": "1.2.3-not-important",
 			},
 			outputSuffixPattern: ".version-%s-output",
 		},
@@ -80,10 +82,6 @@ func TestExamples(t *testing.T) {
 			var version string
 			if version = variant.versions[cv]; version != "" {
 				variant.outputSuffix = fmt.Sprintf(variant.outputSuffixPattern, version)
-			} else {
-				if variant.name == "specific version" {
-					continue
-				}
 			}
 			t.Run(fmt.Sprintf("%s-%s", cv, variant.name), func(t *testing.T) {
 				t.Parallel()


### PR DESCRIPTION
Re-open https://github.com/openshift/oc/pull/2213

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new example fixtures and test data for the upgrade recommendation feature, demonstrating alert condition scenarios and cluster state configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->