### PR TITLE
OCPBUGS-87198: Fix windows builds of oc rpm

### DIFF
--- a/hack/generate-versioninfo.sh
+++ b/hack/generate-versioninfo.sh
@@ -55,7 +55,7 @@ function os::build::generate_windows_versioninfo() {
        }
 }
 EOF
-  goversioninfo -o ${OS_ROOT}/cmd/oc/oc.syso ${windows_versioninfo_file}
+  goversioninfo -64 -o ${OS_ROOT}/cmd/oc/oc.syso ${windows_versioninfo_file}
 }
 readonly -f os::build::generate_windows_versioninfo
 


### PR DESCRIPTION
Hitting this error since bumping the build root from go1.25 to go1.26:
```
$WORK/b001/_pkg_.a(oc.syso): 2496931: unknown relocation type 7
```
while compiling windows binaries in brew: https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=70980110

https://github.com/golang/go/issues/77783 suggests to pass the `-64` option to the invocation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Windows version information generation for 64-bit builds to ensure proper version metadata is embedded in compiled binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->