### PR TITLE
OCPBUGS-88342: openshift-clients RPM has a hard dependency on bash-completion

### DIFF
--- a/oc.spec
+++ b/oc.spec
@@ -52,7 +52,7 @@ BuildRequires:  rsync
 
 Provides:       atomic-openshift-clients = %{version}
 Obsoletes:      atomic-openshift-clients <= %{version}
-Requires:       bash-completion
+Recommends:     bash-completion
 
 %description
 %{summary}


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/OCPBUGS-88342

## Summary

- Downgrade `bash-completion` from a hard `Requires` to a soft `Recommends` in `oc.spec`

## Motivation

The `openshift-clients` RPM has an unnecessary hard dependency on `bash-completion`. Changing this to `Recommends` allows `oc` to be installed in minimal client environments that do not need shell completion support. Packages listed as `Recommends` are still installed by default when available but will not block installation if absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)