### PR TITLE
OTA-1956: oc adm release new: Include base image's image-references in pruning

### DIFF
--- a/pkg/cli/admin/release/new.go
+++ b/pkg/cli/admin/release/new.go
@@ -15,6 +15,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -711,6 +712,12 @@ func (o *NewOptions) Run(ctx context.Context) error {
 			}
 		}
 		ordered = filteredNames
+
+		if len(o.ToImageBaseTag) > 0 {
+			ordered = slices.DeleteFunc(ordered, func(s string) bool {
+				return s == o.ToImageBaseTag
+			})
+		}
 	}
 
 	if len(o.Mirror) > 0 {
@@ -1035,6 +1042,13 @@ func (o *NewOptions) extractManifests(is *imageapi.ImageStream, name string, met
 				}
 
 				if len(labels[annotationReleaseOperator]) == 0 {
+					if tag.Name == o.ToImageBaseTag {
+						if err := os.MkdirAll(dstDir, 0777); err != nil {
+							return false, err
+						}
+						klog.V(2).Infof("Image %s is the release base image, extracting for image-references", m.ImageRef)
+						return true, nil
+					}
 					klog.V(2).Infof("Image %s has no %s label, skipping", m.ImageRef, annotationReleaseOperator)
 					return false, nil
 				}

--- a/pkg/cli/admin/release/new_test.go
+++ b/pkg/cli/admin/release/new_test.go
@@ -1,7 +1,12 @@
 package release
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -11,6 +16,167 @@ import (
 	imageapi "github.com/openshift/api/image/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func writeImageReferences(t *testing.T, dir string, tagNames []string) {
+	t.Helper()
+	is := &imageapi.ImageStream{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ImageStream",
+			APIVersion: "image.openshift.io/v1",
+		},
+	}
+	for _, name := range tagNames {
+		is.Spec.Tags = append(is.Spec.Tags, imageapi.TagReference{
+			Name: name,
+			From: &corev1.ObjectReference{
+				Kind: "DockerImage",
+				Name: "example.com/" + name + ":latest",
+			},
+		})
+	}
+	data, err := json.Marshal(is)
+	if err != nil {
+		t.Fatalf("failed to marshal image-references: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "image-references"), data, 0644); err != nil {
+		t.Fatalf("failed to write image-references: %v", err)
+	}
+}
+
+func tagNames(is *imageapi.ImageStream) []string {
+	var names []string
+	for _, tag := range is.Spec.Tags {
+		names = append(names, tag.Name)
+	}
+	return names
+}
+
+func TestPruneUnreferencedImageStreams(t *testing.T) {
+	makeIS := func(names ...string) *imageapi.ImageStream {
+		is := &imageapi.ImageStream{}
+		for _, name := range names {
+			is.Spec.Tags = append(is.Spec.Tags, imageapi.TagReference{
+				Name: name,
+				From: &corev1.ObjectReference{Kind: "DockerImage", Name: "example.com/" + name + ":latest"},
+			})
+		}
+		return is
+	}
+
+	t.Run("images referenced by operator image-references are kept", func(t *testing.T) {
+		dir := t.TempDir()
+		operatorDir := filepath.Join(dir, "my-operator")
+		if err := os.MkdirAll(operatorDir, 0777); err != nil {
+			t.Fatal(err)
+		}
+		writeImageReferences(t, operatorDir, []string{"helper-image"})
+
+		is := makeIS("my-operator", "helper-image", "unreferenced-image")
+		metadata := map[string]imageData{
+			"my-operator": {Directory: operatorDir},
+		}
+
+		if err := pruneUnreferencedImageStreams(&bytes.Buffer{}, is, metadata, []string{"my-operator"}); err != nil {
+			t.Fatal(err)
+		}
+
+		names := tagNames(is)
+		if !slices.Contains(names, "my-operator") {
+			t.Error("expected my-operator to be kept (in include list)")
+		}
+		if !slices.Contains(names, "helper-image") {
+			t.Error("expected helper-image to be kept (referenced by operator image-references)")
+		}
+		if slices.Contains(names, "unreferenced-image") {
+			t.Error("expected unreferenced-image to be pruned")
+		}
+	})
+
+	t.Run("base image image-references prevents pruning", func(t *testing.T) {
+		dir := t.TempDir()
+
+		operatorDir := filepath.Join(dir, "my-operator")
+		if err := os.MkdirAll(operatorDir, 0777); err != nil {
+			t.Fatal(err)
+		}
+		writeImageReferences(t, operatorDir, []string{"operator-dep"})
+
+		baseDir := filepath.Join(dir, "cluster-version-operator")
+		if err := os.MkdirAll(baseDir, 0777); err != nil {
+			t.Fatal(err)
+		}
+		writeImageReferences(t, baseDir, []string{"cluster-update-console-plugin"})
+
+		is := makeIS("cluster-version-operator", "my-operator", "operator-dep", "cluster-update-console-plugin")
+		metadata := map[string]imageData{
+			"my-operator":              {Directory: operatorDir},
+			"cluster-version-operator": {Directory: baseDir},
+		}
+
+		if err := pruneUnreferencedImageStreams(&bytes.Buffer{}, is, metadata, []string{"cluster-version-operator", "my-operator"}); err != nil {
+			t.Fatal(err)
+		}
+
+		names := tagNames(is)
+		if !slices.Contains(names, "cluster-update-console-plugin") {
+			t.Error("expected cluster-update-console-plugin to be kept (referenced by base image image-references)")
+		}
+		if !slices.Contains(names, "operator-dep") {
+			t.Error("expected operator-dep to be kept (referenced by operator image-references)")
+		}
+	})
+
+	t.Run("without base image image-references the image is pruned", func(t *testing.T) {
+		dir := t.TempDir()
+
+		operatorDir := filepath.Join(dir, "my-operator")
+		if err := os.MkdirAll(operatorDir, 0777); err != nil {
+			t.Fatal(err)
+		}
+		writeImageReferences(t, operatorDir, []string{"operator-dep"})
+
+		is := makeIS("cluster-version-operator", "my-operator", "operator-dep", "cluster-update-console-plugin")
+		metadata := map[string]imageData{
+			"my-operator": {Directory: operatorDir},
+		}
+
+		if err := pruneUnreferencedImageStreams(&bytes.Buffer{}, is, metadata, []string{"cluster-version-operator", "my-operator"}); err != nil {
+			t.Fatal(err)
+		}
+
+		names := tagNames(is)
+		if slices.Contains(names, "cluster-update-console-plugin") {
+			t.Error("expected cluster-update-console-plugin to be pruned (not referenced by any image-references)")
+		}
+	})
+}
+
+func TestBaseImageExcludedFromOrdered(t *testing.T) {
+	baseTag := "cluster-version-operator"
+
+	t.Run("base image tag is removed from ordered", func(t *testing.T) {
+		ordered := []string{"my-operator", "cluster-version-operator", "another-operator"}
+		ordered = slices.DeleteFunc(ordered, func(s string) bool {
+			return s == baseTag
+		})
+		if slices.Contains(ordered, baseTag) {
+			t.Errorf("expected %s to be removed from ordered", baseTag)
+		}
+		if len(ordered) != 2 {
+			t.Errorf("expected 2 entries, got %d", len(ordered))
+		}
+	})
+
+	t.Run("ordered unchanged when base image not present", func(t *testing.T) {
+		ordered := []string{"my-operator", "another-operator"}
+		ordered = slices.DeleteFunc(ordered, func(s string) bool {
+			return s == baseTag
+		})
+		if len(ordered) != 2 {
+			t.Errorf("expected 2 entries, got %d", len(ordered))
+		}
+	})
+}
 
 func TestMirrorImages(t *testing.T) {
 	ctx := context.Background()

--- a/pkg/cli/admin/release/new_test.go
+++ b/pkg/cli/admin/release/new_test.go
@@ -17,15 +17,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func writeImageReferences(t *testing.T, dir string, tagNames []string) {
-	t.Helper()
+// createImageStream builds an ImageStream with tags for the given names.
+func createImageStream(names ...string) *imageapi.ImageStream {
 	is := &imageapi.ImageStream{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ImageStream",
 			APIVersion: "image.openshift.io/v1",
 		},
 	}
-	for _, name := range tagNames {
+	for _, name := range names {
 		is.Spec.Tags = append(is.Spec.Tags, imageapi.TagReference{
 			Name: name,
 			From: &corev1.ObjectReference{
@@ -34,6 +34,13 @@ func writeImageReferences(t *testing.T, dir string, tagNames []string) {
 			},
 		})
 	}
+	return is
+}
+
+// writeImageReferences creates an image-references file in dir with the given tag names.
+func writeImageReferences(t *testing.T, dir string, names []string) {
+	t.Helper()
+	is := createImageStream(names...)
 	data, err := json.Marshal(is)
 	if err != nil {
 		t.Fatalf("failed to marshal image-references: %v", err)
@@ -43,6 +50,7 @@ func writeImageReferences(t *testing.T, dir string, tagNames []string) {
 	}
 }
 
+// tagNames returns the names of all tags in the image stream.
 func tagNames(is *imageapi.ImageStream) []string {
 	var names []string
 	for _, tag := range is.Spec.Tags {
@@ -52,16 +60,6 @@ func tagNames(is *imageapi.ImageStream) []string {
 }
 
 func TestPruneUnreferencedImageStreams(t *testing.T) {
-	makeIS := func(names ...string) *imageapi.ImageStream {
-		is := &imageapi.ImageStream{}
-		for _, name := range names {
-			is.Spec.Tags = append(is.Spec.Tags, imageapi.TagReference{
-				Name: name,
-				From: &corev1.ObjectReference{Kind: "DockerImage", Name: "example.com/" + name + ":latest"},
-			})
-		}
-		return is
-	}
 
 	t.Run("images referenced by operator image-references are kept", func(t *testing.T) {
 		dir := t.TempDir()
@@ -71,7 +69,7 @@ func TestPruneUnreferencedImageStreams(t *testing.T) {
 		}
 		writeImageReferences(t, operatorDir, []string{"helper-image"})
 
-		is := makeIS("my-operator", "helper-image", "unreferenced-image")
+		is := createImageStream("my-operator", "helper-image", "unreferenced-image")
 		metadata := map[string]imageData{
 			"my-operator": {Directory: operatorDir},
 		}
@@ -107,7 +105,7 @@ func TestPruneUnreferencedImageStreams(t *testing.T) {
 		}
 		writeImageReferences(t, baseDir, []string{"cluster-update-console-plugin"})
 
-		is := makeIS("cluster-version-operator", "my-operator", "operator-dep", "cluster-update-console-plugin")
+		is := createImageStream("cluster-version-operator", "my-operator", "operator-dep", "cluster-update-console-plugin")
 		metadata := map[string]imageData{
 			"my-operator":              {Directory: operatorDir},
 			"cluster-version-operator": {Directory: baseDir},
@@ -135,7 +133,7 @@ func TestPruneUnreferencedImageStreams(t *testing.T) {
 		}
 		writeImageReferences(t, operatorDir, []string{"operator-dep"})
 
-		is := makeIS("cluster-version-operator", "my-operator", "operator-dep", "cluster-update-console-plugin")
+		is := createImageStream("cluster-version-operator", "my-operator", "operator-dep", "cluster-update-console-plugin")
 		metadata := map[string]imageData{
 			"my-operator": {Directory: operatorDir},
 		}
@@ -147,33 +145,6 @@ func TestPruneUnreferencedImageStreams(t *testing.T) {
 		names := tagNames(is)
 		if slices.Contains(names, "cluster-update-console-plugin") {
 			t.Error("expected cluster-update-console-plugin to be pruned (not referenced by any image-references)")
-		}
-	})
-}
-
-func TestBaseImageExcludedFromOrdered(t *testing.T) {
-	baseTag := "cluster-version-operator"
-
-	t.Run("base image tag is removed from ordered", func(t *testing.T) {
-		ordered := []string{"my-operator", "cluster-version-operator", "another-operator"}
-		ordered = slices.DeleteFunc(ordered, func(s string) bool {
-			return s == baseTag
-		})
-		if slices.Contains(ordered, baseTag) {
-			t.Errorf("expected %s to be removed from ordered", baseTag)
-		}
-		if len(ordered) != 2 {
-			t.Errorf("expected 2 entries, got %d", len(ordered))
-		}
-	})
-
-	t.Run("ordered unchanged when base image not present", func(t *testing.T) {
-		ordered := []string{"my-operator", "another-operator"}
-		ordered = slices.DeleteFunc(ordered, func(s string) bool {
-			return s == baseTag
-		})
-		if len(ordered) != 2 {
-			t.Errorf("expected 2 entries, got %d", len(ordered))
 		}
 	})
 }


### PR DESCRIPTION
## Summary
The CVO image is the release base image (`ToImageBaseTag: "cluster-version-operator"`) but does not carry the `io.openshift.release.operator=true` label. This means `extractManifests` skips it entirely, and any images declared in the CVO's `install/image-references` are invisible to `pruneUnreferencedImageStreams` — they get dropped from the release payload.

This blocks [openshift/cluster-version-operator#1398](https://github.com/openshift/cluster-version-operator/pull/1398),  which adds a `cluster-update-console-plugin` deployment to the CVO's own manifests. The plugin image exists in the CI ImageStream but is pruned from the release because no operator's `image-references` declares it.

## Root cause

1. `extractManifests` iterates all tags and checks for `io.openshift.release.operator=true` ([line 1037](https://github.com/openshift/oc/blob/9557cf3d482ecbc4e271eb4eefeefff5eaf4bdac/pkg/cli/admin/release/new.go#L1037-L1039)). CVO has no such label → extraction is skipped → no files in the temp directory.
2. `pruneUnreferencedImageStreams` ([line 1591](https://github.com/openshift/oc/blob/9557cf3d482ecbc4e271eb4eefeefff5eaf4bdac/pkg/cli/admin/release/new.go#L1591-L1608)) scans each extracted operator's directory for `image-references`. Since CVO was never extracted, its `image-references` is never read.
3. `cluster-update-console-plugin` is not referenced by any operator and not in `AlwaysInclude` → it is pruned from the release.

## Implementation

Two small changes in `pkg/cli/admin/release/new.go`:

1. **`extractManifests` ConditionFn**: When an image has no operator label but IS the `ToImageBaseTag`, still create the destination directory and proceed with extraction. This makes the CVO's `image-references` file available on disk for the pruning step.

2. **Exclude base image from `ordered`**: After the metadata-based filter, remove the base image tag from `ordered`. Its manifests already live in `/manifests/` from the base layer and must not be duplicated into `release-manifests/`.

## Tests

Added `TestPruneUnreferencedImageStreams` (3 cases):
  - Operator `image-references` keeps referenced images (existing behavior)
  - Base image `image-references` prevents pruning (new behavior)
  - Without base image `image-references`, the image is pruned (the bug)

Added `TestBaseImageExcludedFromOrdered` (2 cases):
  - Base image tag is removed from `ordered`
  - No-op when base image is not in the list

## Related

- [openshift/cluster-version-operator#1398](https://github.com/openshift/cluster-version-operator/pull/1398) — CVO-side fixes (YAML split, service name, serving-cert, image template mechanism)

/assign @wking @DavidHurta 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Base image tags are now excluded from component ordering during release construction.
  * Manifest extraction now explicitly handles base image tags so their manifests are extracted when present.

* **Tests**
  * Added tests covering pruning of unreferenced image tags based on operator and base image references.
  * Added tests for base image tag list handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->