### PR TITLE
NO-JIRA: Fix staticcheck warnings in pkg/cli/admin/mustgather

### DIFF
--- a/pkg/cli/admin/mustgather/mustgather.go
+++ b/pkg/cli/admin/mustgather/mustgather.go
@@ -237,7 +237,7 @@ func (o *MustGatherOptions) Complete(f kcmdutil.Factory, cmd *cobra.Command, arg
 	}
 	// TODO: this should be in Validate() method, but added here because of the call to o.completeImages() below
 	if o.AllImages {
-		errStr := fmt.Sprintf("and --all-images are mutually exclusive: please specify one or the other")
+		errStr := "and --all-images are mutually exclusive: please specify one or the other"
 		if len(o.Images) != 0 {
 			return fmt.Errorf("--image %s", errStr)
 		}
@@ -333,10 +333,7 @@ func (o *MustGatherOptions) completeImages(ctx context.Context) error {
 	}
 	if o.AllImages {
 		// find all csvs and clusteroperators with the annotation "operators.openshift.io/must-gather-image"
-		pluginImages := make(map[string]struct{})
-		var err error
-
-		pluginImages, err = o.annotatedCSVs(ctx)
+		pluginImages, err := o.annotatedCSVs(ctx)
 		if err != nil {
 			return err
 		}
@@ -1340,7 +1337,7 @@ func (o *MustGatherOptions) BackupGathering(ctx context.Context, errs []error) {
 	fmt.Fprintf(o.ErrOut, "Falling back to `oc adm inspect %s` to collect basic cluster types.\n", typeTargets)
 
 	streams := o.IOStreams
-	streams.Out = o.newPrefixWriter(streams.Out, fmt.Sprintf("[must-gather      ] OUT"), false, true)
+	streams.Out = o.newPrefixWriter(streams.Out, "[must-gather      ] OUT", false, true)
 	destDir := path.Join(o.DestDir, fmt.Sprintf("inspect.local.%06d", rand.Int63()))
 
 	if err := runInspect(ctx, streams, rest.CopyConfig(o.Config), destDir, []string{typeTargets}); err != nil {
@@ -1352,7 +1349,6 @@ func (o *MustGatherOptions) BackupGathering(ctx context.Context, errs []error) {
 	if err := runInspect(ctx, streams, rest.CopyConfig(o.Config), destDir, namedTargets); err != nil {
 		fmt.Fprintf(o.ErrOut, "error completing cluster named resource inspection: %v\n", err)
 	}
-	return
 }
 
 func runInspect(ctx context.Context, streams genericiooptions.IOStreams, config *rest.Config, destDir string, arguments []string) error {

--- a/pkg/cli/admin/mustgather/summary.go
+++ b/pkg/cli/admin/mustgather/summary.go
@@ -162,7 +162,7 @@ func humanSummaryForClusterVersion(clusterVersion *configv1.ClusterVersion) stri
 
 	lastChangeHumanDuration := "<unknown>"
 	if len(clusterVersion.Status.History) > 0 {
-		lastChangeHumanDuration = units.HumanDuration(time.Now().Sub(clusterVersion.Status.History[0].StartedTime.Time))
+		lastChangeHumanDuration = units.HumanDuration(time.Since(clusterVersion.Status.History[0].StartedTime.Time))
 	}
 
 	progressingConditionMessage := "<unknown>"
@@ -182,7 +182,7 @@ func humanSummaryForClusterVersion(clusterVersion *configv1.ClusterVersion) stri
 	case isStable:
 		return fmt.Sprintf("Stable at %q", clusterVersion.Status.History[0].Version)
 	default:
-		return fmt.Sprintf("Unknown state")
+		return "Unknown state"
 	}
 }
 


### PR DESCRIPTION
## Description
Address several staticcheck findings in the must-gather package:

- Remove unnecessary `fmt.Sprintf` calls wrapping plain strings (S1039)
- Eliminate unused `make()` allocation overwritten on next line (SA4006)
- Use `time.Since` instead of `time.Now().Sub` (S1012)
- Remove redundant return at end of function (S1023)

## Changes
- `mustgather.go`: Remove two instances of `fmt.Sprintf` with no format verbs, consolidate variable declaration to avoid wasted allocation, remove trailing `return`
- `summary.go`: Replace `time.Now().Sub(x)` with idiomatic `time.Since(x)`, remove `fmt.Sprintf` with no format verbs

All changes are mechanical and do not alter runtime behavior.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the consistency of must-gather fallback output and cluster version status summaries.
  * Simplified option conflict handling and image resolution logic for more reliable behavior.

* **Chores**
  * Cleaned up internal string handling and removed a few unnecessary formatting steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->