### PR TITLE
NO-JIRA: Fix go vet warning in process.go

### DIFF
--- a/pkg/cli/process/process.go
+++ b/pkg/cli/process/process.go
@@ -312,7 +312,7 @@ func (o *ProcessOptions) RunProcess() error {
 		return nil
 	})
 	if len(duplicatedKeys) != 0 {
-		return o.usageErrorFn(fmt.Sprintf("The following parameters were provided more than once: %s", strings.Join(duplicatedKeys.List(), ", ")))
+		return o.usageErrorFn("The following parameters were provided more than once: %s", strings.Join(duplicatedKeys.List(), ", "))
 	}
 
 	if len(o.templateName) == 0 && len(o.filename) == 0 {


### PR DESCRIPTION
`usageErrorFn` has a printf-style signature (it wraps kcmdutil.UsageErrorf)
and expects to perform formatting itself. Passing a pre-formatted
fmt.Sprintf string as the format argument is both redundant and unsafe —
any literal % characters in parameter names would be misinterpreted as
format verbs.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Signed-off-by: Roman Feldman <rofeldma@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how duplicate template parameter errors are handled, while keeping the displayed usage message unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->