### PR TITLE
inspectalerts: improve error message when no bearer token is available

### DIFF
--- a/pkg/cli/admin/inspectalerts/inspectalerts.go
+++ b/pkg/cli/admin/inspectalerts/inspectalerts.go
@@ -99,7 +99,7 @@ func (o *options) Run(ctx context.Context) error {
 // other forms of authentication.
 func ValidateRESTConfig(restConfig *rest.Config) error {
 	if restConfig.BearerToken == "" && restConfig.BearerTokenFile == "" {
-		return fmt.Errorf("no token is currently in use for this session")
+		return fmt.Errorf("no bearer token available for this session; the monitoring API requires token-based authentication, use 'oc login'")
 	}
 	return nil
 }


### PR DESCRIPTION
When using certificate-based authentication (e.g. system:admin from installer kubeconfig), the monitoring API on Thanos Querier rejects the request because kube-rbac-proxy only supports TokenReview-based authentication on the web port (9091). The previous error message ("no token is currently in use for this session") did not explain why it failed or what the user should do.

Update the message to clarify that token-based auth is required and point users to 'oc login' or creating a service account with the 'cluster-monitoring-view' role.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging for token-based authentication failures. When no token is detected, the message now clearly states token-based authentication is required for the monitoring API and directs users to authenticate (for example, by running `oc login` or using an appropriately scoped service account).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->