### PR TITLE
OCPBUGS-114015: Added deployment example to oc set env help command

### DIFF
--- a/pkg/cli/set/env.go
+++ b/pkg/cli/set/env.go
@@ -64,8 +64,11 @@ var (
 		# Update all containers in all replication controllers in the project to have ENV=prod
 		oc set env rc --all ENV=prod
 
-		# Import environment from a secret
+		# Import environment from a secret to deployment config
 		oc set env --from=secret/mysecret dc/myapp
+
+		# Import environment from a secret to deployment
+        oc set env --from=secret/mysecret deployment/myapp
 
 		# Import environment from a config map with a prefix
 		oc set env --from=configmap/myconfigmap --prefix=MYSQL_ dc/myapp


### PR DESCRIPTION
Since OpenShift 4.14+, deployment resources are heavily favoured and recommended over OpenShift DeploymentConfig (dc) resources. While DeploymentConfig is still used in OCP 4.14+, standard deployment resources are now far more widely used in everyday workloads.

Currently, the oc set env --help output only includes examples for dc (DeploymentConfig) resources when injecting Secrets. To reflect modern OCP best practices and prevent confusion for users working with standard Deployments, this PR updates the CLI help examples to include both dc and deployment options.

Changes Included:

Before:

```
# Import environment from a secret
oc set env --from=secret/mysecret dc/myapp
```

After:

```
# Import environment from a secret to deployment config
oc set env --from=secret/mysecret dc/myapp

# Import environment from a secret to deployment
oc set env --from=secret/mysecret deployment/myapp
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI documentation to demonstrate importing environment variables from a secret into both deployment configurations and deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->