### PR TITLE
NO-JIRA: Collect `ControllerRevision` objects when running `adm inspect namespace` 

### DIFF
--- a/pkg/cli/admin/inspect/namespace.go
+++ b/pkg/cli/admin/inspect/namespace.go
@@ -32,6 +32,7 @@ func namespaceResourcesToCollect() []schema.GroupResource {
 		{Resource: "secrets"},
 		{Resource: "servicemonitors"},
 		{Resource: "userdefinednetworks"},
+		{Group: "apps", Resource: "controllerrevisions"},
 		{Group: "networking.k8s.io", Resource: "ingresses"},
 	}
 }


### PR DESCRIPTION
[ControllerRevisions](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/controller-revision-v1/) (apps/v1) store immutable snapshots of `DaemonSet` and `StatefulSet` controller state. 

When troubleshooting DaemonSet or StatefulSet problems via `oc adm inspect`, engineers must currently fetch ControllerRevisions separately, adding friction and risking missed data during time-sensitive debugging.

Since this was a quite minimal change, I was not sure if I should file an issue first. Let me know and I'll create an issue if needed.

**Before**

```sh
❯ omc use inspect.local.5403369705059286438/
Cleaning /home/asoro/.omc/omc.json
Must-Gather    : /tmp/inspect/default/inspect.local.5403369705059286438
Project        : openshift-monitoring (single project)

❯ omc get replicasets                       
NAME                                               DESIRED   CURRENT   READY   AGE
cluster-monitoring-operator-6b4f98dcbf             1         1         1       4h
kube-state-metrics-59c5db5f66                      1         1         1       4h
metrics-server-845f8cbf4d                          2         2         2       4h
monitoring-plugin-5b65996cf7                       2         2         2       4h
openshift-state-metrics-6668c9cd4                  1         1         1       4h
prometheus-operator-78cff5dd4d                     1         1         1       4h
prometheus-operator-admission-webhook-7f68c558c5   2         2         2       4h
telemeter-client-5f7dcdc465                        1         1         1       4h
thanos-querier-648d64db4                           2         2         2       4h

❯ omc get controllerrevisions
No resources controllerrevisions.apps found in openshift-monitoring namespace.
```

**After**

```sh
❯ omc use inspect.local.4150307718930344409 
Must-Gather    : /tmp/inspect/with-controller-revisions/inspect.local.4150307718930344409
Project        : openshift-monitoring (single project)

❯ omc get replicasets                      
NAME                                               DESIRED   CURRENT   READY   AGE
cluster-monitoring-operator-6b4f98dcbf             1         1         1       4h
kube-state-metrics-59c5db5f66                      1         1         1       4h
metrics-server-845f8cbf4d                          2         2         2       4h
monitoring-plugin-5b65996cf7                       2         2         2       4h
openshift-state-metrics-6668c9cd4                  1         1         1       4h
prometheus-operator-78cff5dd4d                     1         1         1       4h
prometheus-operator-admission-webhook-7f68c558c5   2         2         2       4h
telemeter-client-5f7dcdc465                        1         1         1       4h
thanos-querier-648d64db4                           2         2         2       4h

❯ omc get controllerrevisions
NAME                           CONTROLLER   REVISION   AGE
alertmanager-main-76b78448bc   <none>       2          4h
alertmanager-main-789c4b6d99   <none>       1          4h
node-exporter-769b9d5489       <none>       1          4h
prometheus-k8s-57dcbc5dff      <none>       1          4h
prometheus-k8s-7fdcc946c5      <none>       2          4h
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Namespace inspection now includes additional system resources for more comprehensive namespace diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->