### PR TITLE
OCPBUGS-99013: inspect: Redact OAuthClient secrets

### DIFF
--- a/pkg/cli/admin/inspect/oauthclient.go
+++ b/pkg/cli/admin/inspect/oauthclient.go
@@ -1,0 +1,61 @@
+package inspect
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+
+	oauthv1 "github.com/openshift/api/oauth/v1"
+	"k8s.io/cli-runtime/pkg/resource"
+)
+
+var _ listAccessor = &oauthClientList{}
+
+type oauthClientList struct {
+	*oauthv1.OAuthClientList
+}
+
+func (c *oauthClientList) addItem(obj any) error {
+	structuredItem, ok := obj.(*oauthv1.OAuthClient)
+	if !ok {
+		return fmt.Errorf("unhandledStructuredItemType: %T", obj)
+	}
+	c.Items = append(c.Items, *structuredItem)
+	return nil
+}
+
+func inspectOAuthClientInfo(ctx context.Context, info *resource.Info, o *InspectOptions) error {
+	structuredObj, err := toStructuredObject[oauthv1.OAuthClient, oauthv1.OAuthClientList](info.Object)
+	if err != nil {
+		return err
+	}
+
+	switch castObj := structuredObj.(type) {
+	case *oauthv1.OAuthClient:
+		elideOAuthClient(castObj)
+
+	case *oauthv1.OAuthClientList:
+		for i := range castObj.Items {
+			elideOAuthClient(&castObj.Items[i])
+		}
+	}
+
+	dirPath := dirPathForInfo(o.DestDir, info)
+	filename := filenameForInfo(info)
+	if err := os.MkdirAll(dirPath, os.ModePerm); err != nil {
+		return err
+	}
+	return o.fileWriter.WriteFromResource(ctx, path.Join(dirPath, filename), structuredObj)
+}
+
+// elideOAuthClient replaces OAuthClient secret values with length stubs to prevent
+// sensitive credential material from being written to must-gather output.
+func elideOAuthClient(client *oauthv1.OAuthClient) {
+	if len(client.Secret) > 0 {
+		client.Secret = fmt.Sprintf("%d bytes long", len(client.Secret))
+	}
+	for i, s := range client.AdditionalSecrets {
+		client.AdditionalSecrets[i] = fmt.Sprintf("%d bytes long", len(s))
+	}
+}

--- a/pkg/cli/admin/inspect/oauthclient_test.go
+++ b/pkg/cli/admin/inspect/oauthclient_test.go
@@ -1,0 +1,60 @@
+package inspect
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	oauthv1 "github.com/openshift/api/oauth/v1"
+)
+
+func TestElideOAuthClient(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    oauthv1.OAuthClient
+		expected oauthv1.OAuthClient
+	}{
+		{
+			name:     "empty client is unchanged",
+			input:    oauthv1.OAuthClient{},
+			expected: oauthv1.OAuthClient{},
+		},
+		{
+			name: "secret is replaced with length stub",
+			input: oauthv1.OAuthClient{
+				Secret: "supersecret",
+			},
+			expected: oauthv1.OAuthClient{
+				Secret: "11 bytes long",
+			},
+		},
+		{
+			name: "additional secrets are replaced with length stubs",
+			input: oauthv1.OAuthClient{
+				AdditionalSecrets: []string{"abc", "abcdefgh"},
+			},
+			expected: oauthv1.OAuthClient{
+				AdditionalSecrets: []string{"3 bytes long", "8 bytes long"},
+			},
+		},
+		{
+			name: "both secret and additional secrets are elided",
+			input: oauthv1.OAuthClient{
+				Secret:            "topsecret",
+				AdditionalSecrets: []string{"additionalsecret"},
+			},
+			expected: oauthv1.OAuthClient{
+				Secret:            "9 bytes long",
+				AdditionalSecrets: []string{"16 bytes long"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			elideOAuthClient(&tt.input)
+			if diff := cmp.Diff(tt.expected, tt.input); diff != "" {
+				t.Errorf("elideOAuthClient() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/cli/admin/inspect/resource.go
+++ b/pkg/cli/admin/inspect/resource.go
@@ -7,6 +7,7 @@ import (
 	"path"
 
 	configv1 "github.com/openshift/api/config/v1"
+	oauthv1 "github.com/openshift/api/oauth/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -108,6 +109,12 @@ func InspectResource(ctx context.Context, info *resource.Info, resourceCtx *reso
 		}
 		return nil
 
+	case oauthv1.GroupVersion.WithResource("oauthclients").GroupResource():
+		if err := inspectOAuthClientInfo(ctx, info, o); err != nil {
+			return err
+		}
+		return nil
+
 	case admissionregistrationv1.SchemeGroupVersion.WithResource("mutatingwebhookconfigurations").GroupResource():
 		if err := gatherMutatingAdmissionWebhook(ctx, resourceCtx, info, o); err != nil {
 			return err
@@ -151,6 +158,9 @@ func newListAccessor(structuredList interface{}) (listAccessor, error) {
 
 	case *configv1.ProxyList:
 		return &proxyList{castObj}, nil
+
+	case *oauthv1.OAuthClientList:
+		return &oauthClientList{castObj}, nil
 
 	default:
 		return nil, fmt.Errorf("unhandledStructuredListType: %T", castObj)

--- a/pkg/cli/admin/inspect/resource_test.go
+++ b/pkg/cli/admin/inspect/resource_test.go
@@ -1,0 +1,132 @@
+package inspect
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	oauthv1 "github.com/openshift/api/oauth/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/printers"
+	"k8s.io/cli-runtime/pkg/resource"
+	"sigs.k8s.io/yaml"
+)
+
+// TestInspectResource verifies that InspectResource writes redacted output for
+// each supported resource type. Actual output is compared against fixtures in
+// testdata/; run with -update to regenerate them.
+func TestInspectResource(t *testing.T) {
+	tests := []struct {
+		name       string
+		info       func(t *testing.T) *resource.Info
+		outputPath func(destDir string) string
+		fixture    string
+	}{
+		{
+			name: "OAuthClient secrets are redacted",
+			info: func(t *testing.T) *resource.Info {
+				client := &oauthv1.OAuthClient{
+					TypeMeta:          metav1.TypeMeta{APIVersion: "oauth.openshift.io/v1", Kind: "OAuthClient"},
+					ObjectMeta:        metav1.ObjectMeta{Name: "console"},
+					Secret:            "supersecret",
+					AdditionalSecrets: []string{"oldsecret"},
+				}
+				m, err := runtime.DefaultUnstructuredConverter.ToUnstructured(client)
+				if err != nil {
+					t.Fatal("unable to convert to unstructured:", err)
+				}
+				return &resource.Info{
+					Object: &unstructured.Unstructured{Object: m},
+					Name:   "console",
+					Mapping: &apimeta.RESTMapping{
+						Resource:         schema.GroupVersionResource{Group: "oauth.openshift.io", Version: "v1", Resource: "oauthclients"},
+						GroupVersionKind: oauthv1.GroupVersion.WithKind("OAuthClient"),
+					},
+				}
+			},
+			outputPath: func(destDir string) string {
+				return filepath.Join(destDir, "cluster-scoped-resources", "oauth.openshift.io", "oauthclients", "console.yaml")
+			},
+			fixture: "testdata/oauthclient-redacted.yaml",
+		},
+		{
+			name: "OAuthClientList secrets are redacted",
+			info: func(t *testing.T) *resource.Info {
+				makeItem := func(name, secret string, additional []string) unstructured.Unstructured {
+					client := &oauthv1.OAuthClient{
+						TypeMeta:          metav1.TypeMeta{APIVersion: "oauth.openshift.io/v1", Kind: "OAuthClient"},
+						ObjectMeta:        metav1.ObjectMeta{Name: name},
+						Secret:            secret,
+						AdditionalSecrets: additional,
+					}
+					m, err := runtime.DefaultUnstructuredConverter.ToUnstructured(client)
+					if err != nil {
+						t.Fatal("unable to convert to unstructured:", err)
+					}
+					return unstructured.Unstructured{Object: m}
+				}
+				return &resource.Info{
+					Object: &unstructured.UnstructuredList{
+						Object: map[string]any{
+							"apiVersion": "oauth.openshift.io/v1",
+							"kind":       "OAuthClientList",
+						},
+						Items: []unstructured.Unstructured{
+							makeItem("console", "supersecret", []string{"oldsecret"}),
+							makeItem("another", "anothersecret", nil),
+						},
+					},
+					Mapping: &apimeta.RESTMapping{
+						Resource:         schema.GroupVersionResource{Group: "oauth.openshift.io", Version: "v1", Resource: "oauthclients"},
+						GroupVersionKind: oauthv1.GroupVersion.WithKind("OAuthClientList"),
+					},
+				}
+			},
+			outputPath: func(destDir string) string {
+				return filepath.Join(destDir, "cluster-scoped-resources", "oauth.openshift.io", "oauthclients.yaml")
+			},
+			fixture: "testdata/oauthclientlist-redacted.yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			destDir := t.TempDir()
+			o := &InspectOptions{
+				DestDir:    destDir,
+				fileWriter: NewMultiSourceWriter(&printers.YAMLPrinter{}),
+			}
+
+			if err := InspectResource(context.Background(), tt.info(t), NewResourceContext(nil), o); err != nil {
+				t.Fatalf("InspectResource failed: %v", err)
+			}
+
+			actualBytes, err := os.ReadFile(tt.outputPath(destDir))
+			if err != nil {
+				t.Fatalf("failed to read output file: %v", err)
+			}
+			fixtureBytes, err := os.ReadFile(tt.fixture)
+			if err != nil {
+				t.Fatalf("failed to read fixture %s: %v", tt.fixture, err)
+			}
+
+			var actual, expected map[string]any
+			if err := yaml.Unmarshal(actualBytes, &actual); err != nil {
+				t.Fatalf("failed to parse actual output: %v", err)
+			}
+			if err := yaml.Unmarshal(fixtureBytes, &expected); err != nil {
+				t.Fatalf("failed to parse fixture: %v", err)
+			}
+
+			if diff := cmp.Diff(expected, actual); diff != "" {
+				t.Errorf("output mismatch with fixture %s (-want +got):\n%s", tt.fixture, diff)
+			}
+		})
+	}
+}

--- a/pkg/cli/admin/inspect/testdata/oauthclient-redacted.yaml
+++ b/pkg/cli/admin/inspect/testdata/oauthclient-redacted.yaml
@@ -1,0 +1,7 @@
+apiVersion: oauth.openshift.io/v1
+kind: OAuthClient
+metadata:
+  name: console
+secret: 11 bytes long
+additionalSecrets:
+  - 9 bytes long

--- a/pkg/cli/admin/inspect/testdata/oauthclientlist-redacted.yaml
+++ b/pkg/cli/admin/inspect/testdata/oauthclientlist-redacted.yaml
@@ -1,0 +1,16 @@
+apiVersion: oauth.openshift.io/v1
+kind: OAuthClientList
+metadata: {}
+items:
+- apiVersion: oauth.openshift.io/v1
+  kind: OAuthClient
+  metadata:
+    name: console
+  secret: 11 bytes long
+  additionalSecrets:
+    - 9 bytes long
+- apiVersion: oauth.openshift.io/v1
+  kind: OAuthClient
+  metadata:
+    name: another
+  secret: 13 bytes long


### PR DESCRIPTION
OAuthClient.Secret and OAuthClient.AdditionalSecrets were written to disk in plaintext when an OAuthClient appeared in must-gather output (either directly or via a ClusterOperator's relatedObjects). This adds an elideOAuthClient handler that replaces secret values with length stubs, consistent with how Secret data and proxy credentials are already treated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added inspection support for OAuth clients and OAuth client lists.
  * Inspection results can be exported using the configured output format.
  * OAuth client secrets are safely redacted and represented by their byte lengths.

* **Bug Fixes**
  * Invalid structured resource types now return a clear inspection error.

* **Tests**
  * Added coverage for individual and list-based OAuth client inspection, including secret redaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->