### PR TITLE
OCPBUGS-8247: return error when --to-multi-arch is used on a multi-arch cluster

### DIFF
--- a/pkg/cli/admin/upgrade/upgrade.go
+++ b/pkg/cli/admin/upgrade/upgrade.go
@@ -246,10 +246,10 @@ func (o *Options) Run() error {
 
 	case o.ToMultiArch:
 		if cv.Status.Desired.Architecture == configv1.ClusterVersionArchitectureMulti {
-			return fmt.Errorf("Cluster is already multi-architecture")
+			return errors.New("the cluster already targets a multi-architecture release")
 		}
 		if cv.Spec.DesiredUpdate != nil && cv.Spec.DesiredUpdate.Architecture == configv1.ClusterVersionArchitectureMulti {
-			return fmt.Errorf("Cluster has already been requested to update to multi-architecture")
+			return errors.New("a multi-architecture release has already been requested")
 		}
 
 		if err := checkForUpgrade(cv); err != nil {

--- a/pkg/cli/admin/upgrade/upgrade.go
+++ b/pkg/cli/admin/upgrade/upgrade.go
@@ -245,8 +245,11 @@ func (o *Options) Run() error {
 		return nil
 
 	case o.ToMultiArch:
+		if cv.Status.Desired.Architecture == configv1.ClusterVersionArchitectureMulti {
+			return fmt.Errorf("Cluster is already multi-architecture")
+		}
 		if cv.Spec.DesiredUpdate != nil && cv.Spec.DesiredUpdate.Architecture == configv1.ClusterVersionArchitectureMulti {
-			return fmt.Errorf("info: Update to multi cluster architecture has already been requested")
+			return fmt.Errorf("Cluster has already been requested to update to multi-architecture")
 		}
 
 		if err := checkForUpgrade(cv); err != nil {


### PR DESCRIPTION
## Summary

Running `oc adm upgrade --to-multi-arch` on a cluster that is already multi-architecture did not return an error. The existing check only caught the case where a migration was *requested* (via `spec.desiredUpdate.architecture`) but not yet completed. After completion, CVO clears that field, so the command would attempt the patch again.

This adds a check on `status.desired.architecture` to detect clusters that are already running multi-architecture and return a clear error message.

Bug: https://redhat.atlassian.net/browse/OCPBUGS-8247

## Changes

- Added check: if `cv.Status.Desired.Architecture == ClusterVersionArchitectureMulti`, return `"Cluster is already multi-architecture"`
- This runs before the existing `spec.desiredUpdate` check, which catches in-progress migrations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and error messaging for multi-architecture upgrades.
  * Added clear messages when a cluster is already configured for multi-architecture or has an upgrade request in progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->