### PR TITLE
OCPBUGS-105504,OCPBUGS-105503: Fix pre-existing unit test failures on release-4.19

### DIFF
--- a/pkg/helpers/newapp/newapptest/newapp_test.go
+++ b/pkg/helpers/newapp/newapptest/newapp_test.go
@@ -530,7 +530,7 @@ func TestNewAppRunAll(t *testing.T) {
 					SourceRepositories: []string{"https://github.com/openshift/sti-ruby"},
 				},
 				GenerationInputs: cmd.GenerationInputs{
-					ContextDir: "3.1/test/rack-test-app",
+					ContextDir: "3.3/test/rack-test-app",
 				},
 
 				Resolvers: cmd.Resolvers{

--- a/pkg/helpers/source-to-image/git/url_test.go
+++ b/pkg/helpers/source-to-image/git/url_test.go
@@ -94,11 +94,11 @@ func TestParse(t *testing.T) {
 			},
 		},
 		parseTest{
-			rawurl: "http://[::ffff:1.2.3.4]:443",
+			rawurl: "http://[2001:db8::1]:443",
 			expectedGitURL: &URL{
 				URL: url.URL{
 					Scheme: "http",
-					Host:   "[::ffff:1.2.3.4]:443",
+					Host:   "[2001:db8::1]:443",
 				},
 				Type: URLTypeURL,
 			},
@@ -165,10 +165,10 @@ func TestParse(t *testing.T) {
 			},
 		},
 		parseTest{
-			rawurl: "[::ffff:1.2.3.4]:",
+			rawurl: "[2001:db8::1]:",
 			expectedGitURL: &URL{
 				URL: url.URL{
-					Host: "[::ffff:1.2.3.4]",
+					Host: "[2001:db8::1]",
 				},
 				Type: URLTypeSCP,
 			},


### PR DESCRIPTION
## Summary

Fixes two pre-existing unit test failures in `pkg/helpers/newapp/newapptest`
and `pkg/helpers/source-to-image/git` that block all PRs on release-4.19.
Both fixes align with changes already applied on the `main` branch.

## Changes

### 1. Fix TestNewAppRunAll/app_generation_using_context_dir

The test clones `openshift/sti-ruby` and references
`ContextDir: "3.1/test/rack-test-app"`, but the `3.1/` directory was
removed from the upstream repository.

**Fix:** Update `ContextDir` from `"3.1/test/rack-test-app"` to
`"3.3/test/rack-test-app"` in `pkg/helpers/newapp/newapptest/newapp_test.go`.

### 2. Fix TestParse (release-4.19 only)

Two test cases use IPv4-mapped IPv6 addresses (`::ffff:1.2.3.4`) which
Go 1.23 rejects in `url.Parse()` as `invalid IPv6 host`.

**Fix:** Replace `::ffff:1.2.3.4` with the standard IPv6 documentation
address `2001:db8::1` in `pkg/helpers/source-to-image/git/url_test.go`.

## References

- Jira: https://issues.redhat.com/browse/OCPBUGS-73893, https://redhat.atlassian.net/browse/OCPBUGS-105504
- Original fix on main: https://github.com/openshift/oc/pull/2184, https://github.com/openshift/oc/pull/2123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration test fixtures to use the current application repository context.
  * Refined IPv6 URL parsing test cases with standardized documentation addresses and expected host formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->