### PR TITLE
OCPBUGS-109669: Fix pre-existing unit test failures on release-4.18

### DIFF
--- a/pkg/helpers/newapp/newapptest/newapp_test.go
+++ b/pkg/helpers/newapp/newapptest/newapp_test.go
@@ -530,7 +530,7 @@ func TestNewAppRunAll(t *testing.T) {
 					SourceRepositories: []string{"https://github.com/openshift/sti-ruby"},
 				},
 				GenerationInputs: cmd.GenerationInputs{
-					ContextDir: "3.1/test/rack-test-app",
+					ContextDir: "3.3/test/rack-test-app",
 				},
 
 				Resolvers: cmd.Resolvers{


### PR DESCRIPTION
## Summary

Fixes a pre-existing unit test failures in `pkg/helpers/newapp/newapptest`
that block all PRs on release-4.18.
fixes align with changes already applied on the `main` branch.

## Changes

### 1. Fix TestNewAppRunAll/app_generation_using_context_dir

The test clones `openshift/sti-ruby` and references
`ContextDir: "3.1/test/rack-test-app"`, but the `3.1/` directory was
removed from the upstream repository.

**Fix:** Update `ContextDir` from `"3.1/test/rack-test-app"` to
`"3.3/test/rack-test-app"` in `pkg/helpers/newapp/newapptest/newapp_test.go`.


## References

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the context-directory integration test to use the current Rack test application version, improving test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->