### PR TITLE
OCPBUGS-122005: Add IDMS support to `oc image info`

### DIFF
--- a/pkg/cli/admin/release/extract.go
+++ b/pkg/cli/admin/release/extract.go
@@ -129,7 +129,7 @@ func NewExtract(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.C
 
 	flags.StringVar(&o.ICSPFile, "icsp-file", o.ICSPFile, "Path to an ImageContentSourcePolicy file. If set, data from this file will be used to find alternative locations for images.")
 	flags.MarkDeprecated("icsp-file", "support for it will be removed in a future release. Use --idms-file instead.")
-	flags.StringVar(&o.IDMSFile, "idms-file", o.IDMSFile, "Path to an ImageDigestMirrorSet file. If set, data from this file will be used to find alternative locations for images.")
+	flags.StringVar(&o.IDMSFile, "idms-file", o.IDMSFile, "Path to an ImageDigestMirrorSet file. If set, data from this file will be used to find alternative locations for images. Mirrors will be tried first.")
 
 	flags.StringVar(&o.From, "from", o.From, "Image containing the release payload.")
 	flags.StringVar(&o.File, "file", o.File, "Extract a single file from the payload to standard output.")

--- a/pkg/cli/admin/release/info.go
+++ b/pkg/cli/admin/release/info.go
@@ -148,7 +148,7 @@ func NewInfo(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Comm
 
 	flags.StringVar(&o.ICSPFile, "icsp-file", o.ICSPFile, "Path to an ImageContentSourcePolicy file. If set, data from this file will be used to find alternative locations for images.")
 	flags.MarkDeprecated("icsp-file", "support for it will be removed in a future release. Use --idms-file instead.")
-	flags.StringVar(&o.IDMSFile, "idms-file", o.IDMSFile, "Path to an ImageDigestMirrorSet file. If set, data from this file will be used to find alternative locations for images.")
+	flags.StringVar(&o.IDMSFile, "idms-file", o.IDMSFile, "Path to an ImageDigestMirrorSet file. If set, data from this file will be used to find alternative locations for images. Mirrors will be tried first.")
 
 	flags.BoolVar(&o.ShowContents, "contents", o.ShowContents, "Display the contents of a release.")
 	flags.BoolVar(&o.ShowCommit, "commits", o.ShowCommit, "Display information about the source an image was created with.")

--- a/pkg/cli/image/extract/extract.go
+++ b/pkg/cli/image/extract/extract.go
@@ -187,7 +187,7 @@ func NewExtract(streams genericiooptions.IOStreams) *cobra.Command {
 
 	flag.StringVar(&o.ICSPFile, "icsp-file", o.ICSPFile, "Path to an ImageContentSourcePolicy file. If set, data from this file will be used to find alternative locations for images.")
 	flag.MarkDeprecated("icsp-file", "support for it will be removed in a future release. Use --idms-file instead.")
-	flag.StringVar(&o.IDMSFile, "idms-file", o.IDMSFile, "Path to an ImageDigestMirrorSet file. If set, data from this file will be used to find alternative locations for images.")
+	flag.StringVar(&o.IDMSFile, "idms-file", o.IDMSFile, "Path to an ImageDigestMirrorSet file. If set, data from this file will be used to find alternative locations for images. Mirrors will be tried first.")
 
 	flag.StringSliceVar(&o.Files, "file", o.Files, "Extract the specified files to the current directory.")
 	flag.StringSliceVar(&o.Paths, "path", o.Paths, "Extract only part of an image, or, designate the directory on disk to extract image contents into. Must be SRC:DST where SRC is the path within the image and DST a local directory. If not specified the default is to extract everything to the current directory.")

--- a/pkg/cli/image/info/info.go
+++ b/pkg/cli/image/info/info.go
@@ -83,7 +83,7 @@ func NewInfo(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Comm
 	flags.StringVar(&o.FileDir, "dir", o.FileDir, "The directory on disk that file:// images will be read from.")
 	flags.StringVar(&o.ICSPFile, "icsp-file", o.ICSPFile, "Path to an ImageContentSourcePolicy file.  If set, data from this file will be used to find alternative locations for images.")
 	flags.MarkDeprecated("icsp-file", "support for it will be removed in a future release. Use --idms-file instead.")
-	flags.StringVar(&o.IDMSFile, "idms-file", o.IDMSFile, "Path to an ImageDigestMirrorSet file. If set, data from this file will be used to find alternative locations for images.")
+	flags.StringVar(&o.IDMSFile, "idms-file", o.IDMSFile, "Path to an ImageDigestMirrorSet file. If set, data from this file will be used to find alternative locations for images. Mirrors will be tried first.")
 	flags.BoolVar(&o.ShowMultiArch, "show-multiarch", o.ShowMultiArch, "Show information even if the image is multiarch image. If not set, error is thrown for multiarch images.")
 
 	return cmd

--- a/pkg/cli/image/info/info.go
+++ b/pkg/cli/image/info/info.go
@@ -82,6 +82,8 @@ func NewInfo(f kcmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Comm
 	flags.StringVarP(&o.Output, "output", "o", o.Output, "Print the image in an alternative format: json")
 	flags.StringVar(&o.FileDir, "dir", o.FileDir, "The directory on disk that file:// images will be read from.")
 	flags.StringVar(&o.ICSPFile, "icsp-file", o.ICSPFile, "Path to an ImageContentSourcePolicy file.  If set, data from this file will be used to find alternative locations for images.")
+	flags.MarkDeprecated("icsp-file", "support for it will be removed in a future release. Use --idms-file instead.")
+	flags.StringVar(&o.IDMSFile, "idms-file", o.IDMSFile, "Path to an ImageDigestMirrorSet file. If set, data from this file will be used to find alternative locations for images.")
 	flags.BoolVar(&o.ShowMultiArch, "show-multiarch", o.ShowMultiArch, "Show information even if the image is multiarch image. If not set, error is thrown for multiarch images.")
 
 	return cmd
@@ -97,6 +99,7 @@ type InfoOptions struct {
 	FileDir       string
 	Output        string
 	ICSPFile      string
+	IDMSFile      string
 	ShowMultiArch bool
 }
 
@@ -113,6 +116,9 @@ func (o *InfoOptions) Validate(cmd *cobra.Command) error {
 	if len(o.Images) == 0 {
 		return fmt.Errorf("must specify one or more images as arguments")
 	}
+	if len(o.ICSPFile) > 0 && len(o.IDMSFile) > 0 {
+		return fmt.Errorf("icsp-file and idms-file are mutually exclusive")
+	}
 	return o.FilterOptions.Validate()
 }
 
@@ -123,7 +129,12 @@ func (o *InfoOptions) Run() error {
 		return err
 	}
 	if len(o.ICSPFile) > 0 {
+		// We continue to use OnError strategy for ICSP only to maintain
+		// longstanding (but suboptimal) behaviour.
 		registryContext = registryContext.WithAlternateBlobSourceStrategy(strategy.NewICSPOnErrorStrategy(o.ICSPFile))
+	}
+	if len(o.IDMSFile) > 0 {
+		registryContext = registryContext.WithAlternateBlobSourceStrategy(strategy.NewIDMSExplicitStrategy(o.IDMSFile))
 	}
 	opts := &imagesource.Options{
 		FileDir:         o.FileDir,
@@ -132,7 +143,7 @@ func (o *InfoOptions) Run() error {
 	}
 
 	hadError := false
-	icspWarned := false
+	alternateSourceWarned := false
 	for _, location := range o.Images {
 		sources, err := imagesource.ParseSourceReference(location, opts.ExpandWildcard)
 		if err != nil {
@@ -142,9 +153,9 @@ func (o *InfoOptions) Run() error {
 			if len(src.Ref.Tag) == 0 && len(src.Ref.ID) == 0 {
 				return fmt.Errorf("--from must point to an image ID or image tag")
 			}
-			if !icspWarned && len(o.ICSPFile) > 0 && len(src.Ref.Tag) > 0 {
-				fmt.Fprintf(o.ErrOut, "warning: --icsp-file only applies to images referenced by digest and will be ignored for tags\n")
-				icspWarned = true
+			if !alternateSourceWarned && (len(o.ICSPFile) > 0 || len(o.IDMSFile) > 0) && len(src.Ref.Tag) > 0 {
+				fmt.Fprintf(o.ErrOut, "warning: --idms-file (and --icsp-file) only applies to images referenced by digest and will be ignored for tags\n")
+				alternateSourceWarned = true
 			}
 
 			var images []*Image


### PR DESCRIPTION
Deprecate the `--icsp-file` option to `oc image info` and add a `--idms-file` option for consistency with other commands.

Use the Explicit mirror strategy instead of OnError, because users are making an explicit request to respect the mirroring settings. Experience in the field has shown that contacting quay first does not always fail cleanly in some proxy setups, which can break the command altogether.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `--idms-file` option for specifying an IDMS alternate source when retrieving image information.
  - Image retrieval now supports explicit ICSP or IDMS alternate-source strategies.
  - Configured mirrors are tried first when locating images through IDMS.

- **Bug Fixes**
  - Prevented simultaneous use of `--idms-file` and `--icsp-file`.
  - Standardized tag warnings across both alternate-source options so they appear only once.

- **Deprecations**
  - Deprecated the `--icsp-file` option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->