### PR TITLE
OCPBUGS-100310: oc login --exec-plugin oc-oidc fails to refresh expired token against Microsoft Entra ID

### DIFF
--- a/pkg/cli/gettoken/oidc/client.go
+++ b/pkg/cli/gettoken/oidc/client.go
@@ -174,11 +174,16 @@ func NewAuthenticator(ctx context.Context, p *Provider, cacertdata string, cacer
 			}
 		}
 	}
+	endpoint := provider.Endpoint()
+	if p.ClientSecret == "" {
+		endpoint.AuthStyle = oauth2.AuthStyleInParams
+	}
+
 	return &client{
 		httpClient: httpClient,
 		provider:   provider,
 		oauth2Config: oauth2.Config{
-			Endpoint:     provider.Endpoint(),
+			Endpoint:     endpoint,
 			ClientID:     p.ClientID,
 			ClientSecret: p.ClientSecret,
 			Scopes:       append(p.ExtraScopes, gooidc.ScopeOpenID),


### PR DESCRIPTION
## Summary

Fixes token refresh failures against Microsoft Entra ID when using `oc login --exec-plugin oc-oidc`.

The `go-oidc` library's `Endpoint()` returns an `oauth2.Endpoint` without setting `AuthStyle`, which defaults to auto-detect. The `golang.org/x/oauth2` auto-detect mechanism tries `AuthStyleInHeader` (HTTP Basic Auth) first, sending `client_id` in the Authorization header rather than the POST body. Microsoft Entra ID does not support `client_secret_basic` — its discovery document only advertises `client_secret_post` and `private_key_jwt` — and rejects the request with `AADSTS900144: The request body must contain the following parameter: 'client_id'`.

This only manifests when the cached ID token has expired, since that is the only time a POST to the token endpoint is required.

## Changes

- Set `AuthStyle: oauth2.AuthStyleInParams` on the `oauth2.Endpoint` in `NewAuthenticator()` when `ClientSecret` is empty (public client), matching the approach used by [kubelogin](https://github.com/int128/kubelogin/blob/db494e487f9769281401c3133e698b2e2c30a8d5/pkg/oidc/client/factory.go#L67-L69). Confidential clients (with a client secret) continue to use auto-detect.

This is correct per [RFC 6749 §2.3.1](https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1) for public clients and is supported by all targeted OIDC providers. Verified that all seven supported providers advertise `client_secret_post` in their `token_endpoint_auth_methods_supported`:

| Provider | `client_secret_post` | `client_secret_basic` |
|---|---|---|
| Keycloak | Yes | Yes |
| Microsoft Entra ID | Yes | **No** |
| ADFS (Windows Server) | Yes | Yes |
| GitLab | Yes | Yes |
| Google | Yes | Yes |
| Okta | Yes | Yes |
| Ping Identity | Yes | Yes |

## Steps to Reproduce

1. `oc login <api-server> --exec-plugin oc-oidc --client-id <id> --issuer-url <entra-id-issuer>`
2. Wait for the ID token to expire (typically 1 hour)
3. Run the same `oc login` command again
4. **Before fix:** `AADSTS900144: The request body must contain the following parameter: 'client_id'`
5. **After fix:** Token refreshes successfully

## Additional notes for reviewers

There are no existing unit tests in `pkg/cli/gettoken/` or `pkg/cli/gettoken/oidc/`. Adding a meaningful unit test for this change would require significant test infrastructure that does not exist today: a mock OIDC discovery endpoint, a mock JWKS endpoint with test signing keys, a mock token endpoint that validates request format and returns signed JWTs, and JWT generation using the test keys. This is disproportionate to the change, which sets a standard configuration property on the `oauth2.Endpoint`. The fix is validated by the manual test plan below (initial login and token refresh against Entra ID and a second provider).

## Test Plan

- [x] Verify `oc login --exec-plugin oc-oidc` succeeds on initial login against Entra ID
- [x] Wait for token expiry and verify `oc login` refreshes the token without error
- [x] Verify initial login and token refresh against a non-Entra provider (e.g., Keycloak)
- [x] Verify confidential client flow (`--client-secret`) still works