### PR TITLE
NO-JIRA: README: Mention gcc as an oc dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ get a list of all supported make sub-commands.
 By default `make oc` builds the executable without debugging symbols. To include
 debugging symbols, run `make STRIP_DEBUGGING_SYMBOLS=false oc`.
 
-In order to build `oc`, you will need the GSSAPI sources. On a Fedora/CentOS/RHEL
-workstation, install them with:
+In order to build `oc`, you will need the GSSAPI sources and also a C compiler.
+On a Fedora/CentOS/RHEL workstation, install them with:
 
 ```bash
-dnf install krb5-devel gpgme-devel libassuan-devel
+dnf install krb5-devel gpgme-devel libassuan-devel gcc
 ```
 
 For macOS, install build dependencies with:


### PR DESCRIPTION
A compiler is necessary to build oc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Fedora, CentOS, and RHEL build instructions to clarify that a C compiler is required.
  - Added `gcc` to the listed build dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->