### PR TITLE
RFE-9789: oc whoami --show-token should return exec plugin tokens

### DIFF
--- a/pkg/cli/whoami/whoami.go
+++ b/pkg/cli/whoami/whoami.go
@@ -3,6 +3,8 @@ package whoami
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -40,6 +42,9 @@ var whoamiLong = templates.LongDesc(`
 var whoamiExample = templates.Examples(`
 	# Display the currently authenticated user
 	oc whoami
+
+	# Display the token for this session
+	oc whoami --show-token
 `)
 
 type WhoAmIOptions struct {
@@ -83,7 +88,7 @@ func NewCmdWhoAmI(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra
 		},
 	}
 
-	cmd.Flags().BoolVarP(&o.ShowToken, "show-token", "t", o.ShowToken, "Print the token the current session is using. This will return an error if you are using a different form of authentication.")
+	cmd.Flags().BoolVarP(&o.ShowToken, "show-token", "t", o.ShowToken, "Print the token the current session is using, including tokens from exec credential plugins. This will return an error if you are using a different form of authentication.")
 	cmd.Flags().BoolVarP(&o.ShowContext, "show-context", "c", o.ShowContext, "Print the current user context name")
 	cmd.Flags().BoolVar(&o.ShowServer, "show-server", o.ShowServer, "If true, print the current server's REST API URL")
 	cmd.Flags().BoolVar(&o.ShowConsoleUrl, "show-console", o.ShowConsoleUrl, "If true, print the current server's web console URL")
@@ -152,9 +157,6 @@ func (o *WhoAmIOptions) Validate() error {
 	if o.PrintFlags.OutputFlagSpecified() && (o.ShowToken || o.ShowContext || o.ShowServer || o.ShowConsoleUrl) {
 		return fmt.Errorf("--output cannot be used with --show-token, --show-context, --show-server, or --show-console")
 	}
-	if o.ShowToken && len(o.ClientConfig.BearerToken) == 0 {
-		return fmt.Errorf("no token is currently in use for this session")
-	}
 	if o.ShowContext && len(o.RawConfig.CurrentContext) == 0 {
 		return fmt.Errorf("no context has been set")
 	}
@@ -181,7 +183,14 @@ func (o *WhoAmIOptions) getWebConsoleUrl() (string, error) {
 func (o *WhoAmIOptions) Run() error {
 	switch {
 	case o.ShowToken:
-		fmt.Fprintf(o.Out, "%s\n", o.ClientConfig.BearerToken)
+		token, err := currentBearerToken(o.ClientConfig)
+		if err != nil {
+			return err
+		}
+		if len(token) == 0 {
+			return fmt.Errorf("no token is currently in use for this session")
+		}
+		fmt.Fprintf(o.Out, "%s\n", token)
 		return nil
 	case o.ShowContext:
 		fmt.Fprintf(o.Out, "%s\n", o.RawConfig.CurrentContext)
@@ -211,4 +220,56 @@ func (o *WhoAmIOptions) Run() error {
 
 	_, err = o.WhoAmI()
 	return err
+}
+
+// currentBearerToken returns the bearer token used by the current session.
+// Static kubeconfig tokens and token files are returned directly. Exec
+// credential plugins (ExecCredential) and auth providers are resolved through
+// the same client-go transport stack used for API requests, including plugin
+// caching and TTL.
+func currentBearerToken(config *rest.Config) (string, error) {
+	if config == nil {
+		return "", nil
+	}
+	if len(config.BearerToken) > 0 {
+		return config.BearerToken, nil
+	}
+
+	cfg := rest.CopyConfig(config)
+	capture := &bearerCapturingRoundTripper{}
+	rt, err := rest.HTTPWrappersForConfig(cfg, capture)
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "https://kubernetes.default.svc", nil)
+	if err != nil {
+		return "", err
+	}
+	if _, err := rt.RoundTrip(req); err != nil {
+		return "", fmt.Errorf("unable to get token for this session: %w", err)
+	}
+	return capture.token, nil
+}
+
+type bearerCapturingRoundTripper struct {
+	token string
+}
+
+func (rt *bearerCapturingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.token = tokenFromAuthorizationHeader(req.Header.Get("Authorization"))
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       http.NoBody,
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+func tokenFromAuthorizationHeader(header string) string {
+	const prefix = "Bearer "
+	if len(header) < len(prefix) || !strings.EqualFold(header[:len(prefix)], prefix) {
+		return ""
+	}
+	return header[len(prefix):]
 }

--- a/pkg/cli/whoami/whoami_test.go
+++ b/pkg/cli/whoami/whoami_test.go
@@ -5,6 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -20,7 +23,9 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	authfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
 	core "k8s.io/client-go/testing"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/kubectl/pkg/scheme"
 	"sigs.k8s.io/yaml"
 )
@@ -481,4 +486,125 @@ func TestWhoAmIOutputJSONFallbackToUserAPI(t *testing.T) {
 	if diff := cmp.Diff(expectedUser, actualUser); diff != "" {
 		t.Errorf("User mismatch (-expected +actual):\n%s", diff)
 	}
+}
+
+const whoamiTestExecPluginEnv = "WHOAMI_TEST_EXEC_PLUGIN"
+
+func TestMain(m *testing.M) {
+	if pluginMode := os.Getenv(whoamiTestExecPluginEnv); pluginMode != "" {
+		runWhoamiTestExecPlugin(pluginMode)
+	}
+	os.Exit(m.Run())
+}
+
+func TestCurrentBearerToken(t *testing.T) {
+	tokenFile := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(tokenFile, []byte("file-token\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		config  *rest.Config
+		want    string
+		wantErr string
+	}{
+		{
+			name:   "static bearer token",
+			config: &rest.Config{BearerToken: "static-token"},
+			want:   "static-token",
+		},
+		{
+			name:   "bearer token file",
+			config: &rest.Config{BearerTokenFile: tokenFile},
+			want:   "file-token",
+		},
+		{
+			name:   "static token preferred over exec plugin",
+			config: execPluginConfig(t, "plugin-token", "static-preferred"),
+			want:   "static-preferred",
+		},
+		{
+			name:   "exec plugin token",
+			config: execPluginConfig(t, "exec-plugin-token", ""),
+			want:   "exec-plugin-token",
+		},
+		{
+			name:    "no token",
+			config:  &rest.Config{},
+			wantErr: "no token is currently in use for this session",
+		},
+		{
+			name:    "nil config",
+			wantErr: "no token is currently in use for this session",
+		},
+		{
+			name:    "exec plugin failure",
+			config:  execPluginConfig(t, "FAIL", ""),
+			wantErr: "unable to get token for this session",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			opts := &WhoAmIOptions{
+				ClientConfig: tt.config,
+				ShowToken:    true,
+				PrintFlags:   genericclioptions.NewPrintFlags("").WithTypeSetter(scheme.Scheme),
+				IOStreams: genericiooptions.IOStreams{
+					Out:    &buf,
+					ErrOut: io.Discard,
+				},
+			}
+
+			err := opts.Run()
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got := buf.String(); got != tt.want+"\n" {
+				t.Fatalf("got %q, want %q", got, tt.want+"\n")
+			}
+		})
+	}
+}
+
+func execPluginConfig(t *testing.T, pluginToken, staticToken string) *rest.Config {
+	t.Helper()
+	return &rest.Config{
+		Host:        "https://example.invalid",
+		BearerToken: staticToken,
+		ExecProvider: &clientcmdapi.ExecConfig{
+			APIVersion: "client.authentication.k8s.io/v1",
+			Command:    os.Args[0],
+			Args:       []string{"-test.run=^TestCurrentBearerToken$"},
+			Env: []clientcmdapi.ExecEnvVar{
+				{Name: whoamiTestExecPluginEnv, Value: pluginToken},
+			},
+			InteractiveMode: clientcmdapi.NeverExecInteractiveMode,
+		},
+	}
+}
+
+func runWhoamiTestExecPlugin(pluginMode string) {
+	if pluginMode == "FAIL" {
+		os.Exit(1)
+	}
+	_ = json.NewEncoder(os.Stdout).Encode(map[string]any{
+		"apiVersion": "client.authentication.k8s.io/v1",
+		"kind":       "ExecCredential",
+		"status": map[string]any{
+			"token": pluginMode,
+		},
+	})
+	os.Exit(0)
 }


### PR DESCRIPTION
## Summary
- `oc whoami --show-token` currently only reads `rest.Config.BearerToken`, which is empty for ExecCredential plugins such as `oc get-token`.
- Resolve the session token through the same client-go transport stack used for API requests so exec plugins (and token files/auth providers) are invoked with their normal caching/TTL.
- Static bearer tokens and non-token auth (cert/basic) keep the existing behavior, including `no token is currently in use for this session` when no bearer token is available.

Fixes https://github.com/openshift/oc/issues/2377
Jira: https://issues.redhat.com/browse/OCPBUGS-113632
Support case: 04524345

## Test plan
- [ ] `go test ./pkg/cli/whoami/` (covers static token, token file, exec plugin success/failure, and no-token)
- [ ] With a kubeconfig user configured for `oc get-token` exec auth, `oc get projects` succeeds and `oc whoami --show-token` prints the current bearer token
- [ ] With a static token kubeconfig, `oc whoami --show-token` still prints that token
- [ ] With cert-only or basic auth, `oc whoami --show-token` still errors with `no token is currently in use for this session`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `whoami --show-token` now supports tokens from static configuration, token files, exec-based credential providers, and authentication providers.
  - Added clear errors when token resolution fails or no token is available.
  - Updated the flag description and usage example.

- **Bug Fixes**
  - Removed the requirement for a statically configured bearer token when using `--show-token`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->