### PR TITLE
NO-JIRA: First try newer iotop-c and fallback to older one

### DIFF
--- a/images/tools/Dockerfile
+++ b/images/tools/Dockerfile
@@ -8,7 +8,7 @@ COPY --from=builder /go/src/github.com/openshift/oc/oc /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/oc/images/tools/sos.conf /etc/sos/
 RUN for i in kubectl openshift-deploy openshift-docker-build openshift-sti-build openshift-git-clone openshift-manage-dockerfile openshift-extract-image-content openshift-recycle; do ln -sf /usr/bin/oc /usr/bin/$i; done
 # iotop has been deprecated. iotop-c is used in CentOS 10 and upwards
-RUN if yum install -y iotop >/dev/null 2>&1; then IOTOP_PKG="iotop"; else IOTOP_PKG="iotop-c"; fi && \
+RUN if yum install -y iotop-c >/dev/null 2>&1; then IOTOP_PKG="iotop-c"; else IOTOP_PKG="iotop"; fi && \
   INSTALL_PKGS="\
   bash-completion \
   bc \


### PR DESCRIPTION
This PR supersedes https://github.com/openshift/oc/pull/2315 to fix the okd-image failures (e.g. https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_oc/2308/pull-ci-openshift-oc-main-okd-scos-images/2077037933646319616).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tools image setup by preferring the modern `iotop-c` package and automatically falling back to `iotop` when unavailable.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->