### PR TITLE
OCPBUGS-85052: feat: add etcdconfig to operator inspect command

### DIFF
--- a/pkg/cli/admin/inspect/inspect.go
+++ b/pkg/cli/admin/inspect/inspect.go
@@ -366,6 +366,56 @@ func (o *InspectOptions) gatherOperatorResourceData(ctx context.Context, destDir
 	return nil
 }
 
+// gatherEtcdConfigResourceData gathers all etcd.openshift.io resources.
+func (o *InspectOptions) gatherEtcdConfigResourceData(ctx context.Context, destDir string, resourceCtx *resourceContext) error {
+	// determine if we've already collected etcdConfigResourceData
+	if resourceCtx.visited.Has(etcdConfigResourceDataKey) {
+		klog.V(1).Infof("Skipping previously-collected etcd.openshift.io resource data")
+		return nil
+	}
+	resourceCtx.visited.Insert(etcdConfigResourceDataKey)
+
+	// ensure destination path exists
+	if err := os.MkdirAll(destDir, os.ModePerm); err != nil {
+		return err
+	}
+
+	resources, err := retrieveAPIGroupVersionResourceNames(o.discoveryClient, "etcd.openshift.io")
+	if err != nil {
+		return err
+	}
+
+	errs := []error{}
+	for _, resource := range resources {
+		resourceList, err := o.dynamicClient.Resource(resource).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		objToPrint := runtime.Object(resourceList)
+		filename := fmt.Sprintf("%s.yaml", resource.Resource)
+		if err := o.fileWriter.WriteFromResource(ctx, path.Join(destDir, "/"+filename), objToPrint); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+	}
+
+	// if no etcd.openshift.io resources found, remove the directory, to avoid empty directory being created
+	if len(resources) == 0 {
+		err := os.Remove(destDir)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("no etcd.openshift.io resources found, failed to remove directory (%s): %w", destDir, err))
+		}
+		klog.V(1).Infof("no etcd.openshift.io resources found")
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("one or more errors occurred while gathering etcd.openshift.io resource data:\n\n    %v", errors.NewAggregate(errs))
+	}
+	return nil
+}
+
 // ensureDirectoryViable returns an error if DestDir:
 // 1. already exists AND is a file (not a directory)
 // 2. already exists AND is NOT empty, unless overwrite was passed

--- a/pkg/cli/admin/inspect/inspect_test.go
+++ b/pkg/cli/admin/inspect/inspect_test.go
@@ -122,6 +122,29 @@ func TestAPIGroupVersionRetrieval(t *testing.T) {
 			expectedResources: []schema.GroupVersionResource{{Group: "foo.group.io", Version: "v1", Resource: "foos"}},
 		},
 		{
+			name: "ensure etcd apiGroup returns expected pacemaker resource",
+			resourceFinder: &fakeSupportedResourceFinder{
+				supportedResources: []*metav1.APIResourceList{
+					{
+						TypeMeta:     metav1.TypeMeta{Kind: "PacemakerCluster", APIVersion: "v1alpha1"},
+						GroupVersion: schema.GroupVersion{Group: "etcd.openshift.io", Version: "v1alpha1"}.String(),
+						APIResources: []metav1.APIResource{
+							{
+								Name:         "pacemakerclusters",
+								SingularName: "pacemakercluster",
+								Group:        "etcd.openshift.io",
+								Version:      "v1",
+								Kind:         "PacemakerCluster",
+								Verbs:        []string{"get", "list"},
+							},
+						},
+					},
+				},
+			},
+			apiGroup:          "etcd.openshift.io",
+			expectedResources: []schema.GroupVersionResource{{Group: "etcd.openshift.io", Version: "v1alpha1", Resource: "pacemakerclusters"}},
+		},
+		{
 			name: "ensure known apiGroup with NO `list` verb is omitted from results",
 			resourceFinder: &fakeSupportedResourceFinder{
 				supportedResources: []*metav1.APIResourceList{

--- a/pkg/cli/admin/inspect/resource.go
+++ b/pkg/cli/admin/inspect/resource.go
@@ -22,8 +22,9 @@ const (
 	clusterScopedResourcesDirname = "cluster-scoped-resources"
 	namespaceResourcesDirname     = "namespaces"
 
-	configResourceDataKey   = "/cluster-scoped-resources/config.openshift.io"
-	operatorResourceDataKey = "/cluster-scoped-resources/operator.openshift.io"
+	configResourceDataKey     = "/cluster-scoped-resources/config.openshift.io"
+	operatorResourceDataKey   = "/cluster-scoped-resources/operator.openshift.io"
+	etcdConfigResourceDataKey = "/cluster-scoped-resources/etcd.openshift.io"
 )
 
 // InspectResource receives an object to gather debugging data for, and a context to keep track of
@@ -50,6 +51,11 @@ func InspectResource(ctx context.Context, info *resource.Info, resourceCtx *reso
 
 		// then, gather operator.openshift.io resource data
 		if err := o.gatherOperatorResourceData(ctx, path.Join(o.DestDir, "/cluster-scoped-resources/operator.openshift.io"), resourceCtx); err != nil {
+			errs = append(errs, err)
+		}
+
+		// then, gather etcd.openshift.io resource data
+		if err := o.gatherEtcdConfigResourceData(ctx, path.Join(o.DestDir, "/cluster-scoped-resources/etcd.openshift.io"), resourceCtx); err != nil {
 			errs = append(errs, err)
 		}
 


### PR DESCRIPTION
in 4.22 and 5.0 we added a new pacemaker cr under the etcd config for two node fencing clusters, adding the ability to pull down that information during inspect

added a remove step if the resources do not exist, so if the command is used against a non fencing cluster or something that does not have any etcd config we remove the empty directory to avoid noise

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded cluster inspection to collect etcd OpenShift API resources and ensure no empty diagnostic folders are left behind.

* **Tests**
  * Added test coverage for API group discovery and retrieval, including etcd API resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->