### PR TITLE
CNTRLPLANE-3665: Add ARCHITECTURE.md, adopt shared CONTRIBUTING.md, slim README

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -10,5 +10,6 @@ knowledge_base:
     enabled: true
     filePatterns:
     - AGENTS.md
+    - ARCHITECTURE.md
   learnings:
     scope: local

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,22 +4,9 @@ The OpenShift Client (`oc`) is the official CLI for OpenShift Container Platform
 
 ## Architecture: oc and kubectl Relationship
 
-kubectl is a subset of oc — every kubectl command is available in oc. The relationship between oc and kubectl commands falls into these categories:
+kubectl is a subset of oc — every kubectl command is available in oc. Commands range from pure kubectl wrappers (in `pkg/cli/kubectlwrappers/`) through OCP-extended wrappers, to fully OCP-native commands. The key rule: if a command is a pure kubectl wrapper, behavioral changes belong upstream in `k8s.io/kubectl`, not here.
 
-**Pure kubectl wrappers** — Commands wired via `pkg/cli/kubectlwrappers/wrappers.go` using `cmdutil.ReplaceCommandName("kubectl", "oc", ...)`. Includes: get, apply, delete, exec, run, patch, replace, describe, edit, label, annotate, cp, wait, events, port-forward, attach, proxy, explain, diff, auth, api-resources, api-versions, cluster-info, kustomize, completion, plugin. Changes to these should go upstream to `k8s.io/kubectl`.
-
-**Kubectl wrappers with OCP extensions** — `create` (adds route, deployment-config, user, identity, image-stream, build subcommands), `scale`/`autoscale` (adds deploymentconfig resource), `config` (adds admin-kubeconfig, refresh-ca-bundle subcommands). Under `oc adm`: drain, cordon, uncordon, taint, certificates are also kubectl wrappers.
-
-**Commands that extend kubectl** — These embed kubectl's implementation but add OCP-specific logic:
-- `logs` — embeds kubectl's `logs.LogsOptions`, adds Build, BuildConfig, DeploymentConfig, Jenkins pipeline support, and `--version` flag
-- `expose` — extends kubectl expose with OpenShift Route creation
-- `rollout`/`rollback` — extends with DeploymentConfig support
-
-**Commands that diverge from kubectl** — These have their own oc implementation:
-- `debug` — full custom implementation with OpenShift resource support
-- `set` — entirely oc-native with OCP-specific subcommands (env, volume, triggers, build-hook, deployment-hook, route-backends, etc.)
-
-**Purely OCP-native commands** — No kubectl equivalent: new-app, new-build, start-build, cancel-build, import-image, tag, login, logout, whoami, project, projects, request-project, rsh, rsync, status, process, extract, observe, idle, image, registry, policy, secrets, service-accounts, get-token, and the entire `oc adm` subtree (~30 admin subcommands).
+See [ARCHITECTURE.md](ARCHITECTURE.md) for the full taxonomy and design rationale.
 
 ## Build and Test
 
@@ -44,10 +31,6 @@ go test -tags 'include_gcs include_oss containers_image_openpgp gssapi' ./pkg/cl
 # macOS / Windows (omit gssapi)
 go test -tags 'include_gcs include_oss containers_image_openpgp' ./pkg/cli/admin/policy/...
 ```
-
-System dependencies for building:
-- Fedora/CentOS/RHEL: `krb5-devel` (GSSAPI/Kerberos), `gpgme-devel`, `libassuan-devel`
-- macOS: `heimdal`, `gpgme` (via brew)
 
 ## Project Structure
 
@@ -115,17 +98,15 @@ func (o *ExampleOptions) Run() error { ... }
 ## Contributing Rules
 
 - **Do not modify `pkg/cli/cli.go`** unless it is part of a kubectl rebase process (to reflect changes from `kubectl/cmd.go`).
-- **Do not diverge from wrapped kubectl commands.** If a command is a kubectl wrapper, behavioral changes belong upstream in `k8s.io/kubectl`.
+- **Do not diverge from wrapped kubectl commands.** If a command is a pure kubectl wrapper, behavioral changes belong upstream in `k8s.io/kubectl`.
 - **Do not modify files under `vendor/`.** Regenerate via `go mod tidy && go mod vendor`.
 - **Do not edit generated files.** `contrib/completions/` and `docs/generated/` are generated — use `make update-generated-completions` to regenerate.
 - **Write unit tests for every change.** Some commands do not easily support unit tests without dramatic refactoring — those may be excluded, but test coverage is expected by default. Test fixtures go in `testdata/` subdirectories co-located with tests.
 - **Never remove commands, flags, or options without a deprecation notice.** Backwards compatibility is the most important aspect of this tool. Deprecate first, remove later. Use cobra's built-in deprecation: `cmd.Deprecated = "Use X instead"`.
 
-## Dependencies
+## Backporting
 
-Go Modules with vendoring. Workflow: `go mod tidy` then `go mod vendor`.
-
-Key dependencies: `spf13/cobra`, `k8s.io/client-go`, `k8s.io/kubectl`, `openshift/api`, `openshift/client-go`, `openshift/library-go`, `containers/image/v5`.
+Backports must flow sequentially from newer to older releases. On a merged PR, comment `/cherrypick <branches>` (space-separated) or `/jira backport <branches>` (comma-separated) to trigger automated cherry-picks. When cherry-picks fail due to conflicts, create the PR manually and use `/jira cherrypick OCPBUGS-XXX` to link the bug.
 
 ## Testing
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,36 @@
+# Architecture
+
+This document explains the design decisions and component relationships of `oc`, the OpenShift CLI. It is not a user guide — see [README.md](README.md) for building and [CONTRIBUTING.md](CONTRIBUTING.md) for development workflow.
+
+## The kubectl Wrapper Taxonomy
+
+Every kubectl command is available in oc. The relationship falls into five categories, each with a different integration mechanism:
+
+**Pure kubectl wrappers** — Commands in `pkg/cli/kubectlwrappers/wrappers.go` that call kubectl's constructor and wrap with `cmdutil.ReplaceCommandName("kubectl", "oc", ...)`. The wrapping is cosmetic — command name substitution in help text. Behavioral changes to these commands belong upstream in `k8s.io/kubectl`.
+
+**Kubectl wrappers with OCP extensions** — Commands that start from kubectl's implementation but add OCP subcommands or resource types. For example, `create` wraps kubectl create then adds OCP subcommands (route, deployment-config, etc.); `scale`/`autoscale` add `deploymentconfig` to ValidArgs. Under `oc adm`: drain, cordon, uncordon, taint, certificates are also kubectl wrappers.
+
+**Commands that extend kubectl** — These embed kubectl's implementation struct and add OCP-specific logic. `logs` embeds kubectl's `logs.LogsOptions` and adds Build/DeploymentConfig support. `expose` adds Route creation. `rollout`/`rollback` add DeploymentConfig support. These live in their own packages under `pkg/cli/`, not in `kubectlwrappers/`.
+
+**Commands that diverge from kubectl** — Same concept as upstream but fully reimplemented. `debug` and `set` are entirely oc-native.
+
+**Purely OCP-native commands** — No kubectl equivalent. Build, image, auth/project, connectivity, and operational commands, plus the entire `oc adm` subtree.
+
+## Design Decisions
+
+**Why Complete/Validate/Run.** All commands implement a three-phase lifecycle on an Options struct: `Complete` resolves flags and Factory outputs into a populated struct, `Validate` checks invariants without side effects, `Run` executes. This makes commands testable — tests construct Options directly, bypassing cobra — and ensures validation always happens before mutation.
+
+**Why wrapping kubectl instead of forking.** oc stays current with kubectl automatically for wrapped commands. Forking would create maintenance burden that scales with kubectl's release velocity.
+
+**Why polymorphic helpers.** `shimKubectlForOc()` in `pkg/cli/shim_kubectl.go` replaces kubectl's polymorphic helper functions with OCP-aware versions that wrap the originals — trying the OCP handler first, then falling through to kubectl's default. This is how `oc logs` understands BuildConfigs and `oc rollout` understands DeploymentConfigs without forking those commands.
+
+**Why scheme registration in main().** OCP API types must be registered into the kubectl scheme before any command runs, or serialization of OCP resources fails. This happens in `cmd/oc/oc.go` via `schemehelper.InstallSchemes()`. Note: `new-app` and `set` use their own schemes instead of this global one.
+
+## Upstream Context
+
+- **kubernetes/kubectl** is the upstream for all wrapped commands. Changes to pure-wrapper behavior belong there, not in oc.
+- **openshift/api** defines OCP API types. Schema changes happen there.
+
+## Runtime Conventions
+
+**Feature gating.** Experimental commands are gated by environment variables using `kcmdutil.FeatureGate("ENV_VAR").IsEnabled()`. Grep for `FeatureGate` to find current gates.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,214 @@
+# Contributing to the OpenShift Control Plane Components/Repositories
+
+This document serves as a guide for contributing to the OpenShift components/repositories
+that the OpenShift Control Plane group is responsible for maintaining.
+
+This document is explicitly for contributions to individual component repositories and not for high-level
+feature proposals within OpenShift.
+
+Feature proposals should follow the OpenShift Enhancement Proposal process outlined in https://github.com/openshift/enhancements/blob/master/dev-guide/feature-zero-to-hero.md#openshift-feature-development-zero-to-hero-guide.
+If you are looking for a review on an OpenShift Enhancement Proposal that involves changes to components
+maintained by the control plane group, please request a review in the [`#forum-ocp-apiserver`](https://redhat.enterprise.slack.com/archives/CB48XQ4KZ) Slack channel. Requests for review may be redirected to more appropriate and/or more focused channels for discussion.
+
+This document contains the following sections:
+
+- [Code conventions](#code-conventions) - A collection of guidelines, style suggestions, and tips for writing code.
+- [Testing guidelines](#testing-guidelines) - Guidelines and expectations for testing of contributions.
+- [Pull Request process/guidelines](#pull-request-process-and-guidelines) - Guidelines and expectations of pull requests containing contributions.
+- [Review expectations](#review-expectations) - Guidelines and expectations for requesting reviews and interacting with reviewers.
+
+## Code Conventions
+
+We largely follow the [Kubernetes Code Conventions](https://github.com/kubernetes/community/blob/main/contributors/guide/coding-conventions.md#code-conventions).
+
+Review both the Kubernetes Code Conventions and the ones specified here.
+There will be some overlap. If any conventions are at odds with one another, prefer the conventions explicitly documented here.
+
+### Bash
+
+- Follow the [shell styleguide](https://google.github.io/styleguide/shellguide.html).
+- Use [`shellcheck`](https://github.com/koalaman/shellcheck) to identify common mistakes or caveats.
+- Ensure that all scripts run consistently across Linux and macOS.
+
+### Golang (Go)
+
+- Review [Effective Go](https://go.dev/doc/effective_go).
+- Review common [Go Code Review Comments](https://go.dev/wiki/CodeReviewComments).
+- Review and avoid [Go Landmines](https://gist.github.com/lavalamp/4bd23295a9f32706a48f)
+- Comment your code following the [Go comment conventions](https://go.dev/doc/comment).
+  - Comments should be meaningful and add context and/or explain choices that cannot be expressed through clear code.
+  - All exported types, functions, and methods must have descriptive comments.
+  - All unexported types, functions, and methods should have descriptive comments.
+- When adding command-line flags, use dashes/hyphens (`-`) and not underscores (`_`).
+- Naming
+  - Please consider package name when selecting an interface name, and avoid redundancy. For example, `storage.Interface` is better than `storage.StorageInterface`.
+  - Do not use uppercase characters, underscores, or dashes in package names.
+  - Please consider parent directory name when choosing a package name. For example, `pkg/controllers/autoscaler/foo.go` should say `package autoscaler` not `package autoscalercontroller`.
+    - Unless there's a good reason, the package foo line should match the name of the directory in which the .go file exists.
+    - Importers can use a different name if they need to disambiguate.
+  - Locks should be called `lock` and should never be embedded (always `lock sync.Mutex`). When multiple locks are present, give each lock a distinct name following Go conventions: `stateLock`, `mapLock` etc.
+- Error handling
+  - Wrap errors with meaningful context before returning or logging them.
+- When logging, follow the [Kubernetes Logging Conventions](https://github.com/kubernetes/community/blob/main/contributors/devel/sig-instrumentation/logging.md).
+- When patching OpenShift-maintained forks of "upstream" repositories, patches should be as small as reasonably possible and should minimize touch points with code that is likely to change and impact the rebasing process.
+- Dependencies must be vendored. When making changes to dependencies, ensure you've run `go mod tidy` and `go mod vendor`.
+
+### General
+
+Regardless of the programming language, make sure to take the following into consideration:
+- Keep readability / maintainability in mind when writing code.
+  - Clever code and abstractions are often harder to reason about after the fact. Keep clever code and abstractions to the minimum necessary to accomplish the end-goal.
+- Do not reinvent the wheel. Where possible, use existing standard library or vendored library functionality. If you are adding a net-new dependency, stop and think if you _really_ need to add the new dependency to achieve your goals.
+- When writing tests, focus on testing the functional behaviors your code exercises. Avoid writing tests that are testing that the standard library works as expected or is trivial. Do not write tests just for line coverage.
+
+### Directory and File Conventions
+
+- Avoid package sprawl. Find an appropriate subdirectory for new packages.
+  - Libraries with no appropriate home belong in new package subdirectories of `pkg/util`.
+- Avoid general utility packages. Packages called "util" are suspect. Instead, derive a name that describes your desired function. For example, the utility functions dealing with waiting for operations are in the `wait` package and include functionality like `Poll`. The full name is `wait.Poll`.
+- All filenames should be lowercase.
+- Go source files and directories use underscores, not dashes.
+  - Package directories should generally avoid using separators as much as possible. When package names are multiple words, they usually should be in nested subdirectories.
+
+## Testing Guidelines
+
+These are high-level testing guidelines. Where individual component repositories may have
+additional testing guidelines to follow when making contributions.
+
+- All changes must include unit test additions/changes.
+  - Exceptions are at reviewer/approver discretion.
+- Table-driven unit tests are preferred for testing multiple scenarios/inputs. For an example, see https://github.com/openshift/cluster-authentication-operator/blob/a493799952e9b6838021ccc7d15d3d37d7ad3508/pkg/controllers/externaloidc/externaloidc_controller_test.go#L108 .
+- Unit tests must pass on all platforms (at the very least, Linux + macOS).
+- Significant features should come with integration and/or end-to-end (e2e) tests where appropriate.
+  - End-to-end tests _may_ be scoped as a separate work item when the end-to-end tests for the component must be added to the openshift/origin repository instead of the component repository. Adding e2e tests to the component repository is preferred where possible. It is up to reviewer/approver discretion whether a contribution can be merged without end-to-end tests being implemented.
+- Do not expect an asynchronous thing to happen immediately. Do not wait for one second and expect a pod to be running. Wait and retry instead.
+
+
+If necessary, manual integration testing can be done by creating a cluster using the [`Cluster Bot` Slack App](https://redhat.enterprise.slack.com/archives/D03KX7M1CRJ).
+Once you have a cluster created, you can follow some of the instructions in https://github.com/openshift/enhancements/blob/master/dev-guide/operators.md for guidance on how to
+build component images and modify cluster-operators to deploy those images.
+
+Most component repos have existing tooling to run unit tests. Check for Makefiles and shell scripts that might run the unit tests. If none exist, you should be able to use standard testing tooling like `go test ./...` to run all tests for the project. https://pkg.go.dev/cmd/go/internal/test is a good reference for how the `go test` command works.
+
+## Pull Request Process and Guidelines
+
+This section assumes that you have a functional understanding of `git` and how to create a pull request on GitHub.
+
+If you do not, start with [GitHub's "Getting Started" guide](https://docs.github.com/en/get-started/start-your-journey).
+
+### Prerequisites
+
+Before you commit any changes or create any pull requests, you must adhere to OpenShift contribution policies.
+Currently, that means enabling commit signature verification.
+
+See https://docs.google.com/document/d/1184EPSGunUkcSQYUK8T4a6iyawwi6f2zxdbB2jtG9nQ/edit?usp=sharing for more details on
+how to adhere to the commit signature verification policy of OpenShift.
+
+### Creating a Pull Request
+
+When creating a pull request, include the following:
+
+- A brief, but descriptive, title.
+  - All pull requests _should_ link to a Jira ticket associated with the work. There is automation that performs this linking when prefixing the title with the Jira ticket identifier like: `CNTRLPLANE-XXXX: my pull request title`. For pull requests that have no Jira ticket associated with it, you can prefix it with `NO-JIRA:` to signal that there is not a Jira ticket associated with it.
+- A useful description of the changes being made and why they are important. Include links to supporting documents and any additional context that reviewers may need.
+
+### CI / CD
+
+For CI/CD, OpenShift uses Prow to run various checks. This can include unit tests, e2e tests, linters, etc.
+
+The jobs configured for each repository are in https://github.com/openshift/release/tree/main/ci-operator/config/openshift . If you find yourself needing to add additional jobs, review the documentation at https://docs.ci.openshift.org/how-tos/contributing-openshift-release/ .
+
+There are often a mixture of required and optional checks as well as merge criteria that must be met before a pull request can merge.
+When any of these checks fail, the GitHub Prow bot will leave a comment on the PR with links to the run of that check that failed.
+
+As the PR author, it is your responsibility to evaluate the failed checks and determine if there are any changes necessary to pass the checks.
+If you suspect that the check failure was a flake, you can trigger retests by commenting `/retest` (or `/retest-required` for retesting only the required checks) on the PR.
+
+### Verifying your changes / Creating an OpenShift cluster from a PR
+
+As part of merging a PR, there is a requirement to verify that the changes you've made are working as expected using the `/verified` comment command.
+
+While there are a lot of scenarios where the existing CI/CD checks may be sufficient to verify your changes are working (and can be denoted by commenting `/verified by ci`),
+there may be scenarios where manual verification is required.
+
+You can use the `Cluster Bot` Slack App to create a cluster from a PR by sending it a message in the format of `launch ${OCP_VERSION},${PR_LINK} ${PLATFORM},${VARIANT}`.
+As an example, `launch 4.23,https://github.com/openshift/cluster-authentication-operator/pull/928 aws,techpreview` would launch an OpenShift 4.23 cluster with the changes made in openshift/cluster-authentication-operator#928 running on AWS with the TechPreviewNoUpgrade feature-set enabled.
+For more information on what `Cluster Bot` can do, you can send it a message saying `help` and it will respond with additional documentation on how it can be used.
+
+Once you've verified your changes work as expected, you can mark the PR as verified by commenting `/verified by @{your_github_handle}` on the PR.
+
+### Additional Resources
+
+For more information regarding more general OpenShift pull request processes, the following resources are helpful:
+
+- https://docs.ci.openshift.org/architecture/jira
+- https://docs.ci.openshift.org/
+- https://steps.ci.openshift.org/
+
+## Review Expectations
+
+### Requesting a review
+
+If you are not a member of the OpenShift control plane team and you need a review on a PR, post it in the [#forum-ocp-apiserver](https://redhat.enterprise.slack.com/archives/CB48XQ4KZ) Slack channel or
+reach out to folks outlined in the OWNERS file directly.
+
+If you are a member of the OpenShift control plane team, reviews should come from your feature team. In the event your feature team does not have someone that can approve
+a PR, post it in the [#control-plane](https://redhat.enterprise.slack.com/archives/CC3CZCQHM) Slack channel.
+
+OpenShift uses AI code review tools as part of the code review process.
+Before requesting a review, address all feedback from the code review agent(s).
+It is up to your discretion as the contributor how you would like to address that feedback.
+Responding with an explanation as to why you are not going to take action on a comment made
+by the agent is an acceptable way to "address" its feedback.
+
+### Interacting with reviewers
+
+When interacting with reviewers/approvers:
+
+- Be professional.
+- Be respectful of differing opinions, viewpoints, and experiences.
+- Gracefully give and receive constructive feedback.
+- Focus on what is best for the product/organization, not just us as individuals.
+
+A special note on the usage of AI - to respect the time of those that are reviewing your contribution, please do not use AI to respond to review comments.
+
+## OpenShift Tests Extension (OTE)
+
+This repository is compatible with the [OpenShift Tests Extension (OTE)](https://github.com/openshift-eng/openshift-tests-extension) framework.
+
+### Building the test binary
+
+```bash
+make build
+```
+
+### Running test suites and tests
+
+```bash
+# Run the serial suite
+./oc-tests-ext run-suite openshift/oc/conformance/serial
+
+# Run the parallel suite
+./oc-tests-ext run-suite openshift/oc/conformance/parallel
+
+# Run a specific test
+./oc-tests-ext run-test "test-name"
+
+# Run a suite with concurrency limited to 1 (serial execution)
+./oc-tests-ext run-suite openshift/oc/conformance/serial -c 1
+
+# Run with JUnit output
+./oc-tests-ext run-suite openshift/oc/conformance/serial --junit-path=/tmp/junit.xml
+```
+
+### Listing available tests and suites
+
+```bash
+# List all test suites
+./oc-tests-ext list suites
+
+# List tests in a suite
+./oc-tests-ext list tests --suite=openshift/oc/conformance/serial
+```
+
+For more information about the OTE framework, see the [openshift-tests-extension documentation](https://github.com/openshift-eng/openshift-tests-extension).

--- a/README.md
+++ b/README.md
@@ -6,13 +6,11 @@ which means it provides its full capabilities to connect with any kubernetes
 compliant cluster, and on top adds commands simplifying interaction with an
 OpenShift cluster.
 
+## Documentation
 
-# Contributing
-
-All contributions are welcome - oc uses the Apache 2 license and does not require
-any contributor agreement to submit patches.  Please open issues for any bugs
-or problems you encounter. You can also get involved with the [kubectl](https://github.com/kubernetes/kubectl)
-and the [Kubernetes project](https://github.com/kubernetes/kubernetes).
+- [CONTRIBUTING.md](CONTRIBUTING.md) — code conventions, testing, PR process, CI, review expectations (shared across OpenShift Control Plane repos)
+- [ARCHITECTURE.md](ARCHITECTURE.md) — design decisions, component relationships, the kubectl wrapper taxonomy
+- [AGENTS.md](AGENTS.md) — instructions for AI coding agents
 
 ## Building
 
@@ -25,98 +23,52 @@ debugging symbols, run `make STRIP_DEBUGGING_SYMBOLS=false oc`.
 In order to build `oc`, you will need the GSSAPI sources. On a Fedora/CentOS/RHEL
 workstation, install them with:
 
-```
-dnf install krb5-devel
-```
-
-Also:
-
-```
-dnf install gpgme-devel
-dnf install libassuan-devel
+```bash
+dnf install krb5-devel gpgme-devel libassuan-devel
 ```
 
-For MacOS you'll need to install a few brew packages before building locally. Install them with:
+For macOS, install build dependencies with:
+
+```bash
+brew install heimdal gpgme
 ```
-brew install heimdal
-brew install gpgme
-```
+
 ## Testing
 
-All PRs will have to pass a series of automated tests starting from go tools
-such as `go fmt` and `go vet`, through unit tests, up to e2e against a real cluster.
+All PRs must pass automated checks — `go fmt`, `go vet`, unit tests, and e2e tests against a real cluster.
 
-Locally you can invoke the initial verification and unit test through `make verify`
-and `make test`, accordingly.
+Locally you can run verification and unit tests with:
+
+```bash
+make verify
+make test
+```
 
 ## Dependencies
 
 Dependencies are managed through [Go Modules](https://github.com/golang/go/wiki/Modules).
-When updating any dependency the suggested workflow is:
+When updating any dependency:
 
 1. `go mod tidy`
 2. `go mod vendor`
 
+## Key Dependencies
 
-# Security Response
+| Repository | Role |
+|---|---|
+| [kubernetes/kubectl](https://github.com/kubernetes/kubectl) | Upstream CLI — oc wraps and extends it |
+| [k8s.io/client-go](https://github.com/kubernetes/client-go) | Kubernetes API client library |
+| [openshift/api](https://github.com/openshift/api) | OCP API type definitions |
+| [openshift/client-go](https://github.com/openshift/client-go) | Typed clients for OCP resources |
+| [openshift/library-go](https://github.com/openshift/library-go) | Shared OCP library code |
+| [openshift/build-machinery-go](https://github.com/openshift/build-machinery-go) | Standard Makefile targets |
 
-If you've found a security issue that you'd like to disclose confidentially
-please contact Red Hat's Product Security team. Details at
-https://access.redhat.com/security/team/contact
+## Security
 
-## Tests
+If you've found a security issue that you'd like to disclose confidentially, please contact Red Hat's Product Security team. Details at https://access.redhat.com/security/team/contact
 
-This repository is compatible with the "OpenShift Tests Extension (OTE)" framework.
+Do not file security issues as public GitHub issues.
 
-### Building the test binary
-```bash
-make build
-```
-
-### Running test suites and tests
-```bash
-# Run a specific test suite or test
-./oc-tests-ext run-suite openshift/oc/all
-./oc-tests-ext run-test "test-name"
-
-# Run with JUnit output
-./oc-tests-ext run-suite openshift/oc/all --junit-path=/tmp/junit-results/junit.xml
-./oc-tests-ext run-test "test-name" --junit-path=/tmp/junit-results/junit.xml
-```
-
-### Listing available tests and suites
-```bash
-# List all test suites
-./oc-tests-ext list-suites
-
-# List tests in a specific suite
-./oc-tests-ext list-tests openshift/oc/all
-```
-
-The test extension binary is included in the production image for CI/CD integration.
-
-
-# Claude Code
-
-This repository is set up for use with [Claude Code](https://docs.anthropic.com/en/docs/claude-code).
-Project-specific instructions live in `AGENTS.md`. When making changes, keep Claude's knowledge up to date —
-update `AGENTS.md` or the relevant agent definition in `.claude/agents/` if you discover conventions, patterns,
-or gotchas that would save time in future sessions. Keep these changes in a separate commit.
-
-Available agents in `.claude/agents/`:
-
-| Agent | Purpose |
-|-------|---------|
-| `code-reviewer` | PR code review — builds, verifies, reviews for Go style, breaking changes, and oc-specific concerns |
-| `tester` | Build, lint, and test runner — validates changes compile and pass tests |
-
-Available skills in `.claude/skills/`:
-
-| Skill | Purpose |
-|-------|---------|
-| `learn-session` | End-of-session knowledge extraction — reviews the conversation and proposes updates to docs |
-| `learn-history` | Deep analysis of all past sessions to extract recurring patterns worth documenting |
-
-# License
+## License
 
 oc is licensed under the [Apache License, Version 2.0](http://www.apache.org/licenses/).


### PR DESCRIPTION
Contextualization of the oc repository:

- ARCHITECTURE.md: new file covering the kubectl wrapper taxonomy, design decisions (Complete/Validate/Run, polymorphic helpers, scheme registration), upstream context, and runtime conventions
- CONTRIBUTING.md: adopt the shared OpenShift Control Plane contributing guidelines, adding the OTE section for oc
- README.md: slim down to project overview, build instructions, key dependencies, security contact, and pointers to other docs
- AGENTS.md: condense kubectl taxonomy to summary + pointer to ARCHITECTURE.md, add backporting rules, restore "do not diverge" rule
- .coderabbit.yaml: add ARCHITECTURE.md to knowledge base

## Note for the Reviewer

It may be better to just read the whole files, because things were moved around quite substantially.

But please do check for what was perhaps removed/lost and you would want it back.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Documentation**
  * Added an architecture overview guide covering kubectl integration, command lifecycle conventions, runtime behavior, and feature gating.
  * Expanded the contribution guide with clearer scope (including enhancement proposals), coding/testing expectations, PR/verification steps, and OpenShift Tests Extension usage.
  * Updated repository guidance for backporting and improved documentation navigation.
  * Refreshed README build/dependency guidance and reorganized security/license sections for clarity.

* **Chores**
  * Updated documentation knowledge-base configuration to include the new architecture guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->