### PR TITLE
NO-JIRA: Register the e2e tests for accept in the subfolder

### DIFF
--- a/cmd/oc-tests-ext/dependencymagnet.go
+++ b/cmd/oc-tests-ext/dependencymagnet.go
@@ -5,4 +5,5 @@ package main
 import (
 	// Import test packages to register Ginkgo tests
 	_ "github.com/openshift/oc/test/e2e"
+	_ "github.com/openshift/oc/test/e2e/admin/upgrade/accept"
 )


### PR DESCRIPTION
It was missed in https://github.com/openshift/oc/pull/2294.

With the fix, the generated metadata from the build binary recognizes the tests in the subfolder:

```console
$ CGO_CFLAGS="-I/opt/homebrew/opt/heimdal/include" make build && ./oc-tests-ext update
$ cat .openshift-tests-extension/openshift_payload_oc.json| grep Serial | grep accept
      "name": "[sig-cli][OCPFeatureGate:ClusterUpdateAcceptRisks] oc can operate accept risks [Serial]",
$ rg 'accept risks' ./test/e2e
  ./test/e2e/admin/upgrade/accept/accept.go
  62:     g.It("can operate accept risks [Serial]", g.Label("tech-preview"), func() {
```

Apparently, my verification [there](https://github.com/openshift/oc/pull/2294#issuecomment-4876653466) looked at a wrong case.

Pushing the metadata to the repo ([cvo does it](https://github.com/openshift/cluster-version-operator/tree/main/.openshift-tests-extension)) may void a mistake like this but it might not be common practice and it might cause other troubles like [this one](https://redhat-internal.slack.com/archives/C07RDCVEYJG/p1751637388362499) (internal slack conversation). So I am not going there.

Notice that the above test case is not executed in the presubmit [oc-ote-serial](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_oc/2300/pull-ci-openshift-oc-main-e2e-aws-oc-ote-serial/2074255489469779968). However, this is not related to https://github.com/openshift/oc/pull/2294 because it has been  like that from day 1 https://github.com/openshift/oc/pull/2170 . It might be caused by `[OCPFeatureGate:ClusterUpdateAcceptRisks]` in the test name (although I have no proof for it). But I have [proof](https://github.com/openshift/oc/pull/2280) that the case is executed in some other jobs.

---

Update

> It might be caused by `[OCPFeatureGate:ClusterUpdateAcceptRisks]` in the test name (although I have no proof for it)

The proof came.
https://github.com/openshift/oc/pull/2302
The presubmit https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_oc/2302/pull-ci-openshift-oc-main-e2e-aws-oc-ote-serial/2074471953715957760 comes with

```console
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_oc/2302/pull-ci-openshift-oc-main-e2e-aws-oc-ote-serial/2074471953715957760/artifacts/e2e-aws-oc-ote-serial/openshift-e2e-test/artifacts/e2e.log
started: 0/1/2 "[sig-cli] oc can operate accept risks [Serial]"

skip [github.com/openshift/oc/test/e2e/util.go:1506]: This test is skipped because the Tech Preview NoUpgrade is not enabled

skipped: (100ms) 2026-07-07T14:00:32 "[sig-cli] oc can operate accept risks [Serial]"

started: 0/2/2 "[sig-cli] Workloads test oc works well Author:yinzhou-NonPreRelease-Longduration-High-45307-Critical-45327-check oc adm prune deployments to prune RS [Serial][Timeout:30m]"

passed: (1m8s) 2026-07-07T14:01:40 "[sig-cli] Workloads test oc works well Author:yinzhou-NonPreRelease-Longduration-High-45307-Critical-45327-check oc adm prune deployments to prune RS [Serial][Timeout:30m]"

Writing JUnit report to /logs/artifacts/junit/junit_e2e__20260707-135236.xml

Writing extension test results JSON to /logs/artifacts/junit/extension_test_result_e2e__20260707-135236.json
Writing extension test results HTML to /logs/artifacts/junit/extension_test_result_e2e__20260707-135236-summary.html
Writing extension test results HTML to /logs/artifacts/junit/extension_test_result_e2e__20260707-135236-everything.html
1 pass, 0 flaky, 1 skip (9m4s)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Included an additional test suite in the test binary so its scenarios are discovered and run automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->