### PR TITLE
OCPBUGS-85019: oc login: Fix polluting KUBECONFIG file

### DIFF
--- a/pkg/helpers/kubeconfig/smart_merge.go
+++ b/pkg/helpers/kubeconfig/smart_merge.go
@@ -155,8 +155,9 @@ func MergeConfig(startingConfig, addition clientcmdapi.Config) (*clientcmdapi.Co
 // findExistingContextName finds the nickname for the passed context
 func findExistingContextName(haystack clientcmdapi.Config, needle clientcmdapi.Context) string {
 	for key, context := range haystack.Contexts {
-		context.LocationOfOrigin = ""
-		if reflect.DeepEqual(context, needle) {
+		contextCopy := context.DeepCopy()
+		contextCopy.LocationOfOrigin = ""
+		if reflect.DeepEqual(contextCopy, needle) {
 			return key
 		}
 	}

--- a/pkg/helpers/kubeconfig/smart_merge_test.go
+++ b/pkg/helpers/kubeconfig/smart_merge_test.go
@@ -1,0 +1,98 @@
+package kubeconfig
+
+import (
+	"path/filepath"
+	"testing"
+
+	restclient "k8s.io/client-go/rest"
+	clientcmd "k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+// TestLoginDoesNotCopySecondaryFileContextsToDefaultFile verifies that when KUBECONFIG
+// lists multiple files, oc login does not copy contexts from secondary files into the
+// first (default) file.
+func TestLoginDoesNotCopySecondaryFileContextsToDefaultFile(t *testing.T) {
+	dir := t.TempDir()
+	primaryFile := filepath.Join(dir, "config")
+	secondaryFile := filepath.Join(dir, "secondary.yaml")
+
+	// Primary file: empty config (no clusters/contexts/users)
+	if err := clientcmd.WriteToFile(*clientcmdapi.NewConfig(), primaryFile); err != nil {
+		t.Fatal(err)
+	}
+
+	// Secondary file: an existing cluster with context and credentials
+	secondaryConfig := clientcmdapi.NewConfig()
+	secondaryConfig.Clusters["sandbox"] = &clientcmdapi.Cluster{
+		Server: "https://sandbox.example.com:6443",
+	}
+	secondaryConfig.AuthInfos["sandbox"] = &clientcmdapi.AuthInfo{
+		Token: "sandbox-token",
+	}
+	secondaryConfig.Contexts["sandbox"] = &clientcmdapi.Context{
+		Cluster:   "sandbox",
+		AuthInfo:  "sandbox",
+		Namespace: "sandbox-ns",
+	}
+	if err := clientcmd.WriteToFile(*secondaryConfig, secondaryFile); err != nil {
+		t.Fatal(err)
+	}
+
+	// Load both files as a merged starting config, the way oc does when
+	// KUBECONFIG=primaryFile:secondaryFile. The loader stamps LocationOfOrigin
+	// on every entry so ModifyConfig can route writes back to the right file.
+	loadingRules := &clientcmd.ClientConfigLoadingRules{
+		Precedence: []string{primaryFile, secondaryFile},
+	}
+	startingConfig, err := loadingRules.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate logging in to a new cluster (the addition produced by CreateConfig).
+	newLoginConfig, err := CreateConfig("my-project", "alice", &restclient.Config{
+		Host:        "https://new-cluster.example.com:6443",
+		BearerToken: "alice-token",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	configToWrite, err := MergeConfig(*startingConfig, *newLoginConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// PathOptions mirrors what SaveConfig sets up: primary file is the default
+	// write target; both files are in the loading precedence list.
+	pathOptions := &clientcmd.PathOptions{
+		GlobalFile: primaryFile,
+		EnvVar:     "", // no env-var lookup — keeps the test hermetic
+		LoadingRules: &clientcmd.ClientConfigLoadingRules{
+			Precedence: []string{primaryFile, secondaryFile},
+		},
+	}
+	if err := clientcmd.ModifyConfig(pathOptions, *configToWrite, false); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read primary file in isolation and assert it contains the new login context
+	// but not anything that originated in the secondary file.
+	result, err := clientcmd.LoadFromFile(primaryFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := result.Contexts["sandbox"]; ok {
+		t.Error("primary config must not contain the sandbox context from the secondary file")
+	}
+	if _, ok := result.Clusters["sandbox"]; ok {
+		t.Error("primary config must not contain the sandbox cluster from the secondary file")
+	}
+	if _, ok := result.AuthInfos["sandbox"]; ok {
+		t.Error("primary config must not contain the sandbox user from the secondary file")
+	}
+	if _, ok := result.Contexts["my-project/new-cluster-example-com:6443/alice"]; !ok {
+		t.Error("primary config must contain the new login context")
+	}
+}


### PR DESCRIPTION
oc login currently pulls data from secondary KUBECONFIG files into the primary one. This should be now fixed. An explanation follows:

findExistingContextName ranged over haystack.Contexts (map[string]*Context) and set context.LocationOfOrigin = "" through the pointer, mutating the actual Context objects in memory. Since MergeConfig uses a shallow copy
(ret := startingConfig), those same objects back the configToWrite passed to ModifyConfig.

ModifyConfig then compared the cleared LocationOfOrigin against a freshly disk-loaded copy (which had the correct source path), saw a difference, and routed the write to GetDefaultFilename() — the first file in KUBECONFIG — instead of the original source file. This caused contexts from secondary kubeconfig files to appear in the primary file.

Fix by dereferencing into a value copy before clearing LocationOfOrigin so the search does not mutate the haystack.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented login updates from unintentionally copying clusters, contexts, or credentials from secondary kubeconfig files into the primary configuration.
  * Preserved existing kubeconfig context data during configuration comparisons and merges.

* **Tests**
  * Added regression coverage to verify that login data updates only the intended kubeconfig file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->