### PR TITLE
BUG OCPBUGS-119955: Fix oc debug -T race condition with container attach

### DIFF
--- a/pkg/cli/debug/debug.go
+++ b/pkg/cli/debug/debug.go
@@ -298,6 +298,7 @@ func (o *DebugOptions) Complete(cmd *cobra.Command, f kcmdutil.Factory, args []s
 		o.Attach.TTY = false
 	case o.DisableTTY:
 		o.Attach.TTY = false
+		o.Attach.Stdin = false
 	// don't default TTY to true if a command is passed
 	case len(o.Command) > 0:
 		o.Attach.TTY = false


### PR DESCRIPTION
## Summary

- `oc debug -T` (--no-tty) fails with "unable to upgrade connection: container container-00 not found" on OCP 5.0 (OCPBUGS-119955)
- Root cause: when `-T` is set, `Stdin` remains `true`, routing through the SPDY/WebSocket attach path instead of log-streaming. For fast-exiting commands, the container terminates before the upgrade completes.
- Fix: disable `Stdin` when `-T` is set, matching the existing behavior for commands passed without `-T` (lines 302-304). This routes through the log-streaming path which can't race with container completion.

## Details

In `Complete()`, the `case o.DisableTTY:` branch (line 299) only set `o.Attach.TTY = false` but left `o.Attach.Stdin = true` (the default). This caused `RunDebug()` to hit the `default:` case (line 665) which calls `o.Attach.Run()` — an attach that requires a SPDY/WebSocket connection upgrade. When the container exits before the upgrade completes, the kubelet returns "container not found".

The existing `case len(o.Command) > 0:` branch (line 302) already correctly sets both `TTY=false` and `Stdin=false`, but `-T` has higher priority in the switch and was missing the `Stdin=false`.

The code even has a TODO acknowledging this race: `// TODO: attach can race with pod completion, allow attach to switch to logs`

## Test plan

- [ ] `oc debug node/<node> -T -- cat /etc/os-release` should succeed consistently (was 100% failure rate before)
- [ ] `oc debug node/<node> -- cat /etc/os-release` should continue to work (no behavior change)
- [ ] `oc debug node/<node>` (interactive) should continue to work with TTY
- [ ] `oc debug -t node/<node>` (explicit TTY) should continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * When running debug attachment with `--no-tty`, standard input is now disabled as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->