### PR TITLE
NO-JIRA: Add --proxy-url support to oc login

### DIFF
--- a/pkg/cli/login/helpers.go
+++ b/pkg/cli/login/helpers.go
@@ -17,6 +17,34 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
+// parseProxyURL validates a kubeconfig-style proxy URL.
+// Schemes match client-go's kubeconfig proxy-url validation.
+func parseProxyURL(proxyURL string) (*url.URL, error) {
+	u, err := url.Parse(proxyURL)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse: %v", proxyURL)
+	}
+
+	switch u.Scheme {
+	case "http", "https", "socks5":
+	default:
+		return nil, fmt.Errorf("unsupported scheme %q, must be http, https, or socks5", u.Scheme)
+	}
+	return u, nil
+}
+
+// setClientConfigProxy configures rest.Config.Proxy from a proxy URL string.
+// When set, client-go uses this instead of HTTPS_PROXY/HTTP_PROXY, and
+// CreateConfig persists it to the kubeconfig cluster's proxy-url field.
+func setClientConfigProxy(clientConfig *restclient.Config, proxyURL string) error {
+	u, err := parseProxyURL(proxyURL)
+	if err != nil {
+		return err
+	}
+	clientConfig.Proxy = http.ProxyURL(u)
+	return nil
+}
+
 // getMatchingClusters examines the kubeconfig for all clusters that point to the same server
 func getMatchingClusters(clientConfig restclient.Config, kubeconfig clientcmdapi.Config) sets.String {
 	ret := sets.String{}

--- a/pkg/cli/login/helpers.go
+++ b/pkg/cli/login/helpers.go
@@ -3,6 +3,7 @@ package login
 import (
 	"bytes"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -19,20 +20,21 @@ import (
 )
 
 // parseProxyURL validates a kubeconfig-style proxy URL.
-// Schemes match client-go's kubeconfig proxy-url validation.
+// Supported schemes match client-go's kubeconfig proxy-url validation.
+// Errors never include the raw URL, which may contain credentials.
 func parseProxyURL(proxyURL string) (*url.URL, error) {
 	u, err := url.Parse(proxyURL)
 	if err != nil {
-		return nil, fmt.Errorf("could not parse: %v", proxyURL)
+		return nil, errors.New("invalid --proxy-url: could not parse")
 	}
 
 	switch u.Scheme {
 	case "http", "https", "socks5":
 	default:
-		return nil, fmt.Errorf("unsupported scheme %q, must be http, https, or socks5", u.Scheme)
+		return nil, fmt.Errorf("invalid --proxy-url: unsupported scheme %q, must be http, https, or socks5", u.Scheme)
 	}
-	if len(u.Host) == 0 {
-		return nil, fmt.Errorf("host must be specified")
+	if u.Hostname() == "" {
+		return nil, errors.New("invalid --proxy-url: host must be specified")
 	}
 	return u, nil
 }

--- a/pkg/cli/login/helpers.go
+++ b/pkg/cli/login/helpers.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 
+	cliconfig "github.com/openshift/oc/pkg/helpers/kubeconfig"
 	"github.com/openshift/oc/pkg/helpers/term"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/cli-runtime/pkg/printers"
@@ -29,6 +30,9 @@ func parseProxyURL(proxyURL string) (*url.URL, error) {
 	case "http", "https", "socks5":
 	default:
 		return nil, fmt.Errorf("unsupported scheme %q, must be http, https, or socks5", u.Scheme)
+	}
+	if len(u.Host) == 0 {
+		return nil, fmt.Errorf("host must be specified")
 	}
 	return u, nil
 }
@@ -58,8 +62,15 @@ func getMatchingClusters(clientConfig restclient.Config, kubeconfig clientcmdapi
 	return ret
 }
 
-// findClusters returns the first cluster matching the host.
+// findCluster returns a cluster matching the host. Prefer the canonical
+// nickname CreateConfig would write, so login reuses the same cluster entry
+// (and its proxy-url) when multiple stanzas share a server URL.
 func findCluster(host string, kubeconfig clientcmdapi.Config) *clientcmdapi.Cluster {
+	if nick, err := cliconfig.GetClusterNicknameFromURL(host); err == nil {
+		if cluster, ok := kubeconfig.Clusters[nick]; ok && cluster.Server == host {
+			return cluster
+		}
+	}
 	for _, cluster := range kubeconfig.Clusters {
 		if cluster.Server == host {
 			return cluster

--- a/pkg/cli/login/login.go
+++ b/pkg/cli/login/login.go
@@ -52,6 +52,9 @@ var (
 
 		# Log in to the external OIDC issuer through Auth Code + PKCE by starting a local server listening on port 8080
 		oc login localhost:8443 --exec-plugin=oc-oidc --client-id=client-id --extra-scopes=email,profile --callback-port=8080
+
+		# Log in using a proxy and persist proxy-url in the kubeconfig cluster entry
+		oc login localhost:8443 --username=myuser --password=mypass --proxy-url=http://squid.example.com:3128
 	`)
 )
 
@@ -102,6 +105,8 @@ func NewCmdLogin(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.
 	cmds.Flags().StringVar(&o.OIDCIssuerURL, "issuer-url", o.OIDCIssuerURL, "Experimental: Issuer url for external issuer. Required.")
 	cmds.Flags().StringVar(&o.OIDCCAFile, "oidc-certificate-authority", o.OIDCCAFile, "Experimental: The path to a certificate authority bundle to use when communicating with external OIDC issuer.")
 	cmds.Flags().BoolVar(&o.OIDCAutoOpenBrowser, "auto-open-browser", o.OIDCAutoOpenBrowser, "Experimental: Automatically open browser for login. When used with --web, defaults to true. When used with --exec-plugin for external OIDC, defaults to false.")
+
+	cmds.Flags().StringVar(&o.ProxyURL, "proxy-url", o.ProxyURL, "Proxy to use for all requests sent by oc login, and stored as proxy-url in the kubeconfig cluster entry")
 	return cmds
 }
 
@@ -229,6 +234,12 @@ func (o LoginOptions) Validate(cmd *cobra.Command, serverFlag string, args []str
 
 	if cmd.Flags().Changed("auto-open-browser") && !o.WebLogin && o.OIDCExecPluginType == "" {
 		return errors.New("--auto-open-browser can only be specified along with --web or --exec-plugin")
+	}
+
+	if len(o.ProxyURL) > 0 {
+		if _, err := parseProxyURL(o.ProxyURL); err != nil {
+			return fmt.Errorf("invalid --proxy-url %q: %w", o.ProxyURL, err)
+		}
 	}
 
 	return nil

--- a/pkg/cli/login/login.go
+++ b/pkg/cli/login/login.go
@@ -238,7 +238,7 @@ func (o LoginOptions) Validate(cmd *cobra.Command, serverFlag string, args []str
 
 	if len(o.ProxyURL) > 0 {
 		if _, err := parseProxyURL(o.ProxyURL); err != nil {
-			return fmt.Errorf("invalid --proxy-url %q: %w", o.ProxyURL, err)
+			return err
 		}
 	}
 

--- a/pkg/cli/login/loginoptions.go
+++ b/pkg/cli/login/loginoptions.go
@@ -180,7 +180,7 @@ func (o *LoginOptions) getClientConfig() (*restclient.Config, error) {
 	}
 	if len(proxyURL) > 0 {
 		if err := setClientConfigProxy(clientConfig, proxyURL); err != nil {
-			return nil, fmt.Errorf("invalid proxy-url %q: %w", proxyURL, err)
+			return nil, err
 		}
 	}
 

--- a/pkg/cli/login/loginoptions.go
+++ b/pkg/cli/login/loginoptions.go
@@ -71,6 +71,12 @@ type LoginOptions struct {
 	WebLogin     bool
 	CallbackPort int32
 
+	// ProxyURL, when set, is used for the login HTTP client and persisted to the
+	// kubeconfig cluster's proxy-url field. When empty, an existing cluster
+	// proxy-url is preserved; otherwise HTTPS_PROXY/HTTP_PROXY may still apply
+	// via the default transport when rest.Config.Proxy is nil.
+	ProxyURL string
+
 	// infra
 	StartingKubeConfig *kclientcmdapi.Config
 	DefaultNamespace   string
@@ -162,15 +168,31 @@ func (o *LoginOptions) getClientConfig() (*restclient.Config, error) {
 	clientConfig.Host = o.Server
 	clientConfig.Insecure = o.InsecureTLS
 
+	existingCluster := findCluster(clientConfig.Host, *o.StartingKubeConfig)
+
+	// Prefer an explicitly provided --proxy-url. Otherwise reuse an existing
+	// cluster proxy-url so login uses it and CreateConfig does not drop it.
+	// Leave Proxy unset when neither is present so HTTPS_PROXY/HTTP_PROXY still
+	// apply via the default transport without being written into kubeconfig.
+	proxyURL := o.ProxyURL
+	if len(proxyURL) == 0 && existingCluster != nil {
+		proxyURL = existingCluster.ProxyURL
+	}
+	if len(proxyURL) > 0 {
+		if err := setClientConfigProxy(clientConfig, proxyURL); err != nil {
+			return nil, fmt.Errorf("invalid proxy-url %q: %w", proxyURL, err)
+		}
+	}
+
 	if !o.InsecureTLS {
 		// Try to use the specified CA. Then fall back into searching kubeconfig.
 		if len(o.CAFile) > 0 {
 			clientConfig.CAFile = o.CAFile
 			clientConfig.CAData = nil
-		} else if cluster := findCluster(clientConfig.Host, *o.StartingKubeConfig); cluster != nil {
-			clientConfig.Insecure = cluster.InsecureSkipTLSVerify
-			clientConfig.CAFile = cluster.CertificateAuthority
-			clientConfig.CAData = cluster.CertificateAuthorityData
+		} else if existingCluster != nil {
+			clientConfig.Insecure = existingCluster.InsecureSkipTLSVerify
+			clientConfig.CAFile = existingCluster.CertificateAuthority
+			clientConfig.CAData = existingCluster.CertificateAuthorityData
 
 			// It's not allowed to specify both the insecure flag and a CA.
 			// k8s transport init machinery returns an error in that case.

--- a/pkg/cli/login/loginoptions.go
+++ b/pkg/cli/login/loginoptions.go
@@ -71,10 +71,12 @@ type LoginOptions struct {
 	WebLogin     bool
 	CallbackPort int32
 
-	// ProxyURL, when set, is used for the login HTTP client and persisted to the
-	// kubeconfig cluster's proxy-url field. When empty, an existing cluster
-	// proxy-url is preserved; otherwise HTTPS_PROXY/HTTP_PROXY may still apply
-	// via the default transport when rest.Config.Proxy is nil.
+	// ProxyURL comes from --proxy-url. When set, it is used for the login HTTP
+	// client and persisted as the kubeconfig cluster's proxy-url. When empty,
+	// an existing kubeconfig cluster proxy-url is reused. When neither is set,
+	// rest.Config.Proxy is left nil so client-go's default transport still
+	// honors HTTPS_PROXY/HTTP_PROXY; those environment proxies are not written
+	// into kubeconfig.
 	ProxyURL string
 
 	// infra
@@ -172,8 +174,9 @@ func (o *LoginOptions) getClientConfig() (*restclient.Config, error) {
 
 	// Prefer an explicitly provided --proxy-url. Otherwise reuse an existing
 	// cluster proxy-url so login uses it and CreateConfig does not drop it.
-	// Leave Proxy unset when neither is present so HTTPS_PROXY/HTTP_PROXY still
-	// apply via the default transport without being written into kubeconfig.
+	// Leave Proxy unset when neither is present so client-go still honors
+	// HTTPS_PROXY/HTTP_PROXY via the default transport without writing those
+	// environment proxies into kubeconfig.
 	proxyURL := o.ProxyURL
 	if len(proxyURL) == 0 && existingCluster != nil {
 		proxyURL = existingCluster.ProxyURL

--- a/pkg/cli/login/loginoptions_test.go
+++ b/pkg/cli/login/loginoptions_test.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"sync/atomic"
 	"testing"
 
 	"github.com/MakeNowJust/heredoc"
@@ -659,430 +658,335 @@ func TestValidateAutoOpenBrowser(t *testing.T) {
 	}
 }
 
-func TestLoginProxyURLFlagAccepted(t *testing.T) {
-	cmd := NewCmdLogin(nil, genericiooptions.NewTestIOStreamsDiscard())
-	flag := cmd.Flags().Lookup("proxy-url")
-	if flag == nil {
-		t.Fatal("expected oc login to define --proxy-url")
-	}
-	if err := cmd.Flags().Set("proxy-url", "http://squid.example.com:3128"); err != nil {
-		t.Fatalf("expected --proxy-url to accept a value: %v", err)
-	}
-}
+// TestProxyURL covers --proxy-url validation, login client selection, and kubeconfig persistence.
+func TestProxyURL(t *testing.T) {
+	t.Run("flag is registered", func(t *testing.T) {
+		cmd := NewCmdLogin(nil, genericiooptions.NewTestIOStreamsDiscard())
+		if cmd.Flags().Lookup("proxy-url") == nil {
+			t.Fatal("expected oc login to define --proxy-url")
+		}
+	})
 
-func TestValidateProxyURL(t *testing.T) {
-	testCases := []struct {
-		name            string
-		proxyURL        string
-		expectErrSubstr string
-	}{
-		{
-			name:     "valid http proxy",
-			proxyURL: "http://squid.example.com:3128",
-		},
-		{
-			name:     "valid https proxy",
-			proxyURL: "https://squid.example.com:3128",
-		},
-		{
-			name:     "valid socks5 proxy",
-			proxyURL: "socks5://127.0.0.1:1080",
-		},
-		{
-			name:     "empty proxy is allowed",
-			proxyURL: "",
-		},
-		{
-			name:            "invalid scheme",
-			proxyURL:        "ftp://squid.example.com:3128",
-			expectErrSubstr: "invalid --proxy-url",
-		},
-		{
-			name:            "missing scheme",
-			proxyURL:        "squid.example.com:3128",
-			expectErrSubstr: "invalid --proxy-url",
-		},
-		{
-			name:            "scheme only",
-			proxyURL:        "http://",
-			expectErrSubstr: "invalid --proxy-url",
-		},
-		{
-			name:            "missing host",
-			proxyURL:        "http:/proxy",
-			expectErrSubstr: "invalid --proxy-url",
-		},
-	}
+	t.Run("validation", func(t *testing.T) {
+		cases := []struct {
+			name        string
+			proxyURL    string
+			wantErr     bool
+			errContains string
+			// secret must never appear in an error message.
+			secret string
+		}{
+			{name: "http", proxyURL: "http://squid.example.com:3128"},
+			{name: "https", proxyURL: "https://squid.example.com:3128"},
+			{name: "socks5", proxyURL: "socks5://127.0.0.1:1080"},
+			{name: "ipv6", proxyURL: "http://[::1]:3128"},
+			{name: "with credentials", proxyURL: "http://user:s3cret@squid.example.com:3128", secret: "s3cret"},
+			{name: "empty allowed on Validate", proxyURL: ""},
+			{name: "unsupported scheme", proxyURL: "ftp://squid.example.com:3128", wantErr: true, errContains: "unsupported scheme"},
+			{name: "missing scheme", proxyURL: "squid.example.com:3128", wantErr: true, errContains: "unsupported scheme"},
+			{name: "scheme only", proxyURL: "http://", wantErr: true, errContains: "host must be specified"},
+			{name: "port without host", proxyURL: "http://:8080", wantErr: true, errContains: "host must be specified"},
+			{name: "socks5 port without host", proxyURL: "socks5://:1080", wantErr: true, errContains: "host must be specified"},
+			{name: "path-style missing host", proxyURL: "http:/proxy", wantErr: true, errContains: "host must be specified"},
+			{name: "unsupported scheme with credentials", proxyURL: "ftp://user:s3cret@squid.example.com:3128", wantErr: true, errContains: "unsupported scheme", secret: "s3cret"},
+		}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			cmd := NewCmdLogin(nil, genericiooptions.NewTestIOStreamsDiscard())
-			options := &LoginOptions{
-				Server:             "https://api.example.com:6443",
-				ProxyURL:           tc.proxyURL,
-				StartingKubeConfig: &kclientcmdapi.Config{},
-			}
-			err := options.Validate(cmd, "", []string{})
-			if tc.expectErrSubstr == "" {
-				if err != nil {
-					t.Fatalf("expected no error, got: %v", err)
+		cmd := NewCmdLogin(nil, genericiooptions.NewTestIOStreamsDiscard())
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				err := (&LoginOptions{
+					Server:             "https://api.example.com:6443",
+					ProxyURL:           tc.proxyURL,
+					StartingKubeConfig: &kclientcmdapi.Config{},
+				}).Validate(cmd, "", []string{})
+				if tc.wantErr {
+					if err == nil {
+						t.Fatal("expected error")
+					}
+					if !strings.Contains(err.Error(), tc.errContains) {
+						t.Fatalf("error %q does not contain %q", err.Error(), tc.errContains)
+					}
+					if tc.secret != "" && strings.Contains(err.Error(), tc.secret) {
+						t.Fatalf("error leaked proxy credentials: %q", err.Error())
+					}
+					if strings.Contains(err.Error(), tc.proxyURL) {
+						t.Fatalf("error must not include raw proxy URL: %q", err.Error())
+					}
+					return
 				}
-				return
-			}
-			if err == nil {
-				t.Fatalf("expected error containing %q, got nil", tc.expectErrSubstr)
-			}
-			if !strings.Contains(err.Error(), tc.expectErrSubstr) {
-				t.Fatalf("expected error containing %q, got: %v", tc.expectErrSubstr, err)
-			}
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			})
+		}
+	})
+
+	t.Run("explicit flag is used for dial", func(t *testing.T) {
+		contacted := ""
+		apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			contacted = "api"
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer apiServer.Close()
+		proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			contacted = "proxy"
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer proxyServer.Close()
+
+		_, err := (&LoginOptions{
+			Server:             apiServer.URL,
+			ProxyURL:           proxyServer.URL,
+			StartingKubeConfig: &kclientcmdapi.Config{},
+		}).getClientConfig()
+		if err != nil {
+			t.Fatalf("getClientConfig: %v", err)
+		}
+		if contacted != "proxy" {
+			t.Fatalf("dial contacted %q, want proxy", contacted)
+		}
+	})
+
+	t.Run("existing cluster proxy is preserved", func(t *testing.T) {
+		contacted := ""
+		apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			contacted = "api"
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer apiServer.Close()
+		proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			contacted = "proxy"
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer proxyServer.Close()
+
+		_, err := (&LoginOptions{
+			Server: apiServer.URL,
+			StartingKubeConfig: &kclientcmdapi.Config{
+				Clusters: map[string]*kclientcmdapi.Cluster{
+					"existing": {Server: apiServer.URL, ProxyURL: proxyServer.URL},
+				},
+			},
+		}).getClientConfig()
+		if err != nil {
+			t.Fatalf("getClientConfig: %v", err)
+		}
+		if contacted != "proxy" {
+			t.Fatalf("dial contacted %q, want proxy", contacted)
+		}
+	})
+
+	t.Run("explicit flag overrides existing cluster proxy", func(t *testing.T) {
+		contacted := ""
+		apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			contacted = "api"
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer apiServer.Close()
+		oldProxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			contacted = "old-proxy"
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer oldProxy.Close()
+		newProxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			contacted = "new-proxy"
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer newProxy.Close()
+
+		_, err := (&LoginOptions{
+			Server:   apiServer.URL,
+			ProxyURL: newProxy.URL,
+			StartingKubeConfig: &kclientcmdapi.Config{
+				Clusters: map[string]*kclientcmdapi.Cluster{
+					"existing": {Server: apiServer.URL, ProxyURL: oldProxy.URL},
+				},
+			},
+		}).getClientConfig()
+		if err != nil {
+			t.Fatalf("getClientConfig: %v", err)
+		}
+		if contacted != "new-proxy" {
+			t.Fatalf("dial contacted %q, want new-proxy", contacted)
+		}
+	})
+
+	t.Run("prefers canonical cluster nickname over duplicate server entry", func(t *testing.T) {
+		server := "https://api.example.com:6443"
+		canonicalNick, err := cliconfig.GetClusterNicknameFromURL(server)
+		if err != nil {
+			t.Fatal(err)
+		}
+		canonical := &kclientcmdapi.Cluster{Server: server, ProxyURL: "http://canonical.example.com:3128"}
+		alias := &kclientcmdapi.Cluster{Server: server, ProxyURL: "http://alias.example.com:3128"}
+
+		got := findCluster(server, kclientcmdapi.Config{
+			Clusters: map[string]*kclientcmdapi.Cluster{
+				"alias":       alias,
+				canonicalNick: canonical,
+			},
 		})
-	}
-}
+		if got == nil {
+			t.Fatal("expected findCluster to return a cluster")
+		}
+		if got.ProxyURL != "http://canonical.example.com:3128" {
+			t.Errorf("ProxyURL = %q, want canonical proxy", got.ProxyURL)
+		}
+	})
 
-func TestGetClientConfigUsesProxyURL(t *testing.T) {
-	var apiHit atomic.Bool
-	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		apiHit.Store(true)
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer apiServer.Close()
+	t.Run("leaves Proxy nil without flag or cluster proxy", func(t *testing.T) {
+		apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer apiServer.Close()
 
-	var proxiedURL atomic.Pointer[string]
-	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		u := r.URL.String()
-		proxiedURL.Store(&u)
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer proxyServer.Close()
+		cfg, err := (&LoginOptions{
+			Server:             apiServer.URL,
+			StartingKubeConfig: &kclientcmdapi.Config{},
+		}).getClientConfig()
+		if err != nil {
+			t.Fatalf("getClientConfig: %v", err)
+		}
+		if cfg.Proxy != nil {
+			t.Fatal("expected rest.Config.Proxy to remain nil so HTTP(S)_PROXY can apply via the default transport")
+		}
+	})
 
-	options := &LoginOptions{
-		Server:             apiServer.URL,
-		ProxyURL:           proxyServer.URL,
-		StartingKubeConfig: &kclientcmdapi.Config{},
-	}
+	t.Run("SaveConfig persists explicit proxy and isolates clusters", func(t *testing.T) {
+		dir := t.TempDir()
+		kubeconfigPath := filepath.Join(dir, "config")
+		proxyA := "http://proxy-a.example.com:3128"
+		proxyB := "http://proxy-b.example.com:3128"
+		proxyURLA, err := url.Parse(proxyA)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	clientConfig, err := options.getClientConfig()
-	if err != nil {
-		t.Fatalf("getClientConfig failed: %v", err)
-	}
-	if clientConfig.Proxy == nil {
-		t.Fatal("expected rest.Config.Proxy to be set from --proxy-url")
-	}
+		starting := kclientcmdapi.NewConfig()
+		starting.Clusters["api-cluster-a-example-com:6443"] = &kclientcmdapi.Cluster{
+			Server:   "https://api.cluster-a.example.com:6443",
+			ProxyURL: proxyA,
+		}
+		starting.Clusters["api-cluster-b-example-com:6443"] = &kclientcmdapi.Cluster{
+			Server:   "https://api.cluster-b.example.com:6443",
+			ProxyURL: proxyB,
+		}
 
-	req, err := http.NewRequest(http.MethodHead, apiServer.URL, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	got, err := clientConfig.Proxy(req)
-	if err != nil {
-		t.Fatalf("Proxy func failed: %v", err)
-	}
-	if got == nil || got.String() != proxyServer.URL {
-		t.Fatalf("expected proxy %q, got %v", proxyServer.URL, got)
-	}
-
-	// dialToServer requests the API root; absolute form may include a trailing slash.
-	u := proxiedURL.Load()
-	if u == nil {
-		t.Fatal("expected dialToServer to use the configured proxy")
-	}
-	if !strings.HasPrefix(*u, apiServer.URL) {
-		t.Fatalf("proxy saw unexpected URL %q", *u)
-	}
-	if apiHit.Load() {
-		t.Fatal("api server should not have been reached directly when proxy is configured")
-	}
-}
-
-func TestGetClientConfigPrefersCanonicalClusterProxyURL(t *testing.T) {
-	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer apiServer.Close()
-
-	otherProxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Error("non-canonical cluster proxy should not be selected when canonical entry exists")
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer otherProxy.Close()
-
-	canonicalProxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer canonicalProxy.Close()
-
-	canonicalNick, err := cliconfig.GetClusterNicknameFromURL(apiServer.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	options := &LoginOptions{
-		Server: apiServer.URL,
-		StartingKubeConfig: &kclientcmdapi.Config{
-			Clusters: map[string]*kclientcmdapi.Cluster{
-				"alias": {
-					Server:   apiServer.URL,
-					ProxyURL: otherProxy.URL,
-				},
-				canonicalNick: {
-					Server:   apiServer.URL,
-					ProxyURL: canonicalProxy.URL,
+		_, err = (&LoginOptions{
+			Username:           "alice",
+			Project:            "default",
+			StartingKubeConfig: starting,
+			PathOptions: &kclientcmd.PathOptions{
+				GlobalFile: kubeconfigPath,
+				EnvVar:     "",
+				LoadingRules: &kclientcmd.ClientConfigLoadingRules{
+					ExplicitPath: kubeconfigPath,
 				},
 			},
-		},
-	}
-
-	clientConfig, err := options.getClientConfig()
-	if err != nil {
-		t.Fatalf("getClientConfig failed: %v", err)
-	}
-	req, err := http.NewRequest(http.MethodHead, apiServer.URL, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	got, err := clientConfig.Proxy(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got == nil || got.String() != canonicalProxy.URL {
-		t.Fatalf("expected canonical cluster proxy %q, got %v", canonicalProxy.URL, got)
-	}
-}
-
-func TestGetClientConfigPreservesExistingClusterProxyURL(t *testing.T) {
-	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer apiServer.Close()
-
-	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer proxyServer.Close()
-
-	startingConfig := &kclientcmdapi.Config{
-		Clusters: map[string]*kclientcmdapi.Cluster{
-			"existing": {
-				Server:   apiServer.URL,
-				ProxyURL: proxyServer.URL,
+			Config: &restclient.Config{
+				Host:        "https://api.cluster-a.example.com:6443",
+				BearerToken: "token-a",
+				Proxy:       http.ProxyURL(proxyURLA),
 			},
-		},
-	}
+			IOStreams: genericiooptions.NewTestIOStreamsDiscard(),
+		}).SaveConfig()
+		if err != nil {
+			t.Fatalf("SaveConfig: %v", err)
+		}
 
-	options := &LoginOptions{
-		Server:             apiServer.URL,
-		StartingKubeConfig: startingConfig,
-	}
+		result, err := kclientcmd.LoadFromFile(kubeconfigPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := result.Clusters["api-cluster-a-example-com:6443"].ProxyURL; got != proxyA {
+			t.Fatalf("cluster A proxy-url = %q, want %q", got, proxyA)
+		}
+		if got := result.Clusters["api-cluster-b-example-com:6443"].ProxyURL; got != proxyB {
+			t.Fatalf("cluster B proxy-url = %q, want %q", got, proxyB)
+		}
+	})
 
-	clientConfig, err := options.getClientConfig()
-	if err != nil {
-		t.Fatalf("getClientConfig failed: %v", err)
-	}
-	if clientConfig.Proxy == nil {
-		t.Fatal("expected existing cluster proxy-url to be applied to rest.Config.Proxy")
-	}
+	t.Run("SaveConfig writes explicit proxy override", func(t *testing.T) {
+		dir := t.TempDir()
+		kubeconfigPath := filepath.Join(dir, "config")
+		proxyB := "http://proxy-b.example.com:3128"
+		proxyURLB, err := url.Parse(proxyB)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	req, err := http.NewRequest(http.MethodHead, apiServer.URL, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	got, err := clientConfig.Proxy(req)
-	if err != nil {
-		t.Fatalf("Proxy func failed: %v", err)
-	}
-	if got == nil || got.String() != proxyServer.URL {
-		t.Fatalf("expected preserved proxy %q, got %v", proxyServer.URL, got)
-	}
-}
+		starting := kclientcmdapi.NewConfig()
+		starting.Clusters["api-example-com:6443"] = &kclientcmdapi.Cluster{
+			Server:   "https://api.example.com:6443",
+			ProxyURL: "http://proxy-a.example.com:3128",
+		}
 
-func TestGetClientConfigProxyURLFlagOverridesExisting(t *testing.T) {
-	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer apiServer.Close()
-
-	oldProxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Error("old proxy should not be used when --proxy-url is set")
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer oldProxy.Close()
-
-	var newProxyHit atomic.Bool
-	newProxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		newProxyHit.Store(true)
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer newProxy.Close()
-
-	options := &LoginOptions{
-		Server:   apiServer.URL,
-		ProxyURL: newProxy.URL,
-		StartingKubeConfig: &kclientcmdapi.Config{
-			Clusters: map[string]*kclientcmdapi.Cluster{
-				"existing": {
-					Server:   apiServer.URL,
-					ProxyURL: oldProxy.URL,
+		_, err = (&LoginOptions{
+			Username:           "alice",
+			Project:            "default",
+			StartingKubeConfig: starting,
+			PathOptions: &kclientcmd.PathOptions{
+				GlobalFile: kubeconfigPath,
+				EnvVar:     "",
+				LoadingRules: &kclientcmd.ClientConfigLoadingRules{
+					ExplicitPath: kubeconfigPath,
 				},
 			},
-		},
-	}
+			Config: &restclient.Config{
+				Host:        "https://api.example.com:6443",
+				BearerToken: "token",
+				Proxy:       http.ProxyURL(proxyURLB),
+			},
+			IOStreams: genericiooptions.NewTestIOStreamsDiscard(),
+		}).SaveConfig()
+		if err != nil {
+			t.Fatalf("SaveConfig: %v", err)
+		}
 
-	clientConfig, err := options.getClientConfig()
-	if err != nil {
-		t.Fatalf("getClientConfig failed: %v", err)
-	}
-	req, err := http.NewRequest(http.MethodHead, apiServer.URL, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	got, err := clientConfig.Proxy(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got == nil || got.String() != newProxy.URL {
-		t.Fatalf("expected --proxy-url %q to override existing, got %v", newProxy.URL, got)
-	}
-	if !newProxyHit.Load() {
-		t.Fatal("expected dial to use the --proxy-url proxy")
-	}
-}
+		result, err := kclientcmd.LoadFromFile(kubeconfigPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := result.Clusters["api-example-com:6443"].ProxyURL; got != proxyB {
+			t.Fatalf("proxy-url = %q, want override %q", got, proxyB)
+		}
+	})
 
-func TestGetClientConfigLeavesProxyNilWithoutFlagOrClusterProxy(t *testing.T) {
-	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer apiServer.Close()
+	t.Run("SaveConfig does not persist environment proxy", func(t *testing.T) {
+		dir := t.TempDir()
+		kubeconfigPath := filepath.Join(dir, "config")
+		t.Setenv("HTTPS_PROXY", "http://env-proxy.example.com:3128")
+		t.Setenv("HTTP_PROXY", "http://env-proxy.example.com:3128")
 
-	options := &LoginOptions{
-		Server:             apiServer.URL,
-		StartingKubeConfig: &kclientcmdapi.Config{},
-	}
+		_, err := (&LoginOptions{
+			Username:           "alice",
+			Project:            "default",
+			StartingKubeConfig: kclientcmdapi.NewConfig(),
+			PathOptions: &kclientcmd.PathOptions{
+				GlobalFile: kubeconfigPath,
+				EnvVar:     "",
+				LoadingRules: &kclientcmd.ClientConfigLoadingRules{
+					ExplicitPath: kubeconfigPath,
+				},
+			},
+			Config: &restclient.Config{
+				Host:        "https://api.example.com:6443",
+				BearerToken: "token",
+			},
+			IOStreams: genericiooptions.NewTestIOStreamsDiscard(),
+		}).SaveConfig()
+		if err != nil {
+			t.Fatalf("SaveConfig: %v", err)
+		}
 
-	clientConfig, err := options.getClientConfig()
-	if err != nil {
-		t.Fatalf("getClientConfig failed: %v", err)
-	}
-	if clientConfig.Proxy != nil {
-		t.Fatal("expected rest.Config.Proxy to remain nil so HTTPS_PROXY/HTTP_PROXY can still apply")
-	}
-}
-
-func TestSaveConfigPersistsAndPreservesProxyURL(t *testing.T) {
-	dir := t.TempDir()
-	kubeconfigPath := filepath.Join(dir, "config")
-
-	proxyA := "http://proxy-a.example.com:3128"
-	proxyB := "http://proxy-b.example.com:3128"
-	proxyURLA, err := url.Parse(proxyA)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	starting := kclientcmdapi.NewConfig()
-	starting.Clusters["api-cluster-a-example-com:6443"] = &kclientcmdapi.Cluster{
-		Server:   "https://api.cluster-a.example.com:6443",
-		ProxyURL: proxyA,
-	}
-	starting.Clusters["api-cluster-b-example-com:6443"] = &kclientcmdapi.Cluster{
-		Server:   "https://api.cluster-b.example.com:6443",
-		ProxyURL: proxyB,
-	}
-
-	pathOptions := &kclientcmd.PathOptions{
-		GlobalFile: kubeconfigPath,
-		EnvVar:     "",
-		LoadingRules: &kclientcmd.ClientConfigLoadingRules{
-			ExplicitPath: kubeconfigPath,
-		},
-	}
-
-	// Re-login to cluster A without changing Proxy on rest.Config beyond the
-	// preserved value. This mirrors getClientConfig applying existing proxy-url.
-	options := &LoginOptions{
-		Username:           "alice",
-		Project:            "default",
-		StartingKubeConfig: starting,
-		PathOptions:        pathOptions,
-		Config: &restclient.Config{
-			Host:        "https://api.cluster-a.example.com:6443",
-			BearerToken: "token-a",
-			Proxy:       http.ProxyURL(proxyURLA),
-		},
-		IOStreams: genericiooptions.NewTestIOStreamsDiscard(),
-	}
-
-	if _, err := options.SaveConfig(); err != nil {
-		t.Fatalf("SaveConfig failed: %v", err)
-	}
-
-	result, err := kclientcmd.LoadFromFile(kubeconfigPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	clusterA, ok := result.Clusters["api-cluster-a-example-com:6443"]
-	if !ok {
-		t.Fatal("missing cluster A after login")
-	}
-	if clusterA.ProxyURL != proxyA {
-		t.Fatalf("cluster A proxy-url = %q, want %q", clusterA.ProxyURL, proxyA)
-	}
-
-	// Cluster B was only in StartingKubeConfig; MergeConfig keeps unrelated
-	// clusters, so its distinct proxy-url must remain.
-	clusterB, ok := result.Clusters["api-cluster-b-example-com:6443"]
-	if !ok {
-		t.Fatal("missing unrelated cluster B after login")
-	}
-	if clusterB.ProxyURL != proxyB {
-		t.Fatalf("cluster B proxy-url = %q, want %q (clusters must keep distinct proxies)", clusterB.ProxyURL, proxyB)
-	}
-}
-
-func TestSaveConfigDoesNotPersistEnvProxyWhenUnset(t *testing.T) {
-	dir := t.TempDir()
-	kubeconfigPath := filepath.Join(dir, "config")
-
-	pathOptions := &kclientcmd.PathOptions{
-		GlobalFile: kubeconfigPath,
-		EnvVar:     "",
-		LoadingRules: &kclientcmd.ClientConfigLoadingRules{
-			ExplicitPath: kubeconfigPath,
-		},
-	}
-
-	options := &LoginOptions{
-		Username:           "alice",
-		Project:            "default",
-		StartingKubeConfig: kclientcmdapi.NewConfig(),
-		PathOptions:        pathOptions,
-		Config: &restclient.Config{
-			Host:        "https://api.example.com:6443",
-			BearerToken: "token",
-			// Proxy intentionally nil: HTTPS_PROXY may still work at transport
-			// time, but must not be written into kubeconfig.
-		},
-		IOStreams: genericiooptions.NewTestIOStreamsDiscard(),
-	}
-
-	t.Setenv("HTTPS_PROXY", "http://env-proxy.example.com:3128")
-	t.Setenv("HTTP_PROXY", "http://env-proxy.example.com:3128")
-
-	if _, err := options.SaveConfig(); err != nil {
-		t.Fatalf("SaveConfig failed: %v", err)
-	}
-
-	result, err := kclientcmd.LoadFromFile(kubeconfigPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	cluster, ok := result.Clusters["api-example-com:6443"]
-	if !ok {
-		t.Fatal("missing cluster after login")
-	}
-	if cluster.ProxyURL != "" {
-		t.Fatalf("expected no kubeconfig proxy-url when only HTTPS_PROXY is set, got %q", cluster.ProxyURL)
-	}
+		result, err := kclientcmd.LoadFromFile(kubeconfigPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := result.Clusters["api-example-com:6443"].ProxyURL; got != "" {
+			t.Fatalf("expected empty proxy-url, got %q", got)
+		}
+	})
 }
 
 func newTLSServer(certString, keyString string) (*httptest.Server, error) {

--- a/pkg/cli/login/loginoptions_test.go
+++ b/pkg/cli/login/loginoptions_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/MakeNowJust/heredoc"
@@ -739,16 +740,16 @@ func TestValidateProxyURL(t *testing.T) {
 }
 
 func TestGetClientConfigUsesProxyURL(t *testing.T) {
-	apiHit := make(chan struct{}, 1)
+	var apiHit atomic.Bool
 	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		apiHit <- struct{}{}
+		apiHit.Store(true)
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer apiServer.Close()
 
-	proxied := make(chan string, 1)
+	var proxiedURL atomic.Value
 	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		proxied <- r.URL.String()
+		proxiedURL.Store(r.URL.String())
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer proxyServer.Close()
@@ -779,20 +780,16 @@ func TestGetClientConfigUsesProxyURL(t *testing.T) {
 		t.Fatalf("expected proxy %q, got %v", proxyServer.URL, got)
 	}
 
-	select {
-	case u := <-proxied:
-		// dialToServer requests the API root; absolute form may include a trailing slash.
-		if !strings.HasPrefix(u, apiServer.URL) {
-			t.Fatalf("proxy saw unexpected URL %q", u)
-		}
-	default:
+	// dialToServer requests the API root; absolute form may include a trailing slash.
+	u, _ := proxiedURL.Load().(string)
+	if u == "" {
 		t.Fatal("expected dialToServer to use the configured proxy")
 	}
-
-	select {
-	case <-apiHit:
+	if !strings.HasPrefix(u, apiServer.URL) {
+		t.Fatalf("proxy saw unexpected URL %q", u)
+	}
+	if apiHit.Load() {
 		t.Fatal("api server should not have been reached directly when proxy is configured")
-	default:
 	}
 }
 
@@ -909,9 +906,9 @@ func TestGetClientConfigProxyURLFlagOverridesExisting(t *testing.T) {
 	}))
 	defer oldProxy.Close()
 
-	newProxyHit := make(chan struct{}, 1)
+	var newProxyHit atomic.Bool
 	newProxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		newProxyHit <- struct{}{}
+		newProxyHit.Store(true)
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer newProxy.Close()
@@ -944,9 +941,7 @@ func TestGetClientConfigProxyURLFlagOverridesExisting(t *testing.T) {
 	if got == nil || got.String() != newProxy.URL {
 		t.Fatalf("expected --proxy-url %q to override existing, got %v", newProxy.URL, got)
 	}
-	select {
-	case <-newProxyHit:
-	default:
+	if !newProxyHit.Load() {
 		t.Fatal("expected dial to use the --proxy-url proxy")
 	}
 }

--- a/pkg/cli/login/loginoptions_test.go
+++ b/pkg/cli/login/loginoptions_test.go
@@ -701,6 +701,16 @@ func TestValidateProxyURL(t *testing.T) {
 			proxyURL:        "squid.example.com:3128",
 			expectErrSubstr: "invalid --proxy-url",
 		},
+		{
+			name:            "scheme only",
+			proxyURL:        "http://",
+			expectErrSubstr: "invalid --proxy-url",
+		},
+		{
+			name:            "missing host",
+			proxyURL:        "http:/proxy",
+			expectErrSubstr: "invalid --proxy-url",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -783,6 +793,61 @@ func TestGetClientConfigUsesProxyURL(t *testing.T) {
 	case <-apiHit:
 		t.Fatal("api server should not have been reached directly when proxy is configured")
 	default:
+	}
+}
+
+func TestGetClientConfigPrefersCanonicalClusterProxyURL(t *testing.T) {
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer apiServer.Close()
+
+	otherProxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("non-canonical cluster proxy should not be selected when canonical entry exists")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer otherProxy.Close()
+
+	canonicalProxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer canonicalProxy.Close()
+
+	canonicalNick, err := cliconfig.GetClusterNicknameFromURL(apiServer.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	options := &LoginOptions{
+		Server: apiServer.URL,
+		StartingKubeConfig: &kclientcmdapi.Config{
+			Clusters: map[string]*kclientcmdapi.Cluster{
+				"alias": {
+					Server:   apiServer.URL,
+					ProxyURL: otherProxy.URL,
+				},
+				canonicalNick: {
+					Server:   apiServer.URL,
+					ProxyURL: canonicalProxy.URL,
+				},
+			},
+		},
+	}
+
+	clientConfig, err := options.getClientConfig()
+	if err != nil {
+		t.Fatalf("getClientConfig failed: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodHead, apiServer.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := clientConfig.Proxy(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || got.String() != canonicalProxy.URL {
+		t.Fatalf("expected canonical cluster proxy %q, got %v", canonicalProxy.URL, got)
 	}
 }
 

--- a/pkg/cli/login/loginoptions_test.go
+++ b/pkg/cli/login/loginoptions_test.go
@@ -747,9 +747,10 @@ func TestGetClientConfigUsesProxyURL(t *testing.T) {
 	}))
 	defer apiServer.Close()
 
-	var proxiedURL atomic.Value
+	var proxiedURL atomic.Pointer[string]
 	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		proxiedURL.Store(r.URL.String())
+		u := r.URL.String()
+		proxiedURL.Store(&u)
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer proxyServer.Close()
@@ -781,12 +782,12 @@ func TestGetClientConfigUsesProxyURL(t *testing.T) {
 	}
 
 	// dialToServer requests the API root; absolute form may include a trailing slash.
-	u, _ := proxiedURL.Load().(string)
-	if u == "" {
+	u := proxiedURL.Load()
+	if u == nil {
 		t.Fatal("expected dialToServer to use the configured proxy")
 	}
-	if !strings.HasPrefix(u, apiServer.URL) {
-		t.Fatalf("proxy saw unexpected URL %q", u)
+	if !strings.HasPrefix(*u, apiServer.URL) {
+		t.Fatalf("proxy saw unexpected URL %q", *u)
 	}
 	if apiHit.Load() {
 		t.Fatal("api server should not have been reached directly when proxy is configured")

--- a/pkg/cli/login/loginoptions_test.go
+++ b/pkg/cli/login/loginoptions_test.go
@@ -669,10 +669,9 @@ func TestProxyURL(t *testing.T) {
 
 	t.Run("validation", func(t *testing.T) {
 		cases := []struct {
-			name        string
-			proxyURL    string
-			wantErr     bool
-			errContains string
+			name           string
+			proxyURL       string
+			expectedErrMsg string
 			// secret must never appear in an error message.
 			secret string
 		}{
@@ -682,13 +681,42 @@ func TestProxyURL(t *testing.T) {
 			{name: "ipv6", proxyURL: "http://[::1]:3128"},
 			{name: "with credentials", proxyURL: "http://user:s3cret@squid.example.com:3128", secret: "s3cret"},
 			{name: "empty allowed on Validate", proxyURL: ""},
-			{name: "unsupported scheme", proxyURL: "ftp://squid.example.com:3128", wantErr: true, errContains: "unsupported scheme"},
-			{name: "missing scheme", proxyURL: "squid.example.com:3128", wantErr: true, errContains: "unsupported scheme"},
-			{name: "scheme only", proxyURL: "http://", wantErr: true, errContains: "host must be specified"},
-			{name: "port without host", proxyURL: "http://:8080", wantErr: true, errContains: "host must be specified"},
-			{name: "socks5 port without host", proxyURL: "socks5://:1080", wantErr: true, errContains: "host must be specified"},
-			{name: "path-style missing host", proxyURL: "http:/proxy", wantErr: true, errContains: "host must be specified"},
-			{name: "unsupported scheme with credentials", proxyURL: "ftp://user:s3cret@squid.example.com:3128", wantErr: true, errContains: "unsupported scheme", secret: "s3cret"},
+			{
+				name:           "unsupported scheme",
+				proxyURL:       "ftp://squid.example.com:3128",
+				expectedErrMsg: `invalid --proxy-url: unsupported scheme "ftp", must be http, https, or socks5`,
+			},
+			{
+				name:           "missing scheme",
+				proxyURL:       "squid.example.com:3128",
+				expectedErrMsg: `invalid --proxy-url: unsupported scheme "squid.example.com", must be http, https, or socks5`,
+			},
+			{
+				name:           "scheme only",
+				proxyURL:       "http://",
+				expectedErrMsg: "invalid --proxy-url: host must be specified",
+			},
+			{
+				name:           "port without host",
+				proxyURL:       "http://:8080",
+				expectedErrMsg: "invalid --proxy-url: host must be specified",
+			},
+			{
+				name:           "socks5 port without host",
+				proxyURL:       "socks5://:1080",
+				expectedErrMsg: "invalid --proxy-url: host must be specified",
+			},
+			{
+				name:           "path-style missing host",
+				proxyURL:       "http:/proxy",
+				expectedErrMsg: "invalid --proxy-url: host must be specified",
+			},
+			{
+				name:           "unsupported scheme with credentials",
+				proxyURL:       "ftp://user:s3cret@squid.example.com:3128",
+				expectedErrMsg: `invalid --proxy-url: unsupported scheme "ftp", must be http, https, or socks5`,
+				secret:         "s3cret",
+			},
 		}
 
 		cmd := NewCmdLogin(nil, genericiooptions.NewTestIOStreamsDiscard())
@@ -699,18 +727,15 @@ func TestProxyURL(t *testing.T) {
 					ProxyURL:           tc.proxyURL,
 					StartingKubeConfig: &kclientcmdapi.Config{},
 				}).Validate(cmd, "", []string{})
-				if tc.wantErr {
+				if tc.expectedErrMsg != "" {
 					if err == nil {
 						t.Fatal("expected error")
 					}
-					if !strings.Contains(err.Error(), tc.errContains) {
-						t.Fatalf("error %q does not contain %q", err.Error(), tc.errContains)
+					if err.Error() != tc.expectedErrMsg {
+						t.Fatalf("error = %q, want %q", err.Error(), tc.expectedErrMsg)
 					}
 					if tc.secret != "" && strings.Contains(err.Error(), tc.secret) {
 						t.Fatalf("error leaked proxy credentials: %q", err.Error())
-					}
-					if strings.Contains(err.Error(), tc.proxyURL) {
-						t.Fatalf("error must not include raw proxy URL: %q", err.Error())
 					}
 					return
 				}
@@ -721,6 +746,8 @@ func TestProxyURL(t *testing.T) {
 		}
 	})
 
+	// getClientConfig dials the server (via dialToServer); handlers record which
+	// endpoint was contacted so we assert proxy selection without calling Proxy().
 	t.Run("explicit flag is used for dial", func(t *testing.T) {
 		contacted := ""
 		apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -747,6 +774,8 @@ func TestProxyURL(t *testing.T) {
 		}
 	})
 
+	// Re-login without --proxy-url must still dial through the existing
+	// kubeconfig cluster proxy-url (getClientConfig performs the real request).
 	t.Run("existing cluster proxy is preserved", func(t *testing.T) {
 		contacted := ""
 		apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -776,6 +805,7 @@ func TestProxyURL(t *testing.T) {
 		}
 	})
 
+	// --proxy-url must win over an existing cluster proxy-url on the real dial.
 	t.Run("explicit flag overrides existing cluster proxy", func(t *testing.T) {
 		contacted := ""
 		apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -811,6 +841,8 @@ func TestProxyURL(t *testing.T) {
 		}
 	})
 
+	// When two clusters share a server URL, prefer CreateConfig's canonical
+	// nickname so selection is deterministic (not map-iteration order).
 	t.Run("prefers canonical cluster nickname over duplicate server entry", func(t *testing.T) {
 		server := "https://api.example.com:6443"
 		canonicalNick, err := cliconfig.GetClusterNicknameFromURL(server)
@@ -834,6 +866,8 @@ func TestProxyURL(t *testing.T) {
 		}
 	})
 
+	// Leaving Proxy nil preserves normal client-go HTTPS_PROXY/HTTP_PROXY
+	// behavior on the default transport.
 	t.Run("leaves Proxy nil without flag or cluster proxy", func(t *testing.T) {
 		apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)

--- a/pkg/cli/login/loginoptions_test.go
+++ b/pkg/cli/login/loginoptions_test.go
@@ -7,7 +7,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/MakeNowJust/heredoc"
@@ -17,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	restclient "k8s.io/client-go/rest"
+	kclientcmd "k8s.io/client-go/tools/clientcmd"
 	kclientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	userv1 "github.com/openshift/api/user/v1"
@@ -651,6 +655,372 @@ func TestValidateAutoOpenBrowser(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestLoginProxyURLFlagAccepted(t *testing.T) {
+	cmd := NewCmdLogin(nil, genericiooptions.NewTestIOStreamsDiscard())
+	flag := cmd.Flags().Lookup("proxy-url")
+	if flag == nil {
+		t.Fatal("expected oc login to define --proxy-url")
+	}
+	if err := cmd.Flags().Set("proxy-url", "http://squid.example.com:3128"); err != nil {
+		t.Fatalf("expected --proxy-url to accept a value: %v", err)
+	}
+}
+
+func TestValidateProxyURL(t *testing.T) {
+	testCases := []struct {
+		name            string
+		proxyURL        string
+		expectErrSubstr string
+	}{
+		{
+			name:     "valid http proxy",
+			proxyURL: "http://squid.example.com:3128",
+		},
+		{
+			name:     "valid https proxy",
+			proxyURL: "https://squid.example.com:3128",
+		},
+		{
+			name:     "valid socks5 proxy",
+			proxyURL: "socks5://127.0.0.1:1080",
+		},
+		{
+			name:     "empty proxy is allowed",
+			proxyURL: "",
+		},
+		{
+			name:            "invalid scheme",
+			proxyURL:        "ftp://squid.example.com:3128",
+			expectErrSubstr: "invalid --proxy-url",
+		},
+		{
+			name:            "missing scheme",
+			proxyURL:        "squid.example.com:3128",
+			expectErrSubstr: "invalid --proxy-url",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := NewCmdLogin(nil, genericiooptions.NewTestIOStreamsDiscard())
+			options := &LoginOptions{
+				Server:             "https://api.example.com:6443",
+				ProxyURL:           tc.proxyURL,
+				StartingKubeConfig: &kclientcmdapi.Config{},
+			}
+			err := options.Validate(cmd, "", []string{})
+			if tc.expectErrSubstr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.expectErrSubstr)
+			}
+			if !strings.Contains(err.Error(), tc.expectErrSubstr) {
+				t.Fatalf("expected error containing %q, got: %v", tc.expectErrSubstr, err)
+			}
+		})
+	}
+}
+
+func TestGetClientConfigUsesProxyURL(t *testing.T) {
+	apiHit := make(chan struct{}, 1)
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiHit <- struct{}{}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer apiServer.Close()
+
+	proxied := make(chan string, 1)
+	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		proxied <- r.URL.String()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer proxyServer.Close()
+
+	options := &LoginOptions{
+		Server:             apiServer.URL,
+		ProxyURL:           proxyServer.URL,
+		StartingKubeConfig: &kclientcmdapi.Config{},
+	}
+
+	clientConfig, err := options.getClientConfig()
+	if err != nil {
+		t.Fatalf("getClientConfig failed: %v", err)
+	}
+	if clientConfig.Proxy == nil {
+		t.Fatal("expected rest.Config.Proxy to be set from --proxy-url")
+	}
+
+	req, err := http.NewRequest(http.MethodHead, apiServer.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := clientConfig.Proxy(req)
+	if err != nil {
+		t.Fatalf("Proxy func failed: %v", err)
+	}
+	if got == nil || got.String() != proxyServer.URL {
+		t.Fatalf("expected proxy %q, got %v", proxyServer.URL, got)
+	}
+
+	select {
+	case u := <-proxied:
+		// dialToServer requests the API root; absolute form may include a trailing slash.
+		if !strings.HasPrefix(u, apiServer.URL) {
+			t.Fatalf("proxy saw unexpected URL %q", u)
+		}
+	default:
+		t.Fatal("expected dialToServer to use the configured proxy")
+	}
+
+	select {
+	case <-apiHit:
+		t.Fatal("api server should not have been reached directly when proxy is configured")
+	default:
+	}
+}
+
+func TestGetClientConfigPreservesExistingClusterProxyURL(t *testing.T) {
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer apiServer.Close()
+
+	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer proxyServer.Close()
+
+	startingConfig := &kclientcmdapi.Config{
+		Clusters: map[string]*kclientcmdapi.Cluster{
+			"existing": {
+				Server:   apiServer.URL,
+				ProxyURL: proxyServer.URL,
+			},
+		},
+	}
+
+	options := &LoginOptions{
+		Server:             apiServer.URL,
+		StartingKubeConfig: startingConfig,
+	}
+
+	clientConfig, err := options.getClientConfig()
+	if err != nil {
+		t.Fatalf("getClientConfig failed: %v", err)
+	}
+	if clientConfig.Proxy == nil {
+		t.Fatal("expected existing cluster proxy-url to be applied to rest.Config.Proxy")
+	}
+
+	req, err := http.NewRequest(http.MethodHead, apiServer.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := clientConfig.Proxy(req)
+	if err != nil {
+		t.Fatalf("Proxy func failed: %v", err)
+	}
+	if got == nil || got.String() != proxyServer.URL {
+		t.Fatalf("expected preserved proxy %q, got %v", proxyServer.URL, got)
+	}
+}
+
+func TestGetClientConfigProxyURLFlagOverridesExisting(t *testing.T) {
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer apiServer.Close()
+
+	oldProxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("old proxy should not be used when --proxy-url is set")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer oldProxy.Close()
+
+	newProxyHit := make(chan struct{}, 1)
+	newProxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		newProxyHit <- struct{}{}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer newProxy.Close()
+
+	options := &LoginOptions{
+		Server:   apiServer.URL,
+		ProxyURL: newProxy.URL,
+		StartingKubeConfig: &kclientcmdapi.Config{
+			Clusters: map[string]*kclientcmdapi.Cluster{
+				"existing": {
+					Server:   apiServer.URL,
+					ProxyURL: oldProxy.URL,
+				},
+			},
+		},
+	}
+
+	clientConfig, err := options.getClientConfig()
+	if err != nil {
+		t.Fatalf("getClientConfig failed: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodHead, apiServer.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := clientConfig.Proxy(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || got.String() != newProxy.URL {
+		t.Fatalf("expected --proxy-url %q to override existing, got %v", newProxy.URL, got)
+	}
+	select {
+	case <-newProxyHit:
+	default:
+		t.Fatal("expected dial to use the --proxy-url proxy")
+	}
+}
+
+func TestGetClientConfigLeavesProxyNilWithoutFlagOrClusterProxy(t *testing.T) {
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer apiServer.Close()
+
+	options := &LoginOptions{
+		Server:             apiServer.URL,
+		StartingKubeConfig: &kclientcmdapi.Config{},
+	}
+
+	clientConfig, err := options.getClientConfig()
+	if err != nil {
+		t.Fatalf("getClientConfig failed: %v", err)
+	}
+	if clientConfig.Proxy != nil {
+		t.Fatal("expected rest.Config.Proxy to remain nil so HTTPS_PROXY/HTTP_PROXY can still apply")
+	}
+}
+
+func TestSaveConfigPersistsAndPreservesProxyURL(t *testing.T) {
+	dir := t.TempDir()
+	kubeconfigPath := filepath.Join(dir, "config")
+
+	proxyA := "http://proxy-a.example.com:3128"
+	proxyB := "http://proxy-b.example.com:3128"
+	proxyURLA, err := url.Parse(proxyA)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	starting := kclientcmdapi.NewConfig()
+	starting.Clusters["api-cluster-a-example-com:6443"] = &kclientcmdapi.Cluster{
+		Server:   "https://api.cluster-a.example.com:6443",
+		ProxyURL: proxyA,
+	}
+	starting.Clusters["api-cluster-b-example-com:6443"] = &kclientcmdapi.Cluster{
+		Server:   "https://api.cluster-b.example.com:6443",
+		ProxyURL: proxyB,
+	}
+
+	pathOptions := &kclientcmd.PathOptions{
+		GlobalFile: kubeconfigPath,
+		EnvVar:     "",
+		LoadingRules: &kclientcmd.ClientConfigLoadingRules{
+			ExplicitPath: kubeconfigPath,
+		},
+	}
+
+	// Re-login to cluster A without changing Proxy on rest.Config beyond the
+	// preserved value. This mirrors getClientConfig applying existing proxy-url.
+	options := &LoginOptions{
+		Username:           "alice",
+		Project:            "default",
+		StartingKubeConfig: starting,
+		PathOptions:        pathOptions,
+		Config: &restclient.Config{
+			Host:        "https://api.cluster-a.example.com:6443",
+			BearerToken: "token-a",
+			Proxy:       http.ProxyURL(proxyURLA),
+		},
+		IOStreams: genericiooptions.NewTestIOStreamsDiscard(),
+	}
+
+	if _, err := options.SaveConfig(); err != nil {
+		t.Fatalf("SaveConfig failed: %v", err)
+	}
+
+	result, err := kclientcmd.LoadFromFile(kubeconfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clusterA, ok := result.Clusters["api-cluster-a-example-com:6443"]
+	if !ok {
+		t.Fatal("missing cluster A after login")
+	}
+	if clusterA.ProxyURL != proxyA {
+		t.Fatalf("cluster A proxy-url = %q, want %q", clusterA.ProxyURL, proxyA)
+	}
+
+	// Cluster B was only in StartingKubeConfig; MergeConfig keeps unrelated
+	// clusters, so its distinct proxy-url must remain.
+	clusterB, ok := result.Clusters["api-cluster-b-example-com:6443"]
+	if !ok {
+		t.Fatal("missing unrelated cluster B after login")
+	}
+	if clusterB.ProxyURL != proxyB {
+		t.Fatalf("cluster B proxy-url = %q, want %q (clusters must keep distinct proxies)", clusterB.ProxyURL, proxyB)
+	}
+}
+
+func TestSaveConfigDoesNotPersistEnvProxyWhenUnset(t *testing.T) {
+	dir := t.TempDir()
+	kubeconfigPath := filepath.Join(dir, "config")
+
+	pathOptions := &kclientcmd.PathOptions{
+		GlobalFile: kubeconfigPath,
+		EnvVar:     "",
+		LoadingRules: &kclientcmd.ClientConfigLoadingRules{
+			ExplicitPath: kubeconfigPath,
+		},
+	}
+
+	options := &LoginOptions{
+		Username:           "alice",
+		Project:            "default",
+		StartingKubeConfig: kclientcmdapi.NewConfig(),
+		PathOptions:        pathOptions,
+		Config: &restclient.Config{
+			Host:        "https://api.example.com:6443",
+			BearerToken: "token",
+			// Proxy intentionally nil: HTTPS_PROXY may still work at transport
+			// time, but must not be written into kubeconfig.
+		},
+		IOStreams: genericiooptions.NewTestIOStreamsDiscard(),
+	}
+
+	t.Setenv("HTTPS_PROXY", "http://env-proxy.example.com:3128")
+	t.Setenv("HTTP_PROXY", "http://env-proxy.example.com:3128")
+
+	if _, err := options.SaveConfig(); err != nil {
+		t.Fatalf("SaveConfig failed: %v", err)
+	}
+
+	result, err := kclientcmd.LoadFromFile(kubeconfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cluster, ok := result.Clusters["api-example-com:6443"]
+	if !ok {
+		t.Fatal("missing cluster after login")
+	}
+	if cluster.ProxyURL != "" {
+		t.Fatalf("expected no kubeconfig proxy-url when only HTTPS_PROXY is set, got %q", cluster.ProxyURL)
 	}
 }
 

--- a/pkg/helpers/kubeconfig/smart_merge_test.go
+++ b/pkg/helpers/kubeconfig/smart_merge_test.go
@@ -1,6 +1,8 @@
 package kubeconfig
 
 import (
+	"net/http"
+	"net/url"
 	"path/filepath"
 	"testing"
 
@@ -94,5 +96,93 @@ func TestLoginDoesNotCopySecondaryFileContextsToDefaultFile(t *testing.T) {
 	}
 	if _, ok := result.Contexts["my-project/new-cluster-example-com:6443/alice"]; !ok {
 		t.Error("primary config must contain the new login context")
+	}
+}
+
+func TestCreateConfigPersistsProxyURL(t *testing.T) {
+	proxyURL, err := url.Parse("http://squid.example.com:3128")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := CreateConfig("default", "alice", &restclient.Config{
+		Host:        "https://api.example.com:6443",
+		BearerToken: "token",
+		Proxy:       http.ProxyURL(proxyURL),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cluster, ok := cfg.Clusters["api-example-com:6443"]
+	if !ok {
+		t.Fatal("expected cluster entry")
+	}
+	if cluster.ProxyURL != proxyURL.String() {
+		t.Fatalf("ProxyURL = %q, want %q", cluster.ProxyURL, proxyURL.String())
+	}
+}
+
+func TestCreateConfigDoesNotPersistProxyWhenUnset(t *testing.T) {
+	cfg, err := CreateConfig("default", "alice", &restclient.Config{
+		Host:        "https://api.example.com:6443",
+		BearerToken: "token",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cluster, ok := cfg.Clusters["api-example-com:6443"]
+	if !ok {
+		t.Fatal("expected cluster entry")
+	}
+	if cluster.ProxyURL != "" {
+		t.Fatalf("expected empty ProxyURL, got %q", cluster.ProxyURL)
+	}
+}
+
+func TestMergeConfigKeepsDistinctClusterProxyURLs(t *testing.T) {
+	proxyA, err := url.Parse("http://proxy-a.example.com:3128")
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxyB, err := url.Parse("http://proxy-b.example.com:3128")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	starting, err := CreateConfig("ns-a", "alice", &restclient.Config{
+		Host:        "https://api.cluster-a.example.com:6443",
+		BearerToken: "token-a",
+		Proxy:       http.ProxyURL(proxyA),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	addition, err := CreateConfig("ns-b", "bob", &restclient.Config{
+		Host:        "https://api.cluster-b.example.com:6443",
+		BearerToken: "token-b",
+		Proxy:       http.ProxyURL(proxyB),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	merged, err := MergeConfig(*starting, *addition)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clusterA := merged.Clusters["api-cluster-a-example-com:6443"]
+	clusterB := merged.Clusters["api-cluster-b-example-com:6443"]
+	if clusterA == nil || clusterB == nil {
+		t.Fatalf("expected both clusters, got %#v", merged.Clusters)
+	}
+	if clusterA.ProxyURL != proxyA.String() {
+		t.Fatalf("cluster A ProxyURL = %q, want %q", clusterA.ProxyURL, proxyA.String())
+	}
+	if clusterB.ProxyURL != proxyB.String() {
+		t.Fatalf("cluster B ProxyURL = %q, want %q", clusterB.ProxyURL, proxyB.String())
 	}
 }


### PR DESCRIPTION
## Summary
- Add `--proxy-url` to `oc login` so login uses a per-cluster proxy and persists it to kubeconfig `cluster.proxy-url`.
- Reuse an existing cluster `proxy-url` when the flag is omitted, so re-login no longer drops it (including when `HTTPS_PROXY` is set).
- Leave `rest.Config.Proxy` unset when neither flag nor kubeconfig proxy is present, so env proxies still apply without being written into kubeconfig.

Fixes https://github.com/openshift/oc/issues/2314

## Test plan
- [x] Unit: `--proxy-url` flag accepted and validated (`http`/`https`/`socks5`; reject invalid schemes)
- [x] Unit: login client uses `--proxy-url` during dial
- [x] Unit: existing cluster `proxy-url` is reused when flag is omitted
- [x] Unit: `--proxy-url` overrides an existing cluster proxy
- [x] Unit: `SaveConfig` / `CreateConfig` persist `proxy-url`; unrelated clusters keep distinct proxies
- [x] Unit: `HTTPS_PROXY` alone is not written into kubeconfig
- [x] CI: `unit` / `verify` / `verify-deps` green
- [ ] Manual (optional): `oc login --proxy-url=http://<proxy>:3128 ...` and confirm kubeconfig `clusters.*.proxy-url`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--proxy-url` support to the login command.
  * Supports HTTP, HTTPS, and SOCKS5 proxy URLs.
  * Reuses existing cluster proxy settings when no new proxy is specified.
  * Saves explicitly configured proxy settings to login configuration.

* **Bug Fixes**
  * Invalid or unsupported proxy URLs now produce validation errors.
  * Proxy settings are preserved correctly when configurations are merged.
  * Cluster selection now prioritizes the canonical server nickname.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->