### PR TITLE
NO-JIRA: Fix issues collection when CVO handles the risks

### DIFF
--- a/pkg/cli/admin/upgrade/recommend/examples/5.0.0-includes-graph-and-alert-risks.version-5.0.0-ec.5-output
+++ b/pkg/cli/admin/upgrade/recommend/examples/5.0.0-includes-graph-and-alert-risks.version-5.0.0-ec.5-output
@@ -11,5 +11,5 @@ Message: This is a synthetic risk A that always applies for testing purposes htt
   
   Test alert for updates. https://github.com/openshift/runbooks/tree/master/alerts?runbook=notfound
 
-error: There are issues that apply to this cluster and have not been accepted. `oc adm upgrade accept` can be used to accept them: SyntheticRiskA,SyntheticRiskB,SyntheticRiskC,TestAlert
+error: There are issues that apply to this cluster and have not been accepted. `oc adm upgrade accept` can be used to accept them: SyntheticRiskA,SyntheticRiskB,TestAlert
 

--- a/pkg/cli/admin/upgrade/recommend/recommend.go
+++ b/pkg/cli/admin/upgrade/recommend/recommend.go
@@ -166,10 +166,12 @@ func (o *options) Run(ctx context.Context) error {
 		v := o.version.String()
 		for _, cu := range cv.Status.ConditionalUpdates {
 			if cu.Release.Version == v {
-				for _, risk := range cu.Risks {
-					for _, condition := range risk.Conditions {
-						if condition.Type == "Applies" && condition.Status != metav1.ConditionFalse {
-							issues.Insert(risk.Name)
+				for _, riskName := range cu.RiskNames {
+					if risk := findRiskByName(cv.Status.ConditionalUpdateRisks, riskName); risk != nil {
+						for _, condition := range risk.Conditions {
+							if condition.Type == "Applies" && condition.Status != metav1.ConditionFalse {
+								issues.Insert(risk.Name)
+							}
 						}
 					}
 				}
@@ -453,6 +455,15 @@ func (o *options) Run(ctx context.Context) error {
 		}
 	}
 
+	return nil
+}
+
+func findRiskByName(risks []configv1.ConditionalUpdateRisk, name string) *configv1.ConditionalUpdateRisk {
+	for _, risk := range risks {
+		if risk.Name == name {
+			return &risk
+		}
+	}
 	return nil
 }
 

--- a/pkg/cli/admin/upgrade/recommend/recommend.go
+++ b/pkg/cli/admin/upgrade/recommend/recommend.go
@@ -162,12 +162,18 @@ func (o *options) Run(ctx context.Context) error {
 		return fmt.Errorf("`oc adm upgrade accept` is used to accept when the feature gate %s is enabled", features.FeatureGateClusterUpdateAcceptRisks)
 	}
 
-	if cvoChecking {
-		for _, risk := range cv.Status.ConditionalUpdateRisks {
-			for _, condition := range risk.Conditions {
-				if condition.Type == "Applies" && condition.Status != metav1.ConditionFalse {
-					issues.Insert(risk.Name)
+	if cvoChecking && o.version != nil {
+		v := o.version.String()
+		for _, cu := range cv.Status.ConditionalUpdates {
+			if cu.Release.Version == v {
+				for _, risk := range cu.Risks {
+					for _, condition := range risk.Conditions {
+						if condition.Type == "Applies" && condition.Status != metav1.ConditionFalse {
+							issues.Insert(risk.Name)
+						}
+					}
 				}
+				break
 			}
 		}
 		if cv.Spec.DesiredUpdate != nil {


### PR DESCRIPTION
Follow up https://github.com/openshift/oc/pull/2349#discussion_r3727657701

The issues are used only for printing and attached to a specific version whose value is taken from `--to`. The version was not used when the issues are collected in the case of `cvoChecking`. This change fixes that.

/hold

I will rebase after https://github.com/openshift/oc/pull/2349 gets in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Upgrade recommendations now evaluate risks only for the explicitly requested version when CVO checking is enabled.
  * Risks are reported only when their conditions apply, improving the accuracy of upgrade issue detection.
  * When no version is specified, unrelated CVO risk issues are no longer added to recommendations.
  * Corrected the displayed list of unaccepted cluster issues by removing `SyntheticRiskC`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->