### PR TITLE
OCPBUGS-60640: return clean error for upgrade status on HyperShift clusters

### DIFF
--- a/pkg/cli/admin/upgrade/recommend/alerts.go
+++ b/pkg/cli/admin/upgrade/recommend/alerts.go
@@ -286,7 +286,7 @@ func (o *options) alertsEvaluatedByCVO(ctx context.Context) (bool, error) {
 
 	// if the AcceptRisks feature gate is enabled AND oc is not running against a hosted cluster,
 	// the CVO is handling alerts and will generate the Recommended condition if needed
-	return isAcceptRisksEnabled(featureGates, cv.Status.Desired.Version) && !isHostedCluster(infrastructure), nil
+	return isAcceptRisksEnabled(featureGates, cv.Status.Desired.Version) && !status.IsHostedCluster(infrastructure), nil
 }
 
 // isAcceptRisksEnabled checks to see if the 'ClusterUpdateAcceptRisks' feature gate is enabled
@@ -306,8 +306,4 @@ func isAcceptRisksEnabled(featureGate *configv1.FeatureGate, clusterVersion stri
 		}
 	}
 	return false
-}
-
-func isHostedCluster(i *configv1.Infrastructure) bool {
-	return i != nil && i.Status.ControlPlaneTopology == configv1.ExternalTopologyMode
 }

--- a/pkg/cli/admin/upgrade/recommend/alerts_test.go
+++ b/pkg/cli/admin/upgrade/recommend/alerts_test.go
@@ -5,6 +5,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/api/features"
+	"github.com/openshift/oc/pkg/cli/admin/upgrade/status"
 )
 
 func TestIsAcceptRisksEnabled(t *testing.T) {
@@ -122,7 +123,7 @@ func TestIsHypershiftEnabled(t *testing.T) {
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			actual := isHostedCluster(testCase.infrastructure)
+			actual := status.IsHostedCluster(testCase.infrastructure)
 
 			if actual != testCase.expected {
 				t.Errorf("%v != %v", actual, testCase.expected)

--- a/pkg/cli/admin/upgrade/status/status.go
+++ b/pkg/cli/admin/upgrade/status/status.go
@@ -207,6 +207,16 @@ func (o *options) Run(ctx context.Context) error {
 		return fmt.Errorf("no cluster operator information available - you must be connected to an OpenShift version 4 server")
 	}
 
+	if o.mockData.cvPath == "" {
+		infra, err := o.ConfigClient.ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if infra.Status.ControlPlaneTopology == configv1.ExternalTopologyMode {
+			return fmt.Errorf("upgrade status is not supported on Hosted Control Plane (HyperShift) clusters")
+		}
+	}
+
 	progressing := findClusterOperatorStatusCondition(cv.Status.Conditions, configv1.OperatorProgressing)
 	if progressing == nil {
 		return fmt.Errorf("no current %s info, see `oc describe clusterversion` for more details.\n", configv1.OperatorProgressing)

--- a/pkg/cli/admin/upgrade/status/status.go
+++ b/pkg/cli/admin/upgrade/status/status.go
@@ -210,7 +210,7 @@ func (o *options) Run(ctx context.Context) error {
 	if o.mockData.cvPath == "" {
 		infra, err := o.ConfigClient.ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to get cluster infrastructure: %w", err)
 		}
 		if infra.Status.ControlPlaneTopology == configv1.ExternalTopologyMode {
 			return fmt.Errorf("upgrade status is not supported on Hosted Control Plane (HyperShift) clusters")

--- a/pkg/cli/admin/upgrade/status/status.go
+++ b/pkg/cli/admin/upgrade/status/status.go
@@ -212,7 +212,7 @@ func (o *options) Run(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("failed to get cluster infrastructure: %w", err)
 		}
-		if infra.Status.ControlPlaneTopology == configv1.ExternalTopologyMode {
+		if IsHostedCluster(infra) {
 			return fmt.Errorf("upgrade status is not supported on Hosted Control Plane (HyperShift) clusters")
 		}
 	}
@@ -392,6 +392,11 @@ func findClusterOperatorStatusCondition(conditions []configv1.ClusterOperatorSta
 		}
 	}
 	return nil
+}
+
+// IsHostedCluster returns true if the cluster is a Hosted Control Plane (HyperShift) cluster.
+func IsHostedCluster(i *configv1.Infrastructure) bool {
+	return i != nil && i.Status.ControlPlaneTopology == configv1.ExternalTopologyMode
 }
 
 func getMCOImagePullSpec(deployment *appsv1.Deployment) string {


### PR DESCRIPTION
## Summary

`oc adm upgrade status` crashes on HyperShift/HCP clusters with "Error from server (NotFound): deployments.apps "machine-config-operator" not found" because it assumes the MCO deployment exists.

This adds an early check for `Infrastructure.status.controlPlaneTopology == External` (the canonical HyperShift detection pattern, already used in `recommend/alerts.go`) and returns a clean error message before any MCO/MCP API calls.

Bug: https://redhat.atlassian.net/browse/OCPBUGS-60640

## Changes

- Added HyperShift detection in `status.go` `Run()` using `ExternalTopologyMode` check
- Returns "upgrade status is not supported on Hosted Control Plane (HyperShift) clusters" instead of crashing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a clear error when attempting to check upgrade status for unsupported hosted control plane clusters.
  * Upgrade recommendations now consistently recognize hosted clusters.
  * Mock-data execution remains available without this validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->