### PR TITLE
OCPBUGS-109578: proof pr to bump library-go to fix oc macos hcp insecure login

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/openshift/api v0.0.0-20260805215214-cfb63858e9d7
 	github.com/openshift/build-machinery-go v0.0.0-20260629141115-154a2b810491
 	github.com/openshift/client-go v0.0.0-20260806041845-b74fb348f1e7
-	github.com/openshift/library-go v0.0.0-20260901055840-8c76f7d75dd6
+	github.com/openshift/library-go v0.0.0-20260902200604-6de66ffc2023
 	github.com/openshift/osincli v0.0.0-20160924135400-fababb0555f2
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/prometheus/client_golang v1.23.2

--- a/go.sum
+++ b/go.sum
@@ -385,8 +385,8 @@ github.com/openshift/client-go v0.0.0-20260806041845-b74fb348f1e7 h1:Lphm0uMAyM2
 github.com/openshift/client-go v0.0.0-20260806041845-b74fb348f1e7/go.mod h1:u08LcpI8Hq3IpelQLbciGRa/P158cE/O3uQe2Bt3Roo=
 github.com/openshift/gssapi v0.0.0-20260819120910-d6b72669a11e h1:UCxtFDw0ObWGm4bmaAhFZ1hEwZPZnwiSONKj7G6WBr0=
 github.com/openshift/gssapi v0.0.0-20260819120910-d6b72669a11e/go.mod h1:tNrEB5k8SI+g5kOlsCmL2ELASfpqEofI0+FLBgBdN08=
-github.com/openshift/library-go v0.0.0-20260901055840-8c76f7d75dd6 h1:nmN0ZlH/5yVEv6QQgMcsvp1LtOIcoF8zFAQZ/rOus9s=
-github.com/openshift/library-go v0.0.0-20260901055840-8c76f7d75dd6/go.mod h1:pH7rnNOj3dJpdpBtE32LB2pAg0AYDIaaBJJrFxX2pPY=
+github.com/openshift/library-go v0.0.0-20260902200604-6de66ffc2023 h1:Em0zfVCYoLmxk/LnftWd/PDV7VpY5qdes3dpzanNFdI=
+github.com/openshift/library-go v0.0.0-20260902200604-6de66ffc2023/go.mod h1:pH7rnNOj3dJpdpBtE32LB2pAg0AYDIaaBJJrFxX2pPY=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1 h1:PMTgifBcBRLJJiM+LgSzPDTk9/Rx4qS09OUrfpY6GBQ=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/openshift/osincli v0.0.0-20160924135400-fababb0555f2 h1:9oADVMmPa4G60MQtoSjD26aD/vZreqbIAfiUiO220eY=

--- a/vendor/github.com/openshift/library-go/pkg/oauth/tokenrequest/request_token.go
+++ b/vendor/github.com/openshift/library-go/pkg/oauth/tokenrequest/request_token.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"runtime"
 	"slices"
 	"strings"
 
@@ -602,8 +603,23 @@ func verifyServerCertChain(dnsName string, chain []*x509.Certificate) ([][]*x509
 		intermediates.AddCert(c)
 	}
 
-	return chain[0].Verify(x509.VerifyOptions{
+	certChainList, err := chain[0].Verify(x509.VerifyOptions{
 		Intermediates: intermediates,
 		DNSName:       dnsName,
 	})
+
+	if runtime.GOOS == "darwin" && strings.HasPrefix(err.Error(), "x509:") {
+		// this check fills in the gap where root_darwin.go has insufficient
+		// typed errors for macOS platform, leading to a generic string based
+		// x509 error. This will return a proper x509 error which can be used
+		// to return kubeconfig CA client. x509.UnknownAuthorityError was
+		// chosen because this is the fall back also used on Linux/Windows,
+		// keeping the approach consistent across platforms.
+		// https://github.com/golang/go/blob/5a6340ff28c87e099f33c941e3d73e50d715ddf7/src/crypto/x509/root_darwin.go#L74
+		return nil, x509.UnknownAuthorityError{
+			Cert: chain[0],
+		}
+	}
+
+	return certChainList, err
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -900,7 +900,7 @@ github.com/openshift/client-go/user/clientset/versioned/fake
 github.com/openshift/client-go/user/clientset/versioned/scheme
 github.com/openshift/client-go/user/clientset/versioned/typed/user/v1
 github.com/openshift/client-go/user/clientset/versioned/typed/user/v1/fake
-# github.com/openshift/library-go v0.0.0-20260901055840-8c76f7d75dd6
+# github.com/openshift/library-go v0.0.0-20260902200604-6de66ffc2023
 ## explicit; go 1.26.0
 github.com/openshift/library-go/pkg/apiserver/jsonpatch
 github.com/openshift/library-go/pkg/apps/appsserialization


### PR DESCRIPTION
This commit bumps library-go to include the latest changes. It acts as a proof PR for https://github.com/openshift/library-go/pull/2455 . 

This fixes an issue seen when oc client is used to login to a HCP cluster on macOS. This allows oc to login successfully.

`verifyServerCertChain()` now has a check that returns an unknown authority error when it detects macOS and a string based x509 error.

It falls back to kubeconfig CA when a string based x509 error is observed on the macOS platform.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated an internal dependency to a newer revision.
  * Adjusted dependency sourcing to use an alternate compatible revision.
  * No changes were made to publicly exported entities or user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->