### PR TITLE
RFE-8872: warn and confirm before deleting PV/PVC

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,7 +98,7 @@ func (o *ExampleOptions) Run() error { ... }
 ## Contributing Rules
 
 - **Do not modify `pkg/cli/cli.go`** unless it is part of a kubectl rebase process (to reflect changes from `kubectl/cmd.go`).
-- **Do not diverge from wrapped kubectl commands.** If a command is a pure kubectl wrapper, behavioral changes belong upstream in `k8s.io/kubectl`.
+- **Do not diverge from wrapped kubectl commands.** If a command is a pure kubectl wrapper, behavioral changes belong upstream in `k8s.io/kubectl`. `oc delete` is an exception: it adds an OpenShift-specific confirmation prompt for persistent volumes and claims (see `pkg/cli/kubectlwrappers/delete.go`).
 - **Do not modify files under `vendor/`.** Regenerate via `go mod tidy && go mod vendor`.
 - **Do not edit generated files.** `contrib/completions/` and `docs/generated/` are generated — use `make update-generated-completions` to regenerate.
 - **Write unit tests for every change.** Some commands do not easily support unit tests without dramatic refactoring — those may be excluded, but test coverage is expected by default. Test fixtures go in `testdata/` subdirectories co-located with tests.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8,7 +8,7 @@ Every kubectl command is available in oc. The relationship falls into five categ
 
 **Pure kubectl wrappers** — Commands in `pkg/cli/kubectlwrappers/wrappers.go` that call kubectl's constructor and wrap with `cmdutil.ReplaceCommandName("kubectl", "oc", ...)`. The wrapping is cosmetic — command name substitution in help text. Behavioral changes to these commands belong upstream in `k8s.io/kubectl`.
 
-**Kubectl wrappers with OCP extensions** — Commands that start from kubectl's implementation but add OCP subcommands or resource types. For example, `create` wraps kubectl create then adds OCP subcommands (route, deployment-config, etc.); `scale`/`autoscale` add `deploymentconfig` to ValidArgs. Under `oc adm`: drain, cordon, uncordon, taint, certificates are also kubectl wrappers.
+**Kubectl wrappers with OCP extensions** — Commands that start from kubectl's implementation but add OCP subcommands, resource types, or safety checks. For example, `create` wraps kubectl create then adds OCP subcommands (route, deployment-config, etc.); `scale`/`autoscale` add `deploymentconfig` to ValidArgs; `delete` prompts before removing persistent volumes or claims from a terminal (RFE-8872). Under `oc adm`: drain, cordon, uncordon, taint, certificates are also kubectl wrappers.
 
 **Commands that extend kubectl** — These embed kubectl's implementation struct and add OCP-specific logic. `logs` embeds kubectl's `logs.LogsOptions` and adds Build/DeploymentConfig support. `expose` adds Route creation. `rollout`/`rollback` add DeploymentConfig support. These live in their own packages under `pkg/cli/`, not in `kubectlwrappers/`.
 

--- a/pkg/cli/kubectlwrappers/delete.go
+++ b/pkg/cli/kubectlwrappers/delete.go
@@ -1,0 +1,216 @@
+package kubectlwrappers
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/kubectl/pkg/cmd/delete"
+	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/templates"
+
+	cmdutil "github.com/openshift/oc/pkg/helpers/cmd"
+	"github.com/openshift/oc/pkg/helpers/term"
+)
+
+const storageDeleteWarning = `Warning: Deleting a PV or PVC may result in application downtime, data loss or workload failure if it is mounted by any active workload.
+Are you sure you want to proceed? (y/N): `
+
+// pvOrPVCKindRE matches YAML/JSON kind fields for PersistentVolume and PersistentVolumeClaim.
+var pvOrPVCKindRE = regexp.MustCompile(`(?i)kind["']?\s*:\s*["']?PersistentVolume(Claim)?["']?`)
+
+// NewCmdDelete is a wrapper for the Kubernetes cli delete command.
+//
+// When deleting persistent volumes or persistent volume claims from a terminal,
+// oc prints a warning and requires explicit confirmation (RFE-8872). Scripts and
+// other non-interactive sessions are unchanged. Pass --interactive=false to skip
+// the prompt in a terminal.
+func NewCmdDelete(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
+	cmd := cmdutil.ReplaceCommandName("kubectl", "oc", templates.Normalize(delete.NewCmdDelete(f, streams)))
+	cmd.Long = strings.Trim(cmd.Long+"\n\n"+templates.LongDesc(`
+		When deleting persistent volumes (pv) or persistent volume claims (pvc) from a terminal,
+		oc warns that the operation may disrupt workloads or cause data loss and asks for confirmation.
+		The default answer is no. Confirmation is skipped for non-interactive sessions (for example CI
+		scripts) and when --interactive=false is set.`), " \t\n")
+
+	originalRun := cmd.Run
+	cmd.Run = func(c *cobra.Command, args []string) {
+		kcmdutil.CheckErr(runDeleteWithStorageConfirmation(c, args, streams, originalRun, term.IsTerminalReader(streams.In)))
+	}
+	return cmd
+}
+
+func runDeleteWithStorageConfirmation(cmd *cobra.Command, args []string, streams genericiooptions.IOStreams, originalRun func(*cobra.Command, []string), isTerminal bool) error {
+	opts, err := storageDeleteConfirmOptionsFromCmd(cmd, args, isTerminal)
+	if err != nil {
+		// Invalid flags such as --dry-run are reported by the wrapped command.
+		originalRun(cmd, args)
+		return nil
+	}
+
+	if opts.shouldWarn() {
+		if !confirmStorageDelete(streams.In, streams.ErrOut) {
+			fmt.Fprintf(streams.Out, "deletion is cancelled\n")
+			return nil
+		}
+	}
+
+	originalRun(cmd, args)
+	return nil
+}
+
+type storageDeleteConfirmOptions struct {
+	Args               []string
+	Filenames          []string
+	Interactive        bool
+	InteractiveChanged bool
+	DryRun             kcmdutil.DryRunStrategy
+	Raw                string
+	IsTerminal         bool
+}
+
+func storageDeleteConfirmOptionsFromCmd(cmd *cobra.Command, args []string, isTerminal bool) (storageDeleteConfirmOptions, error) {
+	opts := storageDeleteConfirmOptions{
+		Args:       args,
+		IsTerminal: isTerminal,
+	}
+
+	dryRun, err := kcmdutil.GetDryRunStrategy(cmd)
+	if err != nil {
+		return opts, err
+	}
+	opts.DryRun = dryRun
+
+	if cmd.Flags().Lookup("raw") != nil {
+		opts.Raw, _ = cmd.Flags().GetString("raw")
+	}
+	if cmd.Flags().Lookup("filename") != nil {
+		opts.Filenames, _ = cmd.Flags().GetStringSlice("filename")
+	}
+	if f := cmd.Flags().Lookup("interactive"); f != nil {
+		opts.InteractiveChanged = f.Changed
+		opts.Interactive, _ = cmd.Flags().GetBool("interactive")
+	}
+
+	return opts, nil
+}
+
+func (o storageDeleteConfirmOptions) shouldWarn() bool {
+	if !o.IsTerminal {
+		return false
+	}
+	if o.Raw != "" {
+		return false
+	}
+	if o.DryRun != kcmdutil.DryRunNone {
+		return false
+	}
+	if o.InteractiveChanged {
+		// Honor an explicit --interactive setting: kubectl prompts when true,
+		// and the user opted out when false.
+		return false
+	}
+	return argsOrFilesIncludePVOrPVC(o.Args, o.Filenames)
+}
+
+func argsOrFilesIncludePVOrPVC(args, filenames []string) bool {
+	if argsIncludePVOrPVC(args) {
+		return true
+	}
+	for _, filename := range filenames {
+		if fileContainsPVOrPVC(filename) {
+			return true
+		}
+	}
+	return false
+}
+
+func argsIncludePVOrPVC(args []string) bool {
+	if len(args) == 0 {
+		return false
+	}
+
+	hasResourceName := false
+	for _, arg := range args {
+		if strings.Contains(arg, "/") {
+			hasResourceName = true
+			break
+		}
+	}
+
+	if hasResourceName {
+		for _, arg := range args {
+			for _, part := range strings.Split(arg, ",") {
+				resource := strings.TrimSpace(part)
+				if i := strings.Index(resource, "/"); i >= 0 {
+					resource = resource[:i]
+				}
+				if isPVOrPVCResource(resource) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	for _, resource := range strings.Split(args[0], ",") {
+		if isPVOrPVCResource(resource) {
+			return true
+		}
+	}
+	return false
+}
+
+func isPVOrPVCResource(name string) bool {
+	name = strings.ToLower(strings.TrimSpace(name))
+	if i := strings.Index(name, "."); i >= 0 {
+		name = name[:i]
+	}
+	switch name {
+	case "pv", "persistentvolume", "persistentvolumes",
+		"pvc", "persistentvolumeclaim", "persistentvolumeclaims":
+		return true
+	default:
+		return false
+	}
+}
+
+func fileContainsPVOrPVC(path string) bool {
+	if path == "" || path == "-" {
+		return false
+	}
+	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
+		return false
+	}
+
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return false
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	data, err := io.ReadAll(io.LimitReader(f, 1<<20))
+	if err != nil {
+		return false
+	}
+	return pvOrPVCKindRE.Match(data)
+}
+
+func confirmStorageDelete(in io.Reader, out io.Writer) bool {
+	fmt.Fprint(out, storageDeleteWarning)
+	var input string
+	if _, err := fmt.Fscanln(in, &input); err != nil {
+		return false
+	}
+	return strings.EqualFold(input, "y")
+}

--- a/pkg/cli/kubectlwrappers/delete_test.go
+++ b/pkg/cli/kubectlwrappers/delete_test.go
@@ -1,0 +1,304 @@
+package kubectlwrappers
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
+)
+
+func TestArgsIncludePVOrPVC(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "empty", args: nil, want: false},
+		{name: "pod by type and name", args: []string{"pod", "foo"}, want: false},
+		{name: "pvc short name", args: []string{"pvc", "data"}, want: true},
+		{name: "pv short name", args: []string{"pv", "pv-1"}, want: true},
+		{name: "persistentvolumeclaim", args: []string{"persistentvolumeclaim", "data"}, want: true},
+		{name: "persistentvolumes plural", args: []string{"persistentvolumes", "pv-1"}, want: true},
+		{name: "mixed types including pvc", args: []string{"pod,pvc", "foo"}, want: true},
+		{name: "resource/name pvc", args: []string{"pvc/data"}, want: true},
+		{name: "resource/name pv among pods", args: []string{"pod/foo", "pv/bar"}, want: true},
+		{name: "resource/name pods only", args: []string{"pod/foo", "svc/bar"}, want: false},
+		{name: "case insensitive", args: []string{"PersistentVolumeClaim", "data"}, want: true},
+		{name: "name that looks like pvc", args: []string{"pod", "pvc"}, want: false},
+		{name: "qualified kind", args: []string{"persistentvolumeclaims.v1", "data"}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := argsIncludePVOrPVC(tt.args); got != tt.want {
+				t.Errorf("argsIncludePVOrPVC(%q) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsPVOrPVCResource(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{name: "pv", want: true},
+		{name: "pvc", want: true},
+		{name: "PersistentVolume", want: true},
+		{name: "persistentvolumeclaims", want: true},
+		{name: "pod", want: false},
+		{name: "service", want: false},
+		{name: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isPVOrPVCResource(tt.name); got != tt.want {
+				t.Errorf("isPVOrPVCResource(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFileContainsPVOrPVC(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pvcFile := filepath.Join(dir, "pvc.yaml")
+	podFile := filepath.Join(dir, "pod.yaml")
+	jsonFile := filepath.Join(dir, "pvc.json")
+
+	if err := os.WriteFile(pvcFile, []byte("apiVersion: v1\nkind: PersistentVolumeClaim\nmetadata:\n  name: data\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(podFile, []byte("apiVersion: v1\nkind: Pod\nmetadata:\n  name: nginx\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(jsonFile, []byte(`{"apiVersion":"v1","kind":"PersistentVolume","metadata":{"name":"pv1"}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "pvc yaml", path: pvcFile, want: true},
+		{name: "pod yaml", path: podFile, want: false},
+		{name: "pv json", path: jsonFile, want: true},
+		{name: "stdin", path: "-", want: false},
+		{name: "url", path: "https://example.com/pvc.yaml", want: false},
+		{name: "missing", path: filepath.Join(dir, "missing.yaml"), want: false},
+		{name: "directory", path: dir, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := fileContainsPVOrPVC(tt.path); got != tt.want {
+				t.Errorf("fileContainsPVOrPVC(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShouldWarn(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		opts storageDeleteConfirmOptions
+		want bool
+	}{
+		{
+			name: "tty pvc",
+			opts: storageDeleteConfirmOptions{Args: []string{"pvc", "data"}, IsTerminal: true, DryRun: kcmdutil.DryRunNone},
+			want: true,
+		},
+		{
+			name: "non-tty pvc",
+			opts: storageDeleteConfirmOptions{Args: []string{"pvc", "data"}, IsTerminal: false, DryRun: kcmdutil.DryRunNone},
+			want: false,
+		},
+		{
+			name: "tty pod",
+			opts: storageDeleteConfirmOptions{Args: []string{"pod", "foo"}, IsTerminal: true, DryRun: kcmdutil.DryRunNone},
+			want: false,
+		},
+		{
+			name: "dry-run client",
+			opts: storageDeleteConfirmOptions{Args: []string{"pvc", "data"}, IsTerminal: true, DryRun: kcmdutil.DryRunClient},
+			want: false,
+		},
+		{
+			name: "raw request",
+			opts: storageDeleteConfirmOptions{Args: []string{"pvc", "data"}, IsTerminal: true, Raw: "/api/v1/persistentvolumeclaims/data", DryRun: kcmdutil.DryRunNone},
+			want: false,
+		},
+		{
+			name: "explicit interactive false",
+			opts: storageDeleteConfirmOptions{Args: []string{"pvc", "data"}, IsTerminal: true, InteractiveChanged: true, Interactive: false, DryRun: kcmdutil.DryRunNone},
+			want: false,
+		},
+		{
+			name: "explicit interactive true uses kubectl prompt",
+			opts: storageDeleteConfirmOptions{Args: []string{"pvc", "data"}, IsTerminal: true, InteractiveChanged: true, Interactive: true, DryRun: kcmdutil.DryRunNone},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.opts.shouldWarn(); got != tt.want {
+				t.Errorf("shouldWarn() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfirmStorageDelete(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{name: "y", input: "y\n", want: true},
+		{name: "Y", input: "Y\n", want: true},
+		{name: "n", input: "n\n", want: false},
+		{name: "empty", input: "\n", want: false},
+		{name: "yes is not accepted", input: "yes\n", want: false},
+		{name: "eof", input: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var out bytes.Buffer
+			got := confirmStorageDelete(strings.NewReader(tt.input), &out)
+			if got != tt.want {
+				t.Errorf("confirmStorageDelete(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+			if !strings.Contains(out.String(), "Warning:") {
+				t.Errorf("prompt %q does not contain the required warning", out.String())
+			}
+			if !strings.Contains(out.String(), "(y/N)") {
+				t.Errorf("prompt %q does not default to no", out.String())
+			}
+		})
+	}
+}
+
+func TestRunDeleteWithStorageConfirmationCancel(t *testing.T) {
+	t.Parallel()
+
+	var ran bool
+	cmd := newTestDeleteCommand()
+	in := strings.NewReader("n\n")
+	var out, errOut bytes.Buffer
+	streams := genericiooptions.IOStreams{In: in, Out: &out, ErrOut: &errOut}
+
+	err := runDeleteWithStorageConfirmation(cmd, []string{"pvc", "data"}, streams, func(*cobra.Command, []string) {
+		ran = true
+	}, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ran {
+		t.Fatal("wrapped delete ran after the user declined")
+	}
+	if !strings.Contains(out.String(), "deletion is cancelled") {
+		t.Errorf("stdout %q does not report cancellation", out.String())
+	}
+}
+
+func TestRunDeleteWithStorageConfirmationProceed(t *testing.T) {
+	t.Parallel()
+
+	var gotArgs []string
+	cmd := newTestDeleteCommand()
+	in := strings.NewReader("y\n")
+	var out, errOut bytes.Buffer
+	streams := genericiooptions.IOStreams{In: in, Out: &out, ErrOut: &errOut}
+
+	err := runDeleteWithStorageConfirmation(cmd, []string{"pvc", "data"}, streams, func(_ *cobra.Command, args []string) {
+		gotArgs = append([]string(nil), args...)
+	}, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if diff := cmp.Diff([]string{"pvc", "data"}, gotArgs); diff != "" {
+		t.Errorf("wrapped delete args mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestRunDeleteWithStorageConfirmationNonStorage(t *testing.T) {
+	t.Parallel()
+
+	var ran bool
+	cmd := newTestDeleteCommand()
+	in := strings.NewReader("")
+	var out, errOut bytes.Buffer
+	streams := genericiooptions.IOStreams{In: in, Out: &out, ErrOut: &errOut}
+
+	err := runDeleteWithStorageConfirmation(cmd, []string{"pod", "foo"}, streams, func(*cobra.Command, []string) {
+		ran = true
+	}, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ran {
+		t.Fatal("wrapped delete did not run for a non-storage resource")
+	}
+	if errOut.Len() != 0 {
+		t.Errorf("unexpected warning for pod delete: %q", errOut.String())
+	}
+}
+
+func TestRunDeleteWithStorageConfirmationNonInteractive(t *testing.T) {
+	t.Parallel()
+
+	var ran bool
+	cmd := newTestDeleteCommand()
+	in := strings.NewReader("")
+	var out, errOut bytes.Buffer
+	streams := genericiooptions.IOStreams{In: in, Out: &out, ErrOut: &errOut}
+
+	err := runDeleteWithStorageConfirmation(cmd, []string{"pvc", "data"}, streams, func(*cobra.Command, []string) {
+		ran = true
+	}, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ran {
+		t.Fatal("wrapped delete did not run for a non-interactive pvc delete")
+	}
+	if errOut.Len() != 0 {
+		t.Errorf("unexpected prompt in a non-interactive session: %q", errOut.String())
+	}
+}
+
+func newTestDeleteCommand() *cobra.Command {
+	cmd := &cobra.Command{Use: "delete"}
+	cmd.Flags().String("dry-run", "none", "")
+	cmd.Flags().Lookup("dry-run").NoOptDefVal = "unchanged"
+	cmd.Flags().String("raw", "", "")
+	cmd.Flags().StringSlice("filename", nil, "")
+	cmd.Flags().Bool("interactive", false, "")
+	return cmd
+}

--- a/pkg/cli/kubectlwrappers/wrappers.go
+++ b/pkg/cli/kubectlwrappers/wrappers.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/kubectl/pkg/cmd/completion"
 	"k8s.io/kubectl/pkg/cmd/cp"
 	kcreate "k8s.io/kubectl/pkg/cmd/create"
-	"k8s.io/kubectl/pkg/cmd/delete"
 	"k8s.io/kubectl/pkg/cmd/describe"
 	"k8s.io/kubectl/pkg/cmd/diff"
 	"k8s.io/kubectl/pkg/cmd/edit"
@@ -77,11 +76,6 @@ func NewCmdClusterInfo(f kcmdutil.Factory, streams genericiooptions.IOStreams) *
 // NewCmdPatch is a wrapper for the Kubernetes cli patch command
 func NewCmdPatch(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	return cmdutil.ReplaceCommandName("kubectl", "oc", templates.Normalize(patch.NewCmdPatch(f, streams)))
-}
-
-// NewCmdDelete is a wrapper for the Kubernetes cli delete command
-func NewCmdDelete(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
-	return cmdutil.ReplaceCommandName("kubectl", "oc", templates.Normalize(delete.NewCmdDelete(f, streams)))
 }
 
 // NewCmdCreate is a wrapper for the Kubernetes cli create command


### PR DESCRIPTION
## Summary
- Prompt in a terminal before `oc delete` removes a persistent volume or claim, matching [RFE-8872](https://redhat.atlassian.net/browse/RFE-8872).
- Skip the prompt for non-interactive sessions (CI/scripts) and when `--interactive=false` is set, so existing automation is unchanged.
- Detect PV/PVC deletes from resource args (`pvc`, `pv`, `pvc/name`, mixed types) and from local `-f` manifests.

## Test plan
- [ ] `go test -mod=vendor ./pkg/cli/kubectlwrappers/`
- [ ] In a terminal, `oc delete pvc <name>` shows the warning and `(y/N)`; `n` or empty input prints `deletion is cancelled`
- [ ] `echo y | oc delete pvc <name>` (non-TTY) deletes without hanging
- [ ] `oc delete pod <name>` is unchanged
- [ ] `oc delete --interactive=false pvc <name>` skips the new prompt
- [ ] `oc delete --dry-run=client pvc <name>` does not prompt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a safety confirmation prompt when deleting persistent volumes or claims through `oc delete` in an interactive terminal.
  * Supports detecting storage resources specified directly or through local YAML/JSON files.
  * Deletion is canceled when confirmation is declined or invalid.

* **Bug Fixes**
  * Prompts are appropriately skipped for dry runs, raw output, explicit interactive settings, non-storage resources, and non-interactive sessions.

* **Documentation**
  * Updated guidance describing the storage deletion safety check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->