### PR TITLE
NO-JIRA: Test for iotop-c rather than iotop

### DIFF
--- a/images/tools/Dockerfile
+++ b/images/tools/Dockerfile
@@ -8,7 +8,7 @@ COPY --from=builder /go/src/github.com/openshift/oc/oc /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/oc/images/tools/sos.conf /etc/sos/
 RUN for i in kubectl openshift-deploy openshift-docker-build openshift-sti-build openshift-git-clone openshift-manage-dockerfile openshift-extract-image-content openshift-recycle; do ln -sf /usr/bin/oc /usr/bin/$i; done
 # iotop has been deprecated. iotop-c is used in CentOS 10 and upwards
-RUN if yum install -y iotop >/dev/null 2>&1; then IOTOP_PKG="iotop"; else IOTOP_PKG="iotop-c"; fi && \
+RUN if yum install -y iotop-c >/dev/null 2>&1; then IOTOP_PKG="iotop-c"; else IOTOP_PKG="iotop"; fi && \
   INSTALL_PKGS="\
   bash-completion \
   bc \

--- a/images/tools/Dockerfile
+++ b/images/tools/Dockerfile
@@ -8,7 +8,7 @@ COPY --from=builder /go/src/github.com/openshift/oc/oc /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/oc/images/tools/sos.conf /etc/sos/
 RUN for i in kubectl openshift-deploy openshift-docker-build openshift-sti-build openshift-git-clone openshift-manage-dockerfile openshift-extract-image-content openshift-recycle; do ln -sf /usr/bin/oc /usr/bin/$i; done
 # iotop has been deprecated. iotop-c is used in CentOS 10 and upwards
-RUN if yum install -y iotop-c >/dev/null 2>&1; then IOTOP_PKG="iotop-c"; else IOTOP_PKG="iotop"; fi && \
+RUN IOTOP_PKG=$(yum repoquery iotop iotop-c 2>/dev/null|grep -m1 -oE 'iotop(-c)?') && \
   INSTALL_PKGS="\
   bash-completion \
   bc \


### PR DESCRIPTION
On el10, `yum install -y iotop` installs `iotop-c` and completes successfully. This causes `IOTOP_PKG` to be incorrectly set to `iotop`, and fail post install `rpm -V iotop` check.

Reverting to `yum list` (the original check) is not viable because `microdnf`, used in some base images, does not support the `list` subcommand.

Flipping the probe to try `iotop-c` first. On el10 this succeeds and sets `IOTOP_PKG=iotop-c`; on el9 `iotop-c` is not in repos so the install fails and `IOTOP_PKG=iotop` is used instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation compatibility for monitoring tools by selecting the available `iotop-c` package when supported, with an automatic fallback to `iotop`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->