### PR TITLE
OCPBUGS-99549: Update docs.openshift.com base URL to point to OCP docs

### DIFF
--- a/pkg/cli/admin/release/extract_tools.go
+++ b/pkg/cli/admin/release/extract_tools.go
@@ -126,7 +126,7 @@ var (
 	The OpenShift installer \u0060openshift-install\u0060 makes it easy to get a cluster
 	running on the public cloud or your local infrastructure.
 
-	To learn more about installing OpenShift, visit [docs.openshift.com](https://docs.openshift.com)
+	To learn more about installing OpenShift, visit [docs.redhat.com](https://docs.redhat.com/en/documentation/openshift_container_platform/)
 	and select the version of OpenShift you are using.
 
 	## Installing the tools
@@ -149,7 +149,7 @@ var (
 	kube config file management, and access to developer tools. The \u0060kubectl\u0060
 	binary is included alongside for when strict Kubernetes compliance is necessary.
 
-	To learn more about OpenShift, visit [docs.openshift.com](https://docs.openshift.com)
+	To learn more about OpenShift, visit [docs.redhat.com](https://docs.redhat.com/en/documentation/openshift_container_platform/)
 	and select the version of OpenShift you are using.
 
 	## Installing the tools
@@ -175,7 +175,7 @@ var (
 	clusters, offering a number of advantages over \u0060kubectl.exe\u0060 such as easy login,
 	kube config file management, and access to developer tools.
 
-	To learn more about OpenShift, visit [docs.openshift.com](https://docs.openshift.com)
+	To learn more about OpenShift, visit [docs.redhat.com](https://docs.redhat.com/en/documentation/openshift_container_platform/)
 	and select the version of OpenShift you are using.
 
 	## Installing the tools
@@ -204,7 +204,7 @@ var (
 	The ccoctl tool provides various commands to assist with the creating and maintenance of
 	cloud credentials from outside the cluster (necessary when CCO is put in "Manual" mode).
 
-	To learn more about OpenShift, visit [docs.openshift.com](https://docs.openshift.com)
+	To learn more about OpenShift, visit [docs.redhat.com](https://docs.redhat.com/en/documentation/openshift_container_platform/)
 	and select the version of OpenShift you are using.
 
 	## Installing the tools
@@ -978,7 +978,7 @@ func (o *ExtractOptions) extractCommand(command string) error {
 			Client tools for OpenShift
 			--------------------------
 
-			These archives contain the client tooling for [OpenShift](https://docs.openshift.com).
+			These archives contain the client tooling for [OpenShift](https://docs.redhat.com/en/documentation/openshift_container_platform/).
 
 			To verify the contents of this directory, use the 'gpg' and 'shasum' tools to
 			ensure the archives you have downloaded match those published from this location.

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -96,7 +96,7 @@ var (
     allowing you to quickly switch between development and debugging. You can also run kubectl directly
     against any OpenShift cluster using the kubeconfig file created by 'oc login'.
 
-    For more on OpenShift, see the documentation at https://docs.openshift.com.
+    For more on OpenShift, see the documentation at https://docs.redhat.com/en/documentation/openshift_container_platform/.
 
     To see the full list of commands supported, run 'oc --help'.`)
 )

--- a/pkg/cli/set/volume.go
+++ b/pkg/cli/set/volume.go
@@ -65,7 +65,7 @@ var (
 		* secret (mounted secret): Secret volumes mount a named secret to the provided
 		  directory.
 
-		For descriptions on other volume types, see https://docs.openshift.com`)
+		For descriptions on other volume types, see https://docs.redhat.com/en/documentation/openshift_container_platform/`)
 
 	volumeExample = templates.Examples(`
 		# List volumes defined on all deployment configs in the current project


### PR DESCRIPTION
The docs.openshift.com URL does not lead to OCP docs. Other URLs containing that hostname are ok, they get redirected to the right page in the docs from what I tested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OpenShift documentation links across installer, CLI, Windows CLI, CCO utility, archive descriptions, and volume command help.
  * Links now point to the current Red Hat OpenShift documentation site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->