### PR TITLE
NO-JIRA: Handle wrapped ENOTSUP error

### DIFF
--- a/pkg/cli/image/archive/archive.go
+++ b/pkg/cli/image/archive/archive.go
@@ -2,6 +2,7 @@ package archive
 
 import (
 	"archive/tar"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -402,12 +403,12 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, L
 			continue
 		}
 		if err := system.Lsetxattr(path, key, []byte(value), 0); err != nil {
-			if err == system.ErrNotSupportedPlatform {
+			if errors.Is(err, system.ErrNotSupportedPlatform) {
 				// we ignore not supported platform errors
 				// to proceed archiving on platforms like darwin.
 				continue
 			}
-			if err == syscall.ENOTSUP {
+			if errors.Is(err, syscall.ENOTSUP) {
 				// We ignore errors here because not all graphdrivers support
 				// xattrs *cough* old versions of AUFS *cough*. However only
 				// ENOTSUP should be emitted in that case, otherwise we still


### PR DESCRIPTION
system.Lsetxattr wraps syscall errors in XattrError, so comparing the
result with == against syscall.ENOTSUP and ErrNotSupportedPlatform never
matched, causing layer extraction to fail on filesystems that do not
support xattrs instead of silently skipping them.

Replace both == comparisons with errors.Is.

Co-Authored-By: Claude Sonnet 4.6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when restoring archived files across platforms.
  * Unsupported extended-attribute operations are now handled reliably without interrupting extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->