### PR TITLE
OCPBUGS-104179:[release-4.21] Go HTTP/2: Denial of Service via malformed SETTINGS_MAX_FRAME_SIZE frame 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -218,4 +218,4 @@ require (
 
 replace github.com/apcera/gssapi => github.com/openshift/gssapi v0.0.0-20161010215902-5fb4217df13b
 
-replace golang.org/x/net => github.com/openshift-sustaining/net v0.50.0-sec.2
+replace golang.org/x/net => github.com/openshift-sustaining/net v0.50.0-sec.4

--- a/go.sum
+++ b/go.sum
@@ -367,8 +367,8 @@ github.com/opencontainers/runtime-spec v1.2.1 h1:S4k4ryNgEpxW1dzyqffOmhI1BHYcjzU
 github.com/opencontainers/runtime-spec v1.2.1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.12.0 h1:6n5JV4Cf+4y0KNXW48TLj5DwfXpvWlxXplUkdTrmPb8=
 github.com/opencontainers/selinux v1.12.0/go.mod h1:BTPX+bjVbWGXw7ZZWUbdENt8w0htPSrlgOOysQaU62U=
-github.com/openshift-sustaining/net v0.50.0-sec.2 h1:eVij2KKwmcqyE0pWu8ymnD6RvMb+k/8Gd7Z1lC3Q69w=
-github.com/openshift-sustaining/net v0.50.0-sec.2/go.mod h1:UgoSli3F/pBgdJBHCTc+tp3gmrU4XswgGRgtnwWTfyM=
+github.com/openshift-sustaining/net v0.50.0-sec.4 h1:jmkVQIRNrS0DAs24K0yLYJHqH5e+svnbXb/ihoTPKRs=
+github.com/openshift-sustaining/net v0.50.0-sec.4/go.mod h1:UgoSli3F/pBgdJBHCTc+tp3gmrU4XswgGRgtnwWTfyM=
 github.com/openshift/api v0.0.0-20251020135558-286504b695bc h1:hUPxgvR9S2Xt6IUeToTVxSr6mYfV0dyedmccLoSrbIo=
 github.com/openshift/api v0.0.0-20251020135558-286504b695bc/go.mod h1:d5uzF0YN2nQQFA0jIEWzzOZ+edmo6wzlGLvx5Fhz4uY=
 github.com/openshift/build-machinery-go v0.0.0-20251020112516-49aa9f5db6d8 h1:2sktNP3CNpDb5F9rIg1qcBYU4lFxsOfBsUSP32LwAPo=

--- a/vendor/golang.org/x/net/html/token.go
+++ b/vendor/golang.org/x/net/html/token.go
@@ -156,6 +156,7 @@ type Tokenizer struct {
 	// incremented on each call to TagAttr.
 	pendingAttr   [2]span
 	attr          [][2]span
+	attrNames     map[string]bool
 	nAttrReturned int
 	// rawTag is the "script" in "</script>" that closes the next token. If
 	// non-empty, the subsequent call to Next will return a raw or RCDATA text
@@ -867,6 +868,7 @@ func (z *Tokenizer) readStartTag() TokenType {
 func (z *Tokenizer) readTag(saveAttr bool) {
 	z.attr = z.attr[:0]
 	z.nAttrReturned = 0
+	clear(z.attrNames)
 	// Read the tag name and attribute key/value pairs.
 	z.readTagName()
 	if z.skipWhiteSpace(); z.err != nil {
@@ -880,9 +882,11 @@ func (z *Tokenizer) readTag(saveAttr bool) {
 		z.raw.end--
 		z.readTagAttrKey()
 		z.readTagAttrVal()
-		// Save pendingAttr if saveAttr and that attribute has a non-empty key.
-		if saveAttr && z.pendingAttr[0].start != z.pendingAttr[0].end {
+		// Save pendingAttr if saveAttr and that attribute has a non-empty key, and the key hasn't been seen before.
+		key := strings.ToLower(string(z.buf[z.pendingAttr[0].start:z.pendingAttr[0].end]))
+		if saveAttr && z.pendingAttr[0].start != z.pendingAttr[0].end && !z.attrNames[key] {
 			z.attr = append(z.attr, z.pendingAttr)
+			z.attrNames[key] = true
 		}
 		if z.skipWhiteSpace(); z.err != nil {
 			break
@@ -1273,8 +1277,9 @@ func NewTokenizer(r io.Reader) *Tokenizer {
 // The input is assumed to be UTF-8 encoded.
 func NewTokenizerFragment(r io.Reader, contextTag string) *Tokenizer {
 	z := &Tokenizer{
-		r:   r,
-		buf: make([]byte, 0, 4096),
+		r:         r,
+		buf:       make([]byte, 0, 4096),
+		attrNames: make(map[string]bool),
 	}
 	if contextTag != "" {
 		switch s := strings.ToLower(contextTag); s {

--- a/vendor/golang.org/x/net/http2/transport.go
+++ b/vendor/golang.org/x/net/http2/transport.go
@@ -2865,6 +2865,9 @@ func (rl *clientConnReadLoop) processSettingsNoWrite(f *SettingsFrame) error {
 
 	var seenMaxConcurrentStreams bool
 	err := f.ForeachSetting(func(s Setting) error {
+		if err := s.Valid(); err != nil {
+			return err
+		}
 		switch s.ID {
 		case SettingMaxFrameSize:
 			cc.maxFrameSize = s.Val
@@ -2896,9 +2899,6 @@ func (rl *clientConnReadLoop) processSettingsNoWrite(f *SettingsFrame) error {
 			cc.henc.SetMaxDynamicTableSize(s.Val)
 			cc.peerMaxHeaderTableSize = s.Val
 		case SettingEnableConnectProtocol:
-			if err := s.Valid(); err != nil {
-				return err
-			}
 			// If the peer wants to send us SETTINGS_ENABLE_CONNECT_PROTOCOL,
 			// we require that it do so in the first SETTINGS frame.
 			//

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1031,7 +1031,7 @@ golang.org/x/crypto/sha3
 ## explicit; go 1.20
 golang.org/x/exp/maps
 golang.org/x/exp/mmap
-# golang.org/x/net v0.49.0 => github.com/openshift-sustaining/net v0.50.0-sec.2
+# golang.org/x/net v0.49.0 => github.com/openshift-sustaining/net v0.50.0-sec.4
 ## explicit; go 1.24.0
 golang.org/x/net/context
 golang.org/x/net/html
@@ -1924,4 +1924,4 @@ sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v3
 sigs.k8s.io/yaml/kyaml
 # github.com/apcera/gssapi => github.com/openshift/gssapi v0.0.0-20161010215902-5fb4217df13b
-# golang.org/x/net => github.com/openshift-sustaining/net v0.50.0-sec.2
+# golang.org/x/net => github.com/openshift-sustaining/net v0.50.0-sec.4


### PR DESCRIPTION
Summary
  
1.  Fixes CVE-2026-33814 (golang.org/x/net/http2 HTTP/2 client infinite-loop DoS on SETTINGS_MAX_FRAME_SIZE=0, GO-2026-4918, CVSS 7.5) on release-4.21
2.  Uses go mod edit -replace to pin golang.org/x/net to github.com/openshift-sustaining/net@v0.50.0-sec.4 (keeps go 1.24.0; the upstream fix in x/net v0.53.0 would force go 1.25.0)
3.  Ran go mod tidy, go mod vendor, and verified clean build with go build ./...

  Test plan

  - [x] go build ./... passes locally
  - [x] govulncheck ./... no longer reports GO-2026-4918
  - [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)