### PR TITLE
NO-JIRA: accept risks e2e becomes blocking

### DIFF
--- a/test/e2e/accept.go
+++ b/test/e2e/accept.go
@@ -10,7 +10,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
 
-	oteginkgo "github.com/openshift-eng/openshift-tests-extension/pkg/ginkgo"
 	configv1 "github.com/openshift/api/config/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 )
@@ -58,7 +57,7 @@ var _ = g.Describe("[sig-cli][OCPFeatureGate:ClusterUpdateAcceptRisks] oc", g.La
 		}
 	})
 
-	g.It("can operate accept risks [Serial]", g.Label("tech-preview"), oteginkgo.Informing(), func() {
+	g.It("can operate accept risks [Serial]", g.Label("tech-preview"), func() {
 
 		g.By("accepting some risks")
 		out, err := oc.Run("adm").Args("upgrade", "accept", "RiskA,RiskB").WithoutNamespace().Output()


### PR DESCRIPTION
As June 4, 2026, the passing rate in Sippy is 

<img width="1504" height="481" alt="Screenshot 2026-06-04 at 12 07 26" src="https://github.com/user-attachments/assets/11c6b0b9-caee-405c-88e1-993b32d22c3c" />

The failure looks similar to [this one](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-release-main-ci-5.0-e2e-azure-ovn-serial-rhcos9-10-techpreview-2of2/2062374999892692992/artifacts/e2e-azure-ovn-serial-rhcos9-10-techpreview/openshift-e2e-test/artifacts/e2e.log):

```
started: 1/34/46 "[sig-cli][OCPFeatureGate:ClusterUpdateAcceptRisks] oc can operate accept risks [Serial]"

Running 'oc --kubeconfig=/tmp/kubeconfig-4043812754 get configmap microshift-version -n kube-public -o jsonpath={.data.version}'
ERROR: Command failed with error: exit status 1
Output: Error from server (NotFound): configmaps "microshift-version" not found

  [FAILED] in [BeforeEach] - /go/src/github.com/openshift/oc/test/e2e/accept.go:39 @ 06/04/26 06:13:14.427
  [FAILED] in [AfterEach] - /go/src/github.com/openshift/oc/test/e2e/accept.go:57 @ 06/04/26 06:13:14.53

fail [github.com/openshift/oc/test/e2e/accept.go:39]: Expected
    <[]v1.AcceptRisk | len:1, cap:1>: [
        {
            Name: "TestAlertFeatureE2ETestOTA1813",
        },
    ]
to be empty
failed: (400ms) 2026-06-04T06:13:14 "[sig-cli][OCPFeatureGate:ClusterUpdateAcceptRisks] oc can operate accept risks [Serial]"

```


It is because the cleanup in the previous test cases failed

```
started: 0/1/46 "[Jira:\"Cluster Version Operator\"] cluster-version-operator should work with risks from alerts"

  STEP: Using fauxinnati as the upstream and its simple channel @ 06/04/26 05:38:40.344
  STEP: Create a critical alert for testing @ 06/04/26 05:38:40.387
  STEP: Checking if the risk shows up in ClusterVersion's status @ 06/04/26 05:38:40.443
  STEP: Checking that no updates is recommended if alert is firing @ 06/04/26 05:39:10.474
  STEP: Checking that there are recommended conditional updates promoted to available updates after the risk from alert is accepted @ 06/04/26 05:39:10.508
  STEP: Checking that there are no duplicated versions in conditional updates @ 06/04/26 05:39:40.642
  STEP: Checking that there are no duplicated versions in available updates @ 06/04/26 05:39:40.671
  STEP: Checking that there are no recommended conditional updates after the alert is resolved @ 06/04/26 05:39:40.673
  STEP: Checking that there are available updates after the alert is resolved @ 06/04/26 05:40:40.737
  [FAILED] in [AfterEach] - /go/src/github.com/openshift/cluster-version-operator/test/cvo/accept_risks.go:79 @ 06/04/26 05:40:40.824

fail [github.com/openshift/cluster-version-operator/test/cvo/accept_risks.go:79]: Unexpected error:
    <*errors.StatusError | 0xc0004d0c80>: 
    Operation cannot be fulfilled on clusterversions.config.openshift.io "version": the object has been modified; please apply your changes to the latest version and try again
    {
        ErrStatus: {
            TypeMeta: {Kind: "", APIVersion: ""},
            ListMeta: {
                SelfLink: "",
                ResourceVersion: "",
                Continue: "",
                RemainingItemCount: nil,
            },
            Status: "Failure",
            Message: "Operation cannot be fulfilled on clusterversions.config.openshift.io \"version\": the object has been modified; please apply your changes to the latest version and try again",
            Reason: "Conflict",
            Details: {
                Name: "version",
                Group: "config.openshift.io",
                Kind: "clusterversions",
                UID: "",
                Causes: nil,
                RetryAfterSeconds: 0,
            },
            Code: 409,
        },
    }
occurred
failed: (2m1s) 2026-06-04T05:40:40 "[Jira:\"Cluster Version Operator\"] cluster-version-operator should work with risks from alerts"
```

We hope that https://github.com/openshift/cluster-version-operator/pull/1399 will help. Let us review the stats again after a while.

/hold



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Simplified a cluster update acceptance test by removing an unnecessary test option and streamlining its labels.

* **Chores**
  * Cleaned up redundant test code and removed unused test dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->