### PR TITLE
OTA-1814: Handle accept risks with different commands

### DIFF
--- a/pkg/cli/admin/upgrade/recommend/examples/5.0.0-cvo-handling-risks.version-5.0.0-ec.3-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/5.0.0-cvo-handling-risks.version-5.0.0-ec.3-output
@@ -7,5 +7,5 @@ Release URL:
 Reason: TestAlert
 Message: Test alert for updates. https://github.com/openshift/runbooks/tree/master/alerts?runbook=notfound
 
-error: There are issues that apply to this cluster and have not been accepted. `oc adm upgrade accept` can be used to accept them: ConditionalUpdateRisk
+error: There are issues that apply to this cluster and have not been accepted. `oc adm upgrade accept` can be used to accept them: TestAlert
 

--- a/pkg/cli/admin/upgrade/recommend/recommend.go
+++ b/pkg/cli/admin/upgrade/recommend/recommend.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/kubectl/pkg/util/templates"
 
 	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/api/features"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned"
 )
 
@@ -139,7 +140,7 @@ func (o *options) Complete(f kcmdutil.Factory, cmd *cobra.Command, args []string
 
 func (o *options) Run(ctx context.Context) error {
 	issues := sets.New[string]()
-	accept := sets.New[string](o.accept...)
+	accept := sets.New[string]()
 
 	var cv *configv1.ClusterVersion
 	if cv = o.mockData.clusterVersion; cv == nil {
@@ -151,6 +152,31 @@ func (o *options) Run(ctx context.Context) error {
 			}
 			return err
 		}
+	}
+
+	cvoChecking, err := o.alertsEvaluatedByCVO(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to determine if the Cluster Version Operator is checking alerts: %w", err)
+	}
+	if cvoChecking && len(o.accept) > 0 {
+		return fmt.Errorf("`oc adm upgrade accept` is used to accept when the feature gate %s is enabled", features.FeatureGateClusterUpdateAcceptRisks)
+	}
+
+	if cvoChecking {
+		for _, risk := range cv.Status.ConditionalUpdateRisks {
+			for _, condition := range risk.Conditions {
+				if condition.Type == "Applies" && condition.Status != metav1.ConditionFalse {
+					issues.Insert(risk.Name)
+				}
+			}
+		}
+		if cv.Spec.DesiredUpdate != nil {
+			for _, risk := range cv.Spec.DesiredUpdate.AcceptRisks {
+				accept.Insert(risk.Name)
+			}
+		}
+	} else {
+		accept = accept.Insert(o.accept...)
 	}
 
 	if c := findClusterOperatorStatusCondition(cv.Status.Conditions, clusterStatusFailing); c != nil {
@@ -329,23 +355,21 @@ func (o *options) Run(ctx context.Context) error {
 					} else {
 						if !o.quiet {
 							reason := c.Reason
-							if accept.Has("ConditionalUpdateRisk") {
+							if !cvoChecking && accept.Has("ConditionalUpdateRisk") {
 								reason = fmt.Sprintf("accepted %s via ConditionalUpdateRisk", c.Reason)
 							}
 							fmt.Fprintf(o.Out, "Update to %s %s=%s:\nImage: %s\nRelease URL: %s\nReason: %s\nMessage: %s\n", update.Release.Version, c.Type, c.Status, update.Release.Image, update.Release.URL, reason, strings.ReplaceAll(c.Message, "\n", "\n  "))
 						}
-						issues.Insert("ConditionalUpdateRisk")
+						if !cvoChecking {
+							issues.Insert("ConditionalUpdateRisk")
+						}
 					}
 					unaccepted := issues.Difference(accept)
 					if unaccepted.Len() > 0 {
-						if cvoChecking, err := o.alertsEvaluatedByCVO(ctx); cvoChecking {
-							if err != nil {
-								return fmt.Errorf("failed to determine if CVO is checking alerts: %v", err)
-							}
+						if cvoChecking {
 							return fmt.Errorf("There are issues that apply to this cluster and have not been accepted. `oc adm upgrade accept` can be used to accept them: %s\n", strings.Join(sets.List(unaccepted), ","))
-						} else {
-							return fmt.Errorf("issues that apply to this cluster but which were not included in --accept: %s", strings.Join(sets.List(unaccepted), ","))
 						}
+						return fmt.Errorf("issues that apply to this cluster but which were not included in --accept: %s", strings.Join(sets.List(unaccepted), ","))
 					} else if issues.Len() > 0 && !o.quiet {
 						fmt.Fprintf(o.Out, "Update to %s has no known issues relevant to this cluster other than the accepted %s.\n", update.Release.Version, strings.Join(sets.List(issues), ","))
 					}


### PR DESCRIPTION
Follow up https://github.com/openshift/oc/pull/2279#discussion_r3597925292

* When CVO handles accept risks, oc gets risks from `cv.Status.ConditionalUpdateRisks` that applies to the cluster and ignores the ones from `cv.Spec.DesiredUpdate.AcceptRisks`. Moreover, error out early if `oc adm recommend --accept` is used.

* The special risk `ConditionalUpdateRisk` is considered only when CVO does NOT handle accept risks.

This change is required for https://github.com/openshift/origin/pull/31462 which is currently blocked because an error like [this](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-origin-31462-ci-5.0-e2e-aws-ovn-techpreview-serial-1of3/2083159136664555520). My hope is that this pull fixes that case.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Upgrade recommendations now adapt risk reporting to the active alert evaluation mode.
  * Recommendations derive issues and accepted risks from current cluster update data.

* **Bug Fixes**
  * The `--accept` option is now rejected when alerts are evaluated.
  * Error messages identify the specific unaccepted issue, such as `TestAlert`, instead of a generic risk label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->