### PR TITLE
Fix must-gather hang: apply --timeout to log streaming phase

### DIFF
--- a/pkg/cli/admin/mustgather/mustgather.go
+++ b/pkg/cli/admin/mustgather/mustgather.go
@@ -833,9 +833,10 @@ func (o *MustGatherOptions) processNextWorkItem(ctx context.Context, ns string, 
 		log("gather did not start: %s", err)
 		return fmt.Errorf("gather did not start for pod %s: %w", pod.Name, err)
 	}
+
 	// stream gather container logs
 	if err := o.getGatherContainerLogs(ctx, pod); err != nil {
-		if !errors.Is(err, context.Canceled) {
+		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 			log("gather logs unavailable: %v", err)
 		}
 	}
@@ -947,6 +948,12 @@ func (o *MustGatherOptions) copyFilesFromPod(ctx context.Context, pod *corev1.Po
 }
 
 func (o *MustGatherOptions) getGatherContainerLogs(ctx context.Context, pod *corev1.Pod) error {
+	// Create a timeout context covering the entire gather lifecycle (waiting for
+	// container start, streaming logs, waiting for completion). Copying is
+	// intentionally excluded — per flag docs, it continues until finished.
+	gatherCtx, gatherCancel := context.WithTimeout(ctx, o.Timeout)
+	defer gatherCancel()
+
 	since2s := int64(2)
 	opts := &logs.LogsOptions{
 		Namespace:   pod.Namespace,
@@ -967,13 +974,13 @@ func (o *MustGatherOptions) getGatherContainerLogs(ctx context.Context, pod *cor
 		// gather script might take longer than the default API server time,
 		// so we should check if the gather script still runs and re-run logs
 		// thus we run this in a loop
-		if err := opts.RunLogsContext(ctx); err != nil {
+		if err := opts.RunLogsContext(gatherCtx); err != nil {
 			return err
 		}
 
 		// to ensure we don't print all of history set since to past 2 seconds
 		opts.Options.(*corev1.PodLogOptions).SinceSeconds = &since2s
-		if done, _ := o.isGatherDone(ctx, pod); done {
+		if done, _ := o.isGatherDone(gatherCtx, pod); done {
 			return nil
 		}
 		klog.V(4).Infof("lost logs, re-trying...")

--- a/pkg/cli/admin/mustgather/mustgather.go
+++ b/pkg/cli/admin/mustgather/mustgather.go
@@ -948,9 +948,7 @@ func (o *MustGatherOptions) copyFilesFromPod(ctx context.Context, pod *corev1.Po
 }
 
 func (o *MustGatherOptions) getGatherContainerLogs(ctx context.Context, pod *corev1.Pod) error {
-	// Create a timeout context covering the entire gather lifecycle (waiting for
-	// container start, streaming logs, waiting for completion). Copying is
-	// intentionally excluded — per flag docs, it continues until finished.
+	// Use a timeout context to prevent RunLogsContext or isGatherDone from waiting indefinitely
 	gatherCtx, gatherCancel := context.WithTimeout(ctx, o.Timeout)
 	defer gatherCancel()
 


### PR DESCRIPTION
getGatherContainerLogs had no timeout, blocking forever if gather scripts ran long. Wrap all gather phases in a shared deadline context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gather reliability by applying a single timeout across the gather lifecycle, including container startup, log streaming, and completion checks.
  * Reduced noisy errors when gather log streaming stops due to cancellation or timeout.
  * Ensured the gathered output download/copy step continues independently so it can finish after the gather process completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->