### PR TITLE
NO-JIRA: Move test/e2e/accept.go to its own folder

### DIFF
--- a/test/e2e/admin/upgrade/OWNERS
+++ b/test/e2e/admin/upgrade/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - update-approvers

--- a/test/e2e/admin/upgrade/accept/accept.go
+++ b/test/e2e/admin/upgrade/accept/accept.go
@@ -12,14 +12,16 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+
+	"github.com/openshift/oc/test/e2e"
 )
 
 var _ = g.Describe("[sig-cli][OCPFeatureGate:ClusterUpdateAcceptRisks] oc", g.Label("cluster-version-operator"), func() {
 
 	var (
 		ctx            = context.TODO()
-		kubeConfigPath = KubeConfigPath()
-		oc             = NewCLI("oc", kubeConfigPath).EnvVar("OC_ENABLE_CMD_UPGRADE_ACCEPT_RISKS", "true")
+		kubeConfigPath = e2e.KubeConfigPath()
+		oc             = e2e.NewCLI("oc", kubeConfigPath).EnvVar("OC_ENABLE_CMD_UPGRADE_ACCEPT_RISKS", "true")
 		configClient   *configv1client.ConfigV1Client
 	)
 
@@ -29,8 +31,8 @@ var _ = g.Describe("[sig-cli][OCPFeatureGate:ClusterUpdateAcceptRisks] oc", g.La
 		configClient, err = configv1client.NewForConfig(config)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		skipIfMicroShift(oc)
-		SkipIfNotTechPreviewNoUpgrade(ctx, configClient)
+		e2e.SkipIfMicroShift(oc)
+		e2e.SkipIfNotTechPreviewNoUpgrade(ctx, configClient)
 
 		cv, err := configClient.ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/e2e/admin/upgrade/accept/accept.go
+++ b/test/e2e/admin/upgrade/accept/accept.go
@@ -1,4 +1,4 @@
-package e2e
+package accept
 
 import (
 	"context"

--- a/test/e2e/cli.go
+++ b/test/e2e/cli.go
@@ -30,7 +30,7 @@ var _ = g.Describe("[sig-cli] Workloads test oc works well", func() {
 
 	// author: knarra@redhat.com
 	g.It("ROSA-OSD_CCS-ARO-Author:knarra-Medium-48681-Could start debug pod using pod definition yaml", oteginkgo.Informing(), func() {
-		skipIfMicroShift(oc)
+		SkipIfMicroShift(oc)
 		buildPruningBaseDir := FixturePath("testdata", "oc_cli")
 		debugPodUsingDefinitionT := filepath.Join(buildPruningBaseDir, "debugpod_48681.yaml")
 
@@ -58,7 +58,7 @@ var _ = g.Describe("[sig-cli] Workloads test oc works well", func() {
 
 	// author: yinzhou@redhat.com
 	g.It("Author:yinzhou-NonPreRelease-Longduration-High-45307-Critical-45327-check oc adm prune deployments to prune RS [Serial][Timeout:30m]", oteginkgo.Informing(), func() {
-		skipIfMicroShift(oc)
+		SkipIfMicroShift(oc)
 		skipIfDisconnected(oc)
 		g.By("create new namespace")
 		oc.SetupProject()
@@ -114,7 +114,7 @@ var _ = g.Describe("[sig-cli] Workloads test oc works well", func() {
 
 	// author: yinzhou@redhat.com
 	g.It("ROSA-OSD_CCS-ARO-Author:yinzhou-Medium-49859-should failed when oc import-image setting with Garbage values for --reference-policy", oteginkgo.Informing(), func() {
-		skipIfMicroShift(oc)
+		SkipIfMicroShift(oc)
 		g.By("create new namespace")
 		oc.SetupProject()
 
@@ -131,7 +131,7 @@ var _ = g.Describe("[sig-cli] Workloads test oc works well", func() {
 
 	// author: yinzhou@redhat.com
 	g.It("ROSA-OSD_CCS-ARO-ConnectedOnly-NonPreRelease-Longduration-Author:yinzhou-High-42982-Describe quota output should always show units [Timeout:30m]", oteginkgo.Informing(), func() {
-		skipIfMicroShift(oc)
+		SkipIfMicroShift(oc)
 		skipIfDisconnected(oc)
 		if isBaselineCapsSet(oc, "None") || isBaselineCapsSet(oc, "v4.13") || isBaselineCapsSet(oc, "v4.12") || isBaselineCapsSet(oc, "v4.14") || isBaselineCapsSet(oc, "v4.15") || isBaselineCapsSet(oc, "v4.11") && !isEnabledCapability(oc, "DeploymentConfig") {
 			skipMsg := "Skipping the test as baselinecaps have been set to None and some of API capabilities are not enabled!"
@@ -229,7 +229,7 @@ var _ = g.Describe("[sig-cli] Workloads test oc works well", func() {
 
 	// author: yinzhou@redhat.com
 	g.It("ROSA-OSD_CCS-ARO-ConnectedOnly-Author:yinzhou-Medium-51018-oc adm release extract support manifest list", oteginkgo.Informing(), func() {
-		skipIfMicroShift(oc)
+		SkipIfMicroShift(oc)
 		skipIfDisconnected(oc)
 
 		if !assertPullSecret(oc) {
@@ -282,7 +282,7 @@ var _ = g.Describe("[sig-cli] Workloads test oc works well", func() {
 
 	// author: knarra@redhat.com
 	g.It("ROSA-OSD_CCS-ARO-ConnectedOnly-Author:knarra-Medium-66989-Workloads oc debug with or without init container for pod", oteginkgo.Informing(), func() {
-		skipIfMicroShift(oc)
+		SkipIfMicroShift(oc)
 		skipIfDisconnected(oc)
 
 		oc.SetupProject()
@@ -328,7 +328,7 @@ var _ = g.Describe("[sig-cli] Workloads test oc works well", func() {
 
 	// author: yinzhou@redhat.com
 	g.It("ROSA-OSD_CCS-ARO-Author:yinzhou-LEVEL0-Critical-63002-oc new-app propagate containerPort information to the deployment if import-mode is PreserveOriginal", oteginkgo.Informing(), func() {
-		skipIfMicroShift(oc)
+		SkipIfMicroShift(oc)
 		skipIfDisconnected(oc)
 		g.By("create new namespace")
 		oc.SetupProject()
@@ -342,7 +342,7 @@ var _ = g.Describe("[sig-cli] Workloads test oc works well", func() {
 
 	// author: knarra@redhat.com
 	g.It("ROSA-OSD_CCS-ARO-Author:knarra-LEVEL0-Critical-64921-Critical-63854-Verify oc adm release info and oc image extract using --idms-file flag", oteginkgo.Informing(), func() {
-		skipIfMicroShift(oc)
+		SkipIfMicroShift(oc)
 		skipIfDisconnected(oc)
 
 		buildPruningBaseDir := FixturePath("testdata", "oc_cli")
@@ -440,7 +440,7 @@ var _ = g.Describe("[sig-cli] Workloads test oc works well", func() {
 
 	// author: yinzhou@redhat.com
 	g.It("ROSA-OSD_CCS-ARO-ConnectedOnly-Author:yinzhou-High-67013-oc image mirror with multi-arch images and --filter-by-os", oteginkgo.Informing(), func() {
-		skipIfMicroShift(oc)
+		SkipIfMicroShift(oc)
 		skipIfDisconnected(oc)
 
 		if !assertPullSecret(oc) {
@@ -660,7 +660,7 @@ var _ = g.Describe("[sig-cli] Workloads client test", func() {
 
 	// author: yinzhou@redhat.com
 	g.It("ROSA-OSD_CCS-ARO-Longduration-NonPreRelease-Author:yinzhou-Medium-49395-oc debug node should exit when timeout [Timeout:30m]", oteginkgo.Informing(), func() {
-		skipIfMicroShift(oc)
+		SkipIfMicroShift(oc)
 		workerNodeList, err := GetClusterNodesBy(oc, "worker")
 		o.Expect(err).NotTo(o.HaveOccurred())
 		g.By("Create new namespace")
@@ -707,7 +707,7 @@ var _ = g.Describe("[sig-cli] Workloads client test", func() {
 
 	// author: yinzhou@redhat.com
 	g.It("Author:yinzhou-ROSA-OSD_CCS-ARO-NonPreRelease-High-68647-oc whoami must work without oauth-apiserver", oteginkgo.Informing(), func() {
-		skipIfMicroShift(oc)
+		SkipIfMicroShift(oc)
 		isExternalOIDCCluster, err := IsExternalOIDCCluster(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		if !isExternalOIDCCluster {
@@ -859,7 +859,7 @@ var _ = g.Describe("[sig-cli] Workloads client test", func() {
 
 	// author: yinzhou@redhat.com
 	g.It("ROSA-OSD_CCS-ARO-ConnectedOnly-Author:yinzhou-High-71178-Make sure no mismatch for sha256sum of openshift install for mac version", oteginkgo.Informing(), func() {
-		skipIfMicroShift(oc)
+		SkipIfMicroShift(oc)
 		skipIfDisconnected(oc)
 
 		if !assertPullSecret(oc) {
@@ -901,7 +901,7 @@ var _ = g.Describe("[sig-cli] Workloads client test", func() {
 
 	// author: yinzhou@redhat.com
 	g.It("ROSA-OSD_CCS-ARO-ConnectedOnly-Author:yinzhou-Medium-71273-Medium-71275-Validate user is able to extract rhel8 and rhel9 oc from the ocp payload", oteginkgo.Informing(), func() {
-		skipIfMicroShift(oc)
+		SkipIfMicroShift(oc)
 		skipIfDisconnected(oc)
 
 		if !assertPullSecret(oc) {
@@ -973,7 +973,7 @@ var _ = g.Describe("[sig-cli] Workloads client test", func() {
 	})
 	// author: yinzhou@redhat.com
 	g.It("ROSA-OSD_CCS-ARO-Author:yinzhou-Medium-72217-Should get warning when there is an identical short name for two or more resources", oteginkgo.Informing(), func() {
-		skipIfMicroShift(oc)
+		SkipIfMicroShift(oc)
 		customResourceBaseDir := FixturePath("testdata", "oc_cli/case72217")
 		cronTabCRDF := filepath.Join(customResourceBaseDir, "crd-crontab-72217.yaml")
 		cronCRF := filepath.Join(customResourceBaseDir, "cr-cron-72217.yaml")
@@ -1024,7 +1024,7 @@ var _ = g.Describe("[sig-cli] Workloads client test", func() {
 	})
 
 	g.It("Author:yinzhou-ROSA-OSD_CCS-ARO-Medium-76150-Make sure oc debug node has set HOST env var", oteginkgo.Informing(), func() {
-		skipIfMicroShift(oc)
+		SkipIfMicroShift(oc)
 		mnodeName, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node", "-o=jsonpath={.items[0].metadata.name}").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		By("Create new namespace")
@@ -1044,7 +1044,7 @@ var _ = g.Describe("[sig-cli] Workloads client test", func() {
 	})
 
 	g.It("Author:yinzhou-ROSA-OSD_CCS-ARO-High-76116-Make sure oc could run on rhel with fips on", oteginkgo.Informing(), func() {
-		skipIfMicroShift(oc)
+		SkipIfMicroShift(oc)
 		workerNodeList, err := GetClusterNodesBy(oc, "worker")
 		o.Expect(err).NotTo(o.HaveOccurred())
 		By("Create new namespace")
@@ -1077,7 +1077,7 @@ var _ = g.Describe("[sig-cli] Workloads client test", func() {
 	})
 
 	g.It("ROSA-OSD_CCS-ARO-ConnectedOnly-Author:yinzhou-Critical-11882-Return description of resources with cli describe", oteginkgo.Informing(), func() {
-		skipIfMicroShift(oc)
+		SkipIfMicroShift(oc)
 		skipIfDisconnected(oc)
 		By("Create new namespace")
 		oc.SetupProject()
@@ -1114,7 +1114,7 @@ var _ = g.Describe("[sig-cli] Workloads client test", func() {
 	})
 
 	g.It("Author:yinzhou-ROSA-OSD_CCS-ARO-High-76287-make sure tools imagestream contains sosreport", oteginkgo.Informing(), func() {
-		skipIfMicroShift(oc)
+		SkipIfMicroShift(oc)
 		// Skip the case if cluster doest not have the imageRegistry installed
 		if !isEnabledCapability(oc, "ImageRegistry") {
 			skipMsg := "Skipped: cluster does not have imageRegistry installed"

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1050,9 +1050,9 @@ func isMicroShiftCluster(oc *CLI) bool {
 	return false
 }
 
-// skipIfMicroShift skips the test if running on a MicroShift cluster.
+// SkipIfMicroShift skips the test if running on a MicroShift cluster.
 // Use this for tests that are not compatible with MicroShift.
-func skipIfMicroShift(oc *CLI) {
+func SkipIfMicroShift(oc *CLI) {
 	if isMicroShiftCluster(oc) {
 		skipMsg := "Skipping test: not supported on MicroShift cluster"
 		e2e.Warningf("SKIPPING TEST: %s", skipMsg)


### PR DESCRIPTION
The goal is to get additional approvers for the testing like we do for the core code.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added review ownership coverage for the admin upgrade end-to-end test area to ensure the right approvers can review future changes.
  * Updated the upgrade acceptance test package and setup to use the shared end-to-end test helpers for consistent CLI initialization and test gating.
  * Exported the shared MicroShift-skipping helper and updated relevant end-to-end CLI tests to use the standard skip function.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->