### PR TITLE
OCPBUGS-101781: Isolate OCP-42982 kubeconfig writes

### DIFF
--- a/test/e2e/cli.go
+++ b/test/e2e/cli.go
@@ -176,7 +176,7 @@ var _ = g.Describe("[sig-cli] Workloads test oc works well", func() {
 		patchPath := fmt.Sprintf("-p=[{\"op\": \"replace\", \"path\": \"/spec/selector/annotations\", \"value\":{ \"openshift.io/requester\": \"%s\" }}]", userName)
 		err = oc.AsAdmin().WithoutNamespace().Run("patch").Args("clusterresourcequota", "for-user42982", "--type=json", patchPath).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
-		err = oc.WithoutNamespace().Run("new-project").Args("p42982-1").Execute()
+		err = oc.WithoutNamespace().Run("new-project").Args("p42982-1", "--skip-config-write").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		defer oc.AsAdmin().WithoutNamespace().Run("delete").Args("project", "p42982-1").Execute()
 		err = oc.WithoutNamespace().Run("create").Args("-f", deploymentconfigF, "-n", "p42982-1").Execute()


### PR DESCRIPTION
## What changed

Pass `--skip-config-write` when OCP-42982 creates its explicit `p42982-1` project. The project is still created, and the test already supplies `-n p42982-1` to the subsequent command.

## Root cause

`openshift-tests` runs extension tests concurrently with the same injected `KUBECONFIG`. OCP-42982 used `oc new-project p42982-1` without `--skip-config-write`, so `oc` rewrote that shared file to select a context named `p42982-1`. Other test processes could load the kubeconfig during that update and fail before their test body with either:

```text
invalid configuration: context was not found for specified context: p42982-1/...
```

or the same error plus `cluster has no server defined`.

The 5.0 CI stability study found 79 such observations across 72 builds from April 7 through July 24, 2026, spanning AWS, Azure, GCP, and bare metal. Every observed dangling context was named `p42982-1`, while the victim test varied; the long-running OCP-42982 test overlapped the sampled failures.

## Impact

Retained JUnit was streamed for all 72 affected builds. Fifty-seven builds had a passing retry, 15 had at least one unrecovered context failure, and 6 failed Prow jobs had no independent blocking failure. The conservative historical counterfactual is therefore **6 additional green Prow jobs**; no aggregate parent is additionally counted because each affected parent retained an unrelated aggregation failure.

## Validation

```text
GOTOOLCHAIN=auto GOMAXPROCS=2 go test -p=2 -run '^$' ./test/e2e
```
