### PR TITLE
OCPBUGS-100066: skip wildcard sources in IDMS/ICSP image reference parsing

### DIFF
--- a/pkg/cli/image/strategy/onerror.go
+++ b/pkg/cli/image/strategy/onerror.go
@@ -96,7 +96,7 @@ func alternativeImageSourcesICSP(imageRef reference.DockerImageReference, icspLi
 		repoDigestMirrors := icsp.Spec.RepositoryDigestMirrors
 		for _, rdm := range repoDigestMirrors {
 			if strings.HasPrefix(rdm.Source, "*.") {
-				klog.V(5).Infof("Skipping wildcard ICSP source %q", rdm.Source)
+				klog.V(5).Infof("Skipping wildcard ICSP source entry")
 				continue
 			}
 			var suffix string
@@ -234,7 +234,7 @@ func alternativeImageSourcesIDMS(imageRef reference.DockerImageReference, idmsLi
 		repoDigestMirrors := idms.Spec.ImageDigestMirrors
 		for _, rdm := range repoDigestMirrors {
 			if strings.HasPrefix(rdm.Source, "*.") {
-				klog.V(5).Infof("Skipping wildcard IDMS source %q", rdm.Source)
+				klog.V(5).Infof("Skipping wildcard IDMS source entry")
 				continue
 			}
 			var suffix string

--- a/pkg/cli/image/strategy/onerror.go
+++ b/pkg/cli/image/strategy/onerror.go
@@ -95,6 +95,10 @@ func alternativeImageSourcesICSP(imageRef reference.DockerImageReference, icspLi
 	for _, icsp := range icspList {
 		repoDigestMirrors := icsp.Spec.RepositoryDigestMirrors
 		for _, rdm := range repoDigestMirrors {
+			if strings.HasPrefix(rdm.Source, "*.") {
+				klog.V(5).Infof("Skipping wildcard ICSP source %q", rdm.Source)
+				continue
+			}
 			var suffix string
 			var err error
 			rdmSourceRef, err := reference.Parse(rdm.Source)
@@ -229,6 +233,10 @@ func alternativeImageSourcesIDMS(imageRef reference.DockerImageReference, idmsLi
 	for _, idms := range idmsList {
 		repoDigestMirrors := idms.Spec.ImageDigestMirrors
 		for _, rdm := range repoDigestMirrors {
+			if strings.HasPrefix(rdm.Source, "*.") {
+				klog.V(5).Infof("Skipping wildcard IDMS source %q", rdm.Source)
+				continue
+			}
 			var suffix string
 			var err error
 			rdmSourceRef, err := reference.Parse(rdm.Source)

--- a/pkg/cli/image/strategy/onerror_test.go
+++ b/pkg/cli/image/strategy/onerror_test.go
@@ -222,6 +222,50 @@ func TestOnErrorICSPStrategy(t *testing.T) {
 			image:                "quay.io/ocp-test/release:4.5",
 			imageSourcesExpected: []string{"quay.io/ocp-test/release"},
 		},
+		{
+			name: "wildcard source is skipped",
+			icspList: []operatorv1alpha1.ImageContentSourcePolicy{
+				{
+					Spec: operatorv1alpha1.ImageContentSourcePolicySpec{
+						RepositoryDigestMirrors: []operatorv1alpha1.RepositoryDigestMirrors{
+							{
+								Source: "*.redhat.com",
+								Mirrors: []string{
+									"mirror.internal/redhat",
+								},
+							},
+							{
+								Source: "quay.io/ocp-test/release",
+								Mirrors: []string{
+									"someregistry/mirrors/match",
+								},
+							},
+						},
+					},
+				},
+			},
+			image:                "quay.io/ocp-test/release:4.5",
+			imageSourcesExpected: []string{"quay.io/ocp-test/release", "someregistry/mirrors/match"},
+		},
+		{
+			name: "all wildcard sources skipped returns only original",
+			icspList: []operatorv1alpha1.ImageContentSourcePolicy{
+				{
+					Spec: operatorv1alpha1.ImageContentSourcePolicySpec{
+						RepositoryDigestMirrors: []operatorv1alpha1.RepositoryDigestMirrors{
+							{
+								Source: "*.redhat.com",
+								Mirrors: []string{
+									"mirror.internal/redhat",
+								},
+							},
+						},
+					},
+				},
+			},
+			image:                "quay.io/ocp-test/release:4.5",
+			imageSourcesExpected: []string{"quay.io/ocp-test/release"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -465,6 +509,50 @@ func TestOnErrorIDMSStrategy(t *testing.T) {
 		},
 		{
 			name:                 "no IDMS",
+			image:                "quay.io/ocp-test/release:4.5",
+			imageSourcesExpected: []string{"quay.io/ocp-test/release"},
+		},
+		{
+			name: "wildcard source is skipped",
+			idmsList: []apicfgv1.ImageDigestMirrorSet{
+				{
+					Spec: apicfgv1.ImageDigestMirrorSetSpec{
+						ImageDigestMirrors: []apicfgv1.ImageDigestMirrors{
+							{
+								Source: "*.redhat.com",
+								Mirrors: []apicfgv1.ImageMirror{
+									"mirror.internal/redhat",
+								},
+							},
+							{
+								Source: "quay.io/ocp-test/release",
+								Mirrors: []apicfgv1.ImageMirror{
+									"someregistry/mirrors/match",
+								},
+							},
+						},
+					},
+				},
+			},
+			image:                "quay.io/ocp-test/release:4.5",
+			imageSourcesExpected: []string{"quay.io/ocp-test/release", "someregistry/mirrors/match"},
+		},
+		{
+			name: "all wildcard sources skipped returns only original",
+			idmsList: []apicfgv1.ImageDigestMirrorSet{
+				{
+					Spec: apicfgv1.ImageDigestMirrorSetSpec{
+						ImageDigestMirrors: []apicfgv1.ImageDigestMirrors{
+							{
+								Source: "*.redhat.com",
+								Mirrors: []apicfgv1.ImageMirror{
+									"mirror.internal/redhat",
+								},
+							},
+						},
+					},
+				},
+			},
 			image:                "quay.io/ocp-test/release:4.5",
 			imageSourcesExpected: []string{"quay.io/ocp-test/release"},
 		},


### PR DESCRIPTION
## Bug

https://redhat.atlassian.net/browse/OCPBUGS-100066

`oc adm node-image create` fails with `invalid source "*.redhat.com": invalid reference format` when the cluster has an ImageDigestMirrorSet (IDMS) containing wildcard domain sources like `*.redhat.com` or `*.redhat.io`.

## Root Cause

In `pkg/cli/image/strategy/onerror.go`, the `alternativeImageSourcesIDMS()` and `alternativeImageSourcesICSP()` functions call `reference.Parse(rdm.Source)` on every IDMS/ICSP source entry. Wildcard sources (e.g. `*.redhat.com`) are valid in the IDMS CRD schema and handled correctly by CRI-O at runtime, but `reference.Parse()` rejects them because `*` is not a valid character in a Docker image reference.

## Fix

Skip IDMS/ICSP source entries that start with `*.` before attempting to parse them as Docker image references. These wildcard entries cannot be meaningfully matched to a specific image reference anyway, so skipping them is the correct behavior. A debug-level log message is emitted when a wildcard source is skipped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* **Bug Fixes**
  * Wildcard mirror sources beginning with `*.` are now skipped during image mirror resolution for ICSP and IDMS configurations.
  * Valid mirror entries continue to be used when mixed with wildcard entries.
  * Configurations containing only wildcard sources now correctly fall back to the original image source.
  * Wildcard entries are logged and excluded before further processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->