### PR TITLE
NO-JIRA: Fix iterating over stream.Status.Tags

### DIFF
--- a/pkg/cli/admin/top/graph.go
+++ b/pkg/cli/admin/top/graph.go
@@ -68,13 +68,12 @@ func addImageStreamsToGraph(g genericgraph.Graph, streams *imagev1.ImageStreamLi
 		imageStreamNode := isNode.(*imagegraph.ImageStreamNode)
 
 		// connect IS with underlying images
-		for tag, history := range stream.Status.Tags {
-			for i := range history.Items {
-				image := history.Items[i]
+		for _, history := range stream.Status.Tags {
+			for i, image := range history.Items {
 				imageNode := imagegraph.FindImage(g, image.Image)
 				if imageNode == nil {
 					klog.V(2).Infof("Unable to find image %q in graph (from tag=%q, dockerImageReference=%s)",
-						history.Items[i].Image, tag, image.DockerImageReference)
+						image.Image, history.Tag, image.DockerImageReference)
 					continue
 				}
 				klog.V(4).Infof("Adding edge from %q to %q", imageStreamNode.UniqueName(), imageNode.UniqueName())


### PR DESCRIPTION
Iteration is over an `[]T`, not a `map[string]T`, tag string is in `T.Tag`.

Only affects log output. Mistake was AFAICT here from the start, but only showed up a typecheck error with go 1.26.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image stream graph handling so tag history is traversed more reliably when building the image relationships.
  * Updated diagnostics: when an expected image is missing, logs now report the correct tag and image reference, simplifying troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->