### PR TITLE
OCPBUGS-106186: Fix registry blob upload request headers

### DIFF
--- a/deps.diff
+++ b/deps.diff
@@ -1,0 +1,13 @@
+diff --no-dereference -N -r current/vendor/github.com/distribution/distribution/v3/registry/client/blob_writer.go updated/vendor/github.com/distribution/distribution/v3/registry/client/blob_writer.go
+28,31d27
+< type ContentLengthResolver interface {
+< 	ContentLength() int64
+< }
+< 
+49,54d44
+< 
+< 	req.Header.Set("Content-Type", "application/octet-stream")
+< 	if clr, ok := r.(ContentLengthResolver); ok {
+< 		req.ContentLength = clr.ContentLength()
+< 		req.Header.Set("Content-Range", fmt.Sprintf("%d-%d", hbu.offset, hbu.offset+req.ContentLength-1))
+< 	}

--- a/pkg/cli/image/mirror/mirror.go
+++ b/pkg/cli/image/mirror/mirror.go
@@ -664,6 +664,15 @@ func (o *MirrorImageOptions) plan() (*plan, error) {
 	return plan, nil
 }
 
+type readerWithContentLength struct {
+	io.Reader
+	contentLength int64
+}
+
+func (sr readerWithContentLength) ContentLength() int64 {
+	return sr.contentLength
+}
+
 func copyBlob(ctx context.Context, plan *workPlan, c *repositoryBlobCopy, blob distribution.Descriptor, referentialClient *http.Client, force, skipMount bool, errOut io.Writer) error {
 	// if we aren't forcing upload, check to see if the blob aleady exists
 	if !force {
@@ -755,7 +764,7 @@ func copyBlob(ctx context.Context, plan *workPlan, c *repositoryBlobCopy, blob d
 
 		fmt.Fprintf(errOut, "uploading: %s %s %s\n", c.toRef, blob.Digest, units.BytesSize(float64(blob.Size)))
 
-		n, err := w.ReadFrom(r)
+		n, err := w.ReadFrom(readerWithContentLength{Reader: r, contentLength: blob.Size})
 		if err != nil {
 			klog.V(6).Infof("unable to copy layer %s to %s: %v", blob.Digest, c.toRef, err)
 			return fmt.Errorf("unable to copy layer %s to %s: %v", blob.Digest, c.toRef, err)

--- a/vendor/github.com/distribution/distribution/v3/registry/client/blob_writer.go
+++ b/vendor/github.com/distribution/distribution/v3/registry/client/blob_writer.go
@@ -25,6 +25,10 @@ type httpBlobUpload struct {
 	closed   bool
 }
 
+type ContentLengthResolver interface {
+	ContentLength() int64
+}
+
 func (hbu *httpBlobUpload) Reader() (io.ReadCloser, error) {
 	panic("Not implemented")
 }
@@ -42,6 +46,12 @@ func (hbu *httpBlobUpload) ReadFrom(r io.Reader) (n int64, err error) {
 		return 0, err
 	}
 	defer req.Body.Close()
+
+	req.Header.Set("Content-Type", "application/octet-stream")
+	if clr, ok := r.(ContentLengthResolver); ok {
+		req.ContentLength = clr.ContentLength()
+		req.Header.Set("Content-Range", fmt.Sprintf("%d-%d", hbu.offset, hbu.offset+req.ContentLength-1))
+	}
 
 	resp, err := hbu.client.Do(req)
 	if err != nil {


### PR DESCRIPTION
`oc image mirror` intermittently fails when uploading blobs over HTTP/2 to a local Docker registry on bare-metal CI. The `httpBlobUpload.ReadFrom` method in the vendored `distribution/distribution` library sends PATCH requests without `Content-Length`, `Content-Range`, or `Content-Type` headers, violating the OCI Distribution Spec. Over HTTP/2, this causes a flow control race: the client fills the server's flow control window and pauses; if the server sends response headers before granting more window, Go's HTTP/2 transport aborts the stream with `RST_STREAM CANCEL`. On retry, the server retains the partial upload but the client restarts from offset 0, resulting in an unrecoverable `"upload resumed at wrong offset"` error.

This PR:
- Carries a vendor patch on `distribution/distribution` `ReadFrom` to set `Content-Length`, `Content-Range`, and `Content-Type` headers when the reader provides a `ContentLength()` method
- Wraps the blob reader in `copyBlob` with a `readerWithContentLength` struct that exposes the known blob size

The upstream library has deprecated its client package (moved to `internal/` in v3.0.0), so an upstream fix is not viable. See [OCPBUGS-106186](https://issues.redhat.com/browse/OCPBUGS-106186) for details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image mirroring uploads by providing known content-length information during transfers.
  * Prevented incorrect or unnecessary upload headers from being set automatically.
  * Improved compatibility and reliability for blob uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->